### PR TITLE
Fixed default antlr4 error listeners printing onto stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New function `KipperAntlrErrorListener.getSourceCode()` for fetching the source code for a syntax error.
 - Proper tracebacks handling for `KipperSyntaxError` ([#42](https://github.com/Luna-Klatzer/Kipper/issues/42)).
 - Getter fields `line`, `col`, `filePath` and `tokenSrc` in `KipperError`, which returns the metadata for the error.
+- Fallback option for Lexer errors, where if `offendingSymbol` is `undefined` the entire line of code is set as 
+  `tokenSrc` ([#36](https://github.com/Luna-Klatzer/Kipper/issues/36)).
 
 ### Changed
 - Fixed missing traceback line hinting ([#24](https://github.com/Luna-Klatzer/Kipper/issues/24)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New function `KipperLogger.reportError()` for reporting and logging errors.
 - New function `KipperAntlrErrorListener.getSourceCode()` for fetching the source code for a syntax error.
 - Proper tracebacks handling for `KipperSyntaxError` ([#42](https://github.com/Luna-Klatzer/Kipper/issues/42)).
+- Getter fields `line`, `col`, `filePath` and `tokenSrc` in `KipperError`, which returns the metadata for the error.
 
 ### Changed
 - Fixed missing traceback line hinting ([#24](https://github.com/Luna-Klatzer/Kipper/issues/24)).
@@ -18,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed function `CompileAssert.error()` to `CompileAssert.throwError()` and added error logging for the error 
   passed as argument.
 - Renamed `KipperErrorListener` to `KipperAntlrErrorListener`.
+- Renamed `InternalKipperError` to `KipperInternalError`.
+- Fixed usage of default antlr4 listeners for lexer errors ([#36](https://github.com/Luna-Klatzer/Kipper/issues/36)).
 
 ### Removed
 - Field `KipperCompiler.errorListener`, as due to ([#42](https://github.com/Luna-Klatzer/Kipper/issues/42))

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Kipper Base Package - `@kipper/base`
 
 [![Version](https://img.shields.io/npm/v/@kipper/base?label=release&color=%23cd2620&logo=npm)](https://npmjs.org/package/@kipper/base)
-![](https://img.shields.io/badge/Coverage-71%25-5A7302.svg?style=flat&logoColor=white&color=blue&prefix=$coverage$)
+![](https://img.shields.io/badge/Coverage-72%25-5A7302.svg?style=flat&logoColor=white&color=blue&prefix=$coverage$)
 [![Issues](https://img.shields.io/github/issues/Luna-Klatzer/Kipper)](https://github.com/Luna-Klatzer/Kipper/issues)
 [![License](https://img.shields.io/github/license/Para-Lang/Para?color=cyan)](https://github.com/Luna-Klatzer/Kipper/blob/main/LICENSE)
 [![Install size](https://packagephobia.com/badge?p=@kipper/base)](https://packagephobia.com/result?p=@kipper/base)

--- a/src/compiler/antlr-error-listener.ts
+++ b/src/compiler/antlr-error-listener.ts
@@ -93,15 +93,19 @@ export class KipperAntlrErrorListener<TSymbol> implements ANTLRErrorListener<TSy
 		/**
 		 * The source code. This may be undefined, if fetching the source code failed or the symbol is not of a known type.
 		 */
-		let src: string | undefined =
-			offendingSymbol instanceof CommonToken ? this.getSourceCode(offendingSymbol) : undefined;
+		let src: string = (() => {
+			let src = offendingSymbol instanceof CommonToken ? this.getSourceCode(offendingSymbol) : undefined;
+			if (src === undefined) return this.getLineOfCode(line);
+			else return src;
+		})();
 
 		// Create new error and add traceback metadata
-		const err = new KipperSyntaxError<T>(recognizer, offendingSymbol, line, charPositionInLine, msg, e);
+		const err = new KipperSyntaxError<T>(recognizer, offendingSymbol, msg, e);
 		err.setMetadata({
 			location: { line: line, col: charPositionInLine },
 			filePath: this.parseStream.filePath,
-			tokenSrc: src,
+			tokenSrc: src, // Explicitly set the tokenSrc, since syntax errors should be handled differently than
+			// compilation errors.
 		});
 
 		// Log the error

--- a/src/compiler/antlr-error-listener.ts
+++ b/src/compiler/antlr-error-listener.ts
@@ -56,6 +56,21 @@ export class KipperAntlrErrorListener<TSymbol> implements ANTLRErrorListener<TSy
 	}
 
 	/**
+	 * Gets a line of code from the original {@link this.parseStream}.
+	 * @param line The line of code to fetch.
+	 * @protected
+	 * @since 0.4.0
+	 */
+	protected getLineOfCode(line: number): string {
+		const cleanLineEndings = (str: string) => {
+			return str.replace("\r\n", "\n").replace("\r", "\n");
+		};
+
+		// Get the line ending by splitting using a common line ending
+		return cleanLineEndings(this.parseStream.stringContent).split("\n")[line - 1];
+	}
+
+	/**
 	 * Default handler for Antlr4 syntax errors.
 	 * @param recognizer The recognizer which usually represents a {@link KipperParser}.
 	 * @param offendingSymbol The symbol/token that caused the error. In most cases, this is of type {@link CommonToken}.

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -203,6 +203,10 @@ export class KipperCompiler {
 
 		// Create the lexer and parser, which will parse this inputStream
 		const lexer = new KipperLexer(inputStream);
+		lexer.removeErrorListeners(); // removing all error listeners
+		lexer.addErrorListener(errorListener); // adding our own error listener
+
+		// Let the lexer run and generate a token stream
 		const tokenStream = new CommonTokenStream(lexer);
 		const parser = new KipperParser(tokenStream);
 

--- a/test/module/compiler.test.ts
+++ b/test/module/compiler.test.ts
@@ -210,118 +210,175 @@ describe("KipperCompiler", () => {
     });
 
     describe("Errors", () => {
-      it("GetTraceback", async () => {
-        try {
-          await new KipperCompiler().compile("var i: str = \"4\";\n var i: str = \"4\";");
-        } catch (e) {
-          assert((<KipperError>e).constructor.name === "VariableDefinitionAlreadyExistsError", "Expected proper error");
-          return;
-        }
-        assert(false, "Expected 'VariableDefinitionAlreadyExistsError'");
+      describe("KipperSyntaxError", () => {
+        it("LexerError", async () => {
+          try {
+            await new KipperCompiler().compile("var x: num = 4; \nvar x: num = 5; \\\\D");
+          } catch (e) {
+            assert((<KipperSyntaxError<any>>e).constructor.name === "KipperSyntaxError", "Expected proper error");
+            assert((<KipperSyntaxError<any>>e).line != undefined, "Expected existing 'line' meta field");
+            assert((<KipperSyntaxError<any>>e).col != undefined, "Expected existing 'col' meta field");
+            assert((<KipperSyntaxError<any>>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
+            assert((<KipperSyntaxError<any>>e).filePath != undefined, "Expected existing 'filePath' meta field");
+            return;
+          }
+          assert(false, "Expected 'KipperSyntaxError'");
+        });
+
+        it("ParserError", async () => {
+          try {
+            await new KipperCompiler().compile("var x: num = 4; \nvar x: num = 5");
+          } catch (e) {
+            assert((<KipperSyntaxError<any>>e).constructor.name === "KipperSyntaxError", "Expected proper error");
+            assert((<KipperSyntaxError<any>>e).line != undefined, "Expected existing 'line' meta field");
+            assert((<KipperSyntaxError<any>>e).col != undefined, "Expected existing 'col' meta field");
+            assert((<KipperSyntaxError<any>>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
+            assert((<KipperSyntaxError<any>>e).filePath != undefined, "Expected existing 'filePath' meta field");
+            return;
+          }
+          assert(false, "Expected 'KipperSyntaxError'");
+        });
       });
 
-      it("KipperSyntaxError", async () => {
-        try {
-          await new KipperCompiler().compile("var invalid: x = 4; \n var invalid: number = 4");
-        } catch (e) {
-          assert((<KipperError>e).constructor.name === "KipperSyntaxError", "Expected proper error");
-          return;
-        }
-        assert(false, "Expected 'KipperSyntaxError'");
-      });
+      describe("Compilation errors", () => {
 
-      it("UnknownTypeError", async () => {
-        try {
-          await new KipperCompiler().compile("var invalid: UNKNOWN = 4;");
-        } catch (e) {
-          assert((<KipperError>e).constructor.name === "UnknownTypeError", "Expected proper error");
-          return;
-        }
-        assert(false, "Expected 'UnknownTypeError'");
-      });
+        it("GetTraceback", async () => {
+          try {
+            await new KipperCompiler().compile("var i: str = \"4\";\n var i: str = \"4\";");
+          } catch (e) {
+            assert((<KipperError>e).constructor.name === "VariableDefinitionAlreadyExistsError", "Expected proper error");
+            assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
+            assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
+            assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
+            assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
+            return;
+          }
+          assert(false, "Expected 'VariableDefinitionAlreadyExistsError'");
+        });
 
-      it("InvalidGlobalError", async () => {
-        try {
-          const programCtx: KipperProgramContext = await new KipperCompiler().parse(
-            new KipperParseStream("var i: num = 4;")
-          );
+        it("UnknownTypeError", async () => {
+          try {
+            await new KipperCompiler().compile("var invalid: UNKNOWN = 4;");
+          } catch (e) {
+            assert((<KipperError>e).constructor.name === "UnknownTypeError", "Expected proper error");
+            assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
+            assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
+            assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
+            assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
+            return;
+          }
+          assert(false, "Expected 'UnknownTypeError'");
+        });
 
-          // Duplicate identifier
-          programCtx.registerGlobals({identifier: "i", args: [], handler: [""], returnType: "void"});
-          programCtx.registerGlobals({identifier: "i", args: [], handler: [""], returnType: "void"});
-        } catch (e) {
-          assert((<KipperError>e).constructor.name === "InvalidGlobalError", "Expected proper error");
-          return;
-        }
-        assert(false, "Expected 'InvalidGlobalError'");
-      });
+        it("InvalidGlobalError", async () => {
+          try {
+            const programCtx: KipperProgramContext = await new KipperCompiler().parse(
+              new KipperParseStream("var i: num = 4;")
+            );
 
-      it("BuiltInOverwriteError", async () => {
-        try {
-          const programCtx: KipperProgramContext = await new KipperCompiler().parse(
-            new KipperParseStream("var i: num = 4;")
-          );
+            // Duplicate identifier
+            programCtx.registerGlobals({identifier: "i", args: [], handler: [""], returnType: "void"});
+            programCtx.registerGlobals({identifier: "i", args: [], handler: [""], returnType: "void"});
+          } catch (e) {
+            assert((<KipperError>e).constructor.name === "InvalidGlobalError", "Expected proper error");
+            assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
+            assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 
-          // Register new global
-          programCtx.registerGlobals({identifier: "i", args: [], handler: [""], returnType: "void"});
-          await programCtx.compileProgram();
-        } catch (e) {
-          assert((<KipperError>e).constructor.name === "BuiltInOverwriteError", "Expected proper error");
-          return;
-        }
-        assert(false, "Expected 'BuiltInOverwriteError'");
-      });
+            // Token src should not exist, since this is a configuration error!
+            assert((<KipperError>e).tokenSrc === undefined, "Expected non-existing 'tokenSrc' meta field");
+            assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
+            return;
+          }
+          assert(false, "Expected 'InvalidGlobalError'");
+        });
 
-      it("IdentifierAlreadyUsedByFunctionError", async () => {
-        try {
-          const programCtx: KipperProgramContext = await new KipperCompiler().parse(
-            new KipperParseStream("def x() -> void; var x: num = 4;")
-          );
-          await programCtx.compileProgram();
-        } catch (e) {
-          assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByFunctionError", "Expected proper error");
-          return;
-        }
-        assert(false, "Expected 'IdentifierAlreadyUsedByFunctionError'");
-      });
+        it("BuiltInOverwriteError", async () => {
+          try {
+            const programCtx: KipperProgramContext = await new KipperCompiler().parse(
+              new KipperParseStream("var i: num = 4;")
+            );
 
-      it("IdentifierAlreadyUsedByVariableError", async () => {
-        try {
-          const programCtx: KipperProgramContext = await new KipperCompiler().parse(
-            new KipperParseStream("var x: num; def x() -> void;")
-          );
-          await programCtx.compileProgram();
-        } catch (e) {
-          assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError", "Expected proper error");
-          return;
-        }
-        assert(false, "Expected 'IdentifierAlreadyUsedByVariableError'");
-      });
+            // Register new global
+            programCtx.registerGlobals({identifier: "i", args: [], handler: [""], returnType: "void"});
+            await programCtx.compileProgram();
+          } catch (e) {
+            assert((<KipperError>e).constructor.name === "BuiltInOverwriteError", "Expected proper error");
+            assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
+            assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
+            assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
+            assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
+            return;
+          }
+          assert(false, "Expected 'BuiltInOverwriteError'");
+        });
 
-      it("FunctionDefinitionAlreadyExistsError", async () => {
-        try {
-          const programCtx: KipperProgramContext = await new KipperCompiler().parse(
-            new KipperParseStream("def x() -> void {} def x() -> void {}")
-          );
-          await programCtx.compileProgram();
-        } catch (e) {
-          assert((<KipperError>e).constructor.name === "FunctionDefinitionAlreadyExistsError", "Expected proper error");
-          return;
-        }
-        assert(false, "Expected 'FunctionDefinitionAlreadyExistsError'");
-      });
+        it("IdentifierAlreadyUsedByFunctionError", async () => {
+          try {
+            const programCtx: KipperProgramContext = await new KipperCompiler().parse(
+              new KipperParseStream("def x() -> void; var x: num = 4;")
+            );
+            await programCtx.compileProgram();
+          } catch (e) {
+            assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByFunctionError", "Expected proper error");
+            assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
+            assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
+            assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
+            assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
+            return;
+          }
+          assert(false, "Expected 'IdentifierAlreadyUsedByFunctionError'");
+        });
 
-      it("VariableDefinitionAlreadyExistsError", async () => {
-        try {
-          const programCtx: KipperProgramContext = await new KipperCompiler().parse(
-            new KipperParseStream("var x: num = 4; \n    var x: num = 5;")
-          );
-          await programCtx.compileProgram();
-        } catch (e) {
-          assert((<KipperError>e).constructor.name === "VariableDefinitionAlreadyExistsError", "Expected proper error");
-          return;
-        }
-        assert(false, "Expected 'VariableDefinitionAlreadyExistsError'");
+        it("IdentifierAlreadyUsedByVariableError", async () => {
+          try {
+            const programCtx: KipperProgramContext = await new KipperCompiler().parse(
+              new KipperParseStream("var x: num; def x() -> void;")
+            );
+            await programCtx.compileProgram();
+          } catch (e) {
+            assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError", "Expected proper error");
+            assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
+            assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
+            assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
+            assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
+            return;
+          }
+          assert(false, "Expected 'IdentifierAlreadyUsedByVariableError'");
+        });
+
+        it("FunctionDefinitionAlreadyExistsError", async () => {
+          try {
+            const programCtx: KipperProgramContext = await new KipperCompiler().parse(
+              new KipperParseStream("def x() -> void {} def x() -> void {}")
+            );
+            await programCtx.compileProgram();
+          } catch (e) {
+            assert((<KipperError>e).constructor.name === "FunctionDefinitionAlreadyExistsError", "Expected proper error");
+            assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
+            assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
+            assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
+            assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
+            return;
+          }
+          assert(false, "Expected 'FunctionDefinitionAlreadyExistsError'");
+        });
+
+        it("VariableDefinitionAlreadyExistsError", async () => {
+          try {
+            const programCtx: KipperProgramContext = await new KipperCompiler().parse(
+              new KipperParseStream("var x: num = 4; \n    var x: num = 5;")
+            );
+            await programCtx.compileProgram();
+          } catch (e) {
+            assert((<KipperError>e).constructor.name === "VariableDefinitionAlreadyExistsError", "Expected proper error");
+            assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
+            assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
+            assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
+            assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
+            return;
+          }
+          assert(false, "Expected 'VariableDefinitionAlreadyExistsError'");
+        });
       });
     });
   });


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it. Remove any non-checked option -->

- [x] Bug fix (Non-breaking change which fixes an issue)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

Fixed default antlr4 error listener reporting errors directly onto stdout clogging the output.

Fixes #36

## Changes
<!-- Please explain the changes in this PR and their influence. If this fixes an issue, explain what fixed the issue. -->

- Removed default error listeners for the `KipperLexer` and explicitly set `KipperAntlrErrorListener` as the only error listener.
- Updated `KipperError` metadata fields and added `line`, `col`, `filePath` and `tokenSrc`.
- Added fallback option for Lexer errors, where if `offendingSymbol` is `undefined` the entire line of code is set as `tokenSrc`.

<!-- Remove example text! -->

## Does this PR create new warnings?
<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Changelog
<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added). -->

### Added
- Getter fields `line`, `col`, `filePath` and `tokenSrc` in `KipperError`, which returns the metadata for the error.
- Fallback option for Lexer errors, where if `offendingSymbol` is `undefined` the entire line of code is set as 
  `tokenSrc` ([#36](https://github.com/Luna-Klatzer/Kipper/issues/36)).

### Changed
- Renamed `InternalKipperError` to `KipperInternalError`.
- Fixed usage of default antlr4 listeners for lexer errors ([#36](https://github.com/Luna-Klatzer/Kipper/issues/36)).

<!-- Remove any header with no item. -->

## Linked other issues or PRs
<!-- Include other issues and PRs that are related to this if any exist. -->

- [x] #36 
