### PR TITLE
Fixed missing logs for compilation errors and internal errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- New function `KipperLogger.reportError()` for reporting and logging errors.
 
 ### Changed
 - Fixed missing traceback line hinting ([#24](https://github.com/Luna-Klatzer/Kipper/issues/24)).
+- Fixed missing error and fatal error logs ([#34](https://github.com/Luna-Klatzer/Kipper/issues/34)).
+- Renamed `CompileAssert.error` to `CompileAssert.throwError`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Fixed missing traceback line hinting ([#24](https://github.com/Luna-Klatzer/Kipper/issues/24)).
 - Fixed missing error and fatal error logs ([#34](https://github.com/Luna-Klatzer/Kipper/issues/34)).
-- Renamed `CompileAssert.error` to `CompileAssert.throwError`.
+- Renamed `CompileAssert.error()` to `CompileAssert.throwError()` and added error logging for the error passed as 
+  argument.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Kipper Base Package - `@kipper/base`
 
 [![Version](https://img.shields.io/npm/v/@kipper/base?label=release&color=%23cd2620&logo=npm)](https://npmjs.org/package/@kipper/base)
-![](https://img.shields.io/badge/Coverage-70%25-5A7302.svg?style=flat&logoColor=white&color=blue&prefix=$coverage$)
+![](https://img.shields.io/badge/Coverage-71%25-5A7302.svg?style=flat&logoColor=white&color=blue&prefix=$coverage$)
 [![Issues](https://img.shields.io/github/issues/Luna-Klatzer/Kipper)](https://github.com/Luna-Klatzer/Kipper/issues)
 [![License](https://img.shields.io/github/license/Para-Lang/Para?color=cyan)](https://github.com/Luna-Klatzer/Kipper/blob/main/LICENSE)
 [![Install size](https://packagephobia.com/badge?p=@kipper/base)](https://packagephobia.com/result?p=@kipper/base)

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -50,10 +50,10 @@ export class KipperError extends Error {
 		const tokenSrc = this.antlrCtx ? Utils.getTokenSource(this.antlrCtx) : undefined;
 		return (
 			`Traceback:\n  File '${this.tracebackData.filePath ?? "Unknown"}', ` +
-			`line ${this.tracebackData.location ? this.tracebackData.location.line : "Unknown"}, ` +
-			`col ${this.tracebackData.location ? this.tracebackData.location.col : "Unknown"}:\n` +
-			`    ${tokenSrc ? tokenSrc + "\n" : ""}` +
-			`    ${tokenSrc ? "^".repeat(tokenSrc.length) + "\n" : ""}` +
+			`line ${this.tracebackData.location ? this.tracebackData.location.line : "'Unknown'"}, ` +
+			`col ${this.tracebackData.location ? this.tracebackData.location.col : "'Unknown'"}:\n` +
+			`${tokenSrc ? "    " + tokenSrc + "\n" : ""}` +
+			`${tokenSrc ? "    " + "^".repeat(tokenSrc.length) + "\n" : ""}` +
 			`${this.name}: ${this.message}`
 		);
 	}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,6 +7,8 @@
  * @since 0.0.3
  */
 
+import {KipperError} from "./errors";
+
 /**
  * The log levels for the {@link KipperLogger}, but as numeric values to allow comparisons.
  * @since 0.2.0
@@ -145,4 +147,14 @@ export class KipperLogger {
 
 		return this._emitHandler(level, msg);
 	}
+
+  /**
+   * Reports an error with the passed level.
+   * @param level The {@link LogLevel level} to log the error with.
+   * @param err The error to log.
+   * @since 0.3.1
+   */
+  public reportError(level: LogLevel.WARN | LogLevel.ERROR | LogLevel.FATAL, err: KipperError | string) {
+    this.log(level, err instanceof KipperError ? err.getTraceback() : err);
+  }
 }


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it. Remove any non-checked option -->

- [x] Bug fix (Non-breaking change which fixes an issue)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary
<!-- Explain the reason for this pr, changes and solution briefly. -->

Adds error logging for compilation errors in `KipperCompiler.compile()`.

Fixes #34 

## Changes
<!-- Please explain the changes in this PR and their influence. If this fixes an issue, explain what fixed the issue. -->

- Renamed `CompileAssert.error()` to `CompilerAssert.throwError()`.
- Added new function `KipperLogger.reportError()` which will log the error with its traceback.

<!-- Remove example text! -->

## Does this PR create new warnings?
<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

## Changelog
<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added). -->

### Added
- New function `KipperLogger.reportError()` for reporting and logging errors.

### Changed
- Fixed missing error and fatal error logs ([#34](https://github.com/Luna-Klatzer/Kipper/issues/34)).
- Renamed `CompileAssert.error()` to `CompileAssert.throwError()` and added error logging for the error passed as 
  argument.

<!-- Remove any header with no item. -->

## Linked other issues or PRs
<!-- Include other issues and PRs that are related to this if any exist. -->

- [x] #34
