### PR TITLE
Fixed oudated version identifier in src/index.ts

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,23 +11,27 @@ and must be migrated to newer versions to work continuously.
 The following versions are supported and will get bug-fixes and security updates:
 
 | Version | Supported          |
-| ------- | ------------------ |
-| 0.3.0   | :white_check_mark: |
+|---------|--------------------|
+| 0.3.x   | :white_check_mark: |
 | 0.2.x   | :x:                |
 | 0.1.x   | :x:                |
 | 0.0.x   | :x:                |
 
 ### NPM Deprecation
 
-If a version gets deprecated/loses support, it will be deprecated as well on the NPM registry. 
-This means the version will be marked as outdated and NPM will provide a deprecation warning to everyone who attempts to install it.
+If a version gets deprecated/loses support, it will be deprecated as well on the NPM registry.
+This means the version will be marked as outdated and NPM will provide a deprecation warning to everyone who attempts to
+install it.
 
 View a list of all available NPM versions [here](https://www.npmjs.com/package/@kipper/base/).
 
 ## Reporting a Vulnerability
 
-Reporting a vulnerability or issue can be done under the [issues page](https://github.com/Luna-Klatzer/Kipper/issues/new/choose). 
-Mark the issue as a bug report, and follow the guidelines inside the issue editor. Be as detailed as possible to avoid too many
+Reporting a vulnerability or issue can be done under
+the [issues page](https://github.com/Luna-Klatzer/Kipper/issues/new/choose).
+Mark the issue as a bug report, and follow the guidelines inside the issue editor. Be as detailed as possible to avoid
+too many
 followup questions.
 
-Remember though when reporting an issue, this project is in build-up and development, so it will almost definitely not be a high priority for development.
+Remember though when reporting an issue, this project is in build-up and development, so it will almost definitely not
+be a high priority for development.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kipper/base",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kipper/base",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "GPL-3.0",
       "dependencies": {
         "antlr4ts": "^0.5.0-alpha.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kipper/base",
   "description": "The Kipper programming language and compiler for the browser! \uD83E\uDD8A",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "Luna-Klatzer @Luna-Klatzer",
   "dependencies": {
     "antlr4ts": "^0.5.0-alpha.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export * from "./errors";
 // eslint-disable-next-line no-unused-vars
 export const name = "kipper";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.2.2";
+export const version = "0.3.1";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it. -->

- [x] Maintenance Change (Non-breaking change that updates dependencies or updated other text files)
- [x] Bug fix (Non-breaking change which fixes an issue)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary
<!-- Explain the reason for this pr, changes and solution briefly. -->

Fixes invalid identifier in `src/index.ts` indicating that the version is still `v0.2.2` despite it being already `0.3.x`.
## Changes
<!-- Please explain the changes in this PR and their influence. If this fixes an issue, explain what fixed the issue. -->

- Replaced version identifier `0.2.2` with `0.3.1`, as `0.3.1` is currently in work.

<!-- Remove example text! -->

## Does this PR create new warnings?
<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Changelog
<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added). -->

Empty.

<!-- Remove any header with no item. -->

## Linked other issues or PRs
<!-- Include other issues and PRs that are related to this if any exist. -->

<!-- Use this format: - [ ] #ISSUE_OR_PR -->

<!-- Default: -->
No linked issues.
