### PR TITLE
Removed `Utils` namespace from `utils.ts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Getter fields `line`, `col`, `filePath` and `tokenSrc` in `KipperError`, which returns the metadata for the error.
 - Fallback option for Lexer errors, where if `offendingSymbol` is `undefined` the entire line of code is set as 
   `tokenSrc` ([#36](https://github.com/Luna-Klatzer/Kipper/issues/36)).
+- Getter field `KipperParseStream.lines` returning all lines in the source file as an array.
 
 ### Changed
 - Fixed missing traceback line hinting ([#24](https://github.com/Luna-Klatzer/Kipper/issues/24)).
@@ -27,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Field `KipperCompiler.errorListener`, as due to ([#42](https://github.com/Luna-Klatzer/Kipper/issues/42))
   the `KipperAntlrErrorListener` will have to be initialised per compilation, not per compiler instance.
+- Namespace `Utils` and moved its methods into the global scope of the file to allow the following import scheme
+  `import * as Utils from "@kipper/base/utils"`, where the user can themselves define the wanted scope identifier.
 
 ## [0.3.0] - 2022-04-28
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Kipper Base Package - `@kipper/base`
 
 [![Version](https://img.shields.io/npm/v/@kipper/base?label=release&color=%23cd2620&logo=npm)](https://npmjs.org/package/@kipper/base)
-![](https://img.shields.io/badge/Coverage-72%25-5A7302.svg?style=flat&logoColor=white&color=blue&prefix=$coverage$)
+![](https://img.shields.io/badge/Coverage-73%25-5A7302.svg?style=flat&logoColor=white&color=blue&prefix=$coverage$)
 [![Issues](https://img.shields.io/github/issues/Luna-Klatzer/Kipper)](https://github.com/Luna-Klatzer/Kipper/issues)
 [![License](https://img.shields.io/github/license/Para-Lang/Para?color=cyan)](https://github.com/Luna-Klatzer/Kipper/blob/main/LICENSE)
 [![Install size](https://packagephobia.com/badge?p=@kipper/base)](https://packagephobia.com/result?p=@kipper/base)

--- a/src/compiler/antlr-error-listener.ts
+++ b/src/compiler/antlr-error-listener.ts
@@ -12,6 +12,7 @@ import { KipperSyntaxError } from "../errors";
 import { KipperParseStream } from "./parse-stream";
 import { Interval } from "antlr4ts/misc/Interval";
 import { CommonToken } from "antlr4ts";
+import {getNaturalOrZero} from "../utils";
 
 /**
  * The Error Handler for the Kipper implementation of {@link ANTLRErrorListener}
@@ -62,12 +63,10 @@ export class KipperAntlrErrorListener<TSymbol> implements ANTLRErrorListener<TSy
 	 * @since 0.4.0
 	 */
 	protected getLineOfCode(line: number): string {
-		const cleanLineEndings = (str: string) => {
-			return str.replace("\r\n", "\n").replace("\r", "\n");
-		};
+    if (line < 0 || line > this.parseStream.lines.length)
+      throw new RangeError("Range out of parse stream bounds.");
 
-		// Get the line ending by splitting using a common line ending
-		return cleanLineEndings(this.parseStream.stringContent).split("\n")[line - 1];
+		return this.parseStream.lines[line - 1];
 	}
 
 	/**

--- a/src/compiler/antlr-error-listener.ts
+++ b/src/compiler/antlr-error-listener.ts
@@ -46,7 +46,7 @@ export class KipperAntlrErrorListener<TSymbol> implements ANTLRErrorListener<TSy
 			let calcStart = symbol.stopIndex - col;
 
 			// Avoid negative values
-			let start = calcStart < 0 ? 0 : calcStart;
+			let start = getNaturalOrZero(calcStart);
 			if (symbol.startIndex < start) start = symbol.startIndex;
 			return start;
 		})();

--- a/src/compiler/antlr-error-listener.ts
+++ b/src/compiler/antlr-error-listener.ts
@@ -12,7 +12,7 @@ import { KipperSyntaxError } from "../errors";
 import { KipperParseStream } from "./parse-stream";
 import { Interval } from "antlr4ts/misc/Interval";
 import { CommonToken } from "antlr4ts";
-import {getNaturalOrZero} from "../utils";
+import { getNaturalOrZero } from "../utils";
 
 /**
  * The Error Handler for the Kipper implementation of {@link ANTLRErrorListener}
@@ -63,8 +63,7 @@ export class KipperAntlrErrorListener<TSymbol> implements ANTLRErrorListener<TSy
 	 * @since 0.4.0
 	 */
 	protected getLineOfCode(line: number): string {
-    if (line < 0 || line > this.parseStream.lines.length)
-      throw new RangeError("Range out of parse stream bounds.");
+		if (line < 0 || line > this.parseStream.lines.length) throw new RangeError("Range out of parse stream bounds.");
 
 		return this.parseStream.lines[line - 1];
 	}

--- a/src/compiler/parse-stream.ts
+++ b/src/compiler/parse-stream.ts
@@ -59,7 +59,7 @@ export class KipperParseStream {
    */
   public get lines(): Array<string> {
     const cleanLineEndings = (str: string) => {
-      return str.replace("\r\n", "\n").replace("\r", "\n");
+      return str.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
     };
     return cleanLineEndings(this.stringContent).split('\n');
   }

--- a/src/compiler/parse-stream.ts
+++ b/src/compiler/parse-stream.ts
@@ -53,16 +53,18 @@ export class KipperParseStream {
 		return this._charStream.toString();
 	}
 
-  /**
-   * Returns the lines of code inside the {@link charStream}.
-   * @since 0.4.0
-   */
-  public get lines(): Array<string> {
-    const cleanLineEndings = (str: string) => {
-      return str.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-    };
-    return cleanLineEndings(this.stringContent).split('\n');
-  }
+	/**
+	 * Returns the lines of code inside the {@link charStream}.
+   *
+   * The returned lines have the line ending stripped away!
+	 * @since 0.4.0
+	 */
+	public get lines(): Array<string> {
+		const cleanLineEndings = (str: string) => {
+			return str.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+		};
+		return cleanLineEndings(this.stringContent).split("\n");
+	}
 
 	/**
 	 * Returns the file path of the file.

--- a/src/compiler/parse-stream.ts
+++ b/src/compiler/parse-stream.ts
@@ -53,6 +53,17 @@ export class KipperParseStream {
 		return this._charStream.toString();
 	}
 
+  /**
+   * Returns the lines of code inside the {@link charStream}.
+   * @since 0.4.0
+   */
+  public get lines(): Array<string> {
+    const cleanLineEndings = (str: string) => {
+      return str.replace("\r\n", "\n").replace("\r", "\n");
+    };
+    return cleanLineEndings(this.stringContent).split('\n');
+  }
+
 	/**
 	 * Returns the file path of the file.
 	 * @note If {@link _filePath} wasn't set during construction, then this defaults to {@link name}.

--- a/src/compiler/parse-stream.ts
+++ b/src/compiler/parse-stream.ts
@@ -55,8 +55,8 @@ export class KipperParseStream {
 
 	/**
 	 * Returns the lines of code inside the {@link charStream}.
-   *
-   * The returned lines have the line ending stripped away!
+	 *
+	 * The returned lines have the line ending stripped away!
 	 * @since 0.4.0
 	 */
 	public get lines(): Array<string> {

--- a/src/compiler/tokens/definitions.ts
+++ b/src/compiler/tokens/definitions.ts
@@ -21,7 +21,7 @@ import { KipperStorageType, KipperType } from "../logic";
 import { CompoundStatement } from "./statements";
 import { KipperProgramContext } from "../program-ctx";
 import { UnableToDetermineMetadataError } from "../../errors";
-import { Utils } from "../../utils";
+import {determineScope} from "../../utils";
 
 /**
  * Every antlr4 definition ctx type
@@ -277,7 +277,7 @@ export class VariableDeclaration extends Declaration<VariableDeclarationSemantic
 			identifier: this.tokenStream.getText(declaratorCtx.sourceInterval),
 			storageType: <KipperStorageType>this.tokenStream.getText(storageTypeCtx.sourceInterval),
 			valueType: <KipperType>this.tokenStream.getText(typeSpecifier.sourceInterval),
-			scope: Utils.determineScope(this),
+			scope: determineScope(this),
 		};
 
 		// Assert that the variable type exists

--- a/src/compiler/tokens/definitions.ts
+++ b/src/compiler/tokens/definitions.ts
@@ -21,7 +21,7 @@ import { KipperStorageType, KipperType } from "../logic";
 import { CompoundStatement } from "./statements";
 import { KipperProgramContext } from "../program-ctx";
 import { UnableToDetermineMetadataError } from "../../errors";
-import {determineScope} from "../../utils";
+import { determineScope } from "../../utils";
 
 /**
  * Every antlr4 definition ctx type

--- a/src/compiler/tokens/parse-token.ts
+++ b/src/compiler/tokens/parse-token.ts
@@ -8,9 +8,9 @@
 import { ParserRuleContext } from "antlr4ts/ParserRuleContext";
 import { KipperParser } from "../parser";
 import { TokenStream } from "antlr4ts/TokenStream";
-import { Utils } from "../../utils";
 import type { KipperProgramContext } from "../program-ctx";
 import { UnableToDetermineMetadataError } from "../../errors";
+import {getTokenSource} from "../../utils";
 
 export type eligibleParentToken = CompilableParseToken<any> | RootFileParseToken;
 export type eligibleChildToken = CompilableParseToken<any>;
@@ -96,7 +96,7 @@ export abstract class CompilableParseToken<Semantics extends SemanticData> {
 	 * The Kipper source code that was used to generate this {@link CompilableParseToken}.
 	 */
 	public get sourceCode(): string {
-		return Utils.getTokenSource(this.antlrCtx);
+		return getTokenSource(this.antlrCtx);
 	}
 
 	/**

--- a/src/compiler/tokens/parse-token.ts
+++ b/src/compiler/tokens/parse-token.ts
@@ -10,7 +10,7 @@ import { KipperParser } from "../parser";
 import { TokenStream } from "antlr4ts/TokenStream";
 import type { KipperProgramContext } from "../program-ctx";
 import { UnableToDetermineMetadataError } from "../../errors";
-import {getTokenSource} from "../../utils";
+import { getTokenSource } from "../../utils";
 
 export type eligibleParentToken = CompilableParseToken<any> | RootFileParseToken;
 export type eligibleChildToken = CompilableParseToken<any>;

--- a/src/compiler/tokens/statements.ts
+++ b/src/compiler/tokens/statements.ts
@@ -24,7 +24,7 @@ import { VariableDeclaration } from "./definitions";
 import { Expression } from "./expressions";
 import { UnableToDetermineMetadataError } from "../../errors";
 import { KipperProgramContext } from "../program-ctx";
-import { Utils } from "../../utils";
+import {determineScope} from "../../utils";
 
 /**
  * Every antlr4 statement ctx type
@@ -152,7 +152,7 @@ export class CompoundStatement extends Statement<{ scope: KipperProgramContext |
 	 */
 	public async semanticAnalysis(): Promise<void> {
 		this.semanticData = {
-			scope: Utils.determineScope(this),
+			scope: determineScope(this),
 		};
 	}
 
@@ -210,7 +210,7 @@ export class SelectionStatement extends Statement<{ scope: KipperProgramContext 
 	 */
 	public async semanticAnalysis(): Promise<void> {
 		this.semanticData = {
-			scope: Utils.determineScope(this),
+			scope: determineScope(this),
 		};
 	}
 
@@ -264,7 +264,7 @@ export class ExpressionStatement extends Statement<{ scope: KipperProgramContext
 	 */
 	public async semanticAnalysis(): Promise<void> {
 		this.semanticData = {
-			scope: Utils.determineScope(this),
+			scope: determineScope(this),
 		};
 	}
 
@@ -322,7 +322,7 @@ export class IterationStatement extends Statement<{ scope: KipperProgramContext 
 	 */
 	public async semanticAnalysis(): Promise<void> {
 		this.semanticData = {
-			scope: Utils.determineScope(this),
+			scope: determineScope(this),
 		};
 	}
 
@@ -377,7 +377,7 @@ export class JumpStatement extends Statement<{ scope: KipperProgramContext | Com
 	 */
 	public async semanticAnalysis(): Promise<void> {
 		this.semanticData = {
-			scope: Utils.determineScope(this),
+			scope: determineScope(this),
 		};
 	}
 

--- a/src/compiler/tokens/statements.ts
+++ b/src/compiler/tokens/statements.ts
@@ -24,7 +24,7 @@ import { VariableDeclaration } from "./definitions";
 import { Expression } from "./expressions";
 import { UnableToDetermineMetadataError } from "../../errors";
 import { KipperProgramContext } from "../program-ctx";
-import {determineScope} from "../../utils";
+import { determineScope } from "../../utils";
 
 /**
  * Every antlr4 statement ctx type

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -346,7 +346,7 @@ export class BuiltInOverwriteError extends KipperError {
  * compilation is started without the required semantic data.
  */
 export class UnableToDetermineMetadataError extends KipperInternalError {
-  constructor() {
-    super(`Failed to determine metadata for one or more tokens. Did you forget to run 'semanticAnalysis'?`);
-  }
+	constructor() {
+		super(`Failed to determine metadata for one or more tokens. Did you forget to run 'semanticAnalysis'?`);
+	}
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -9,7 +9,7 @@ import { InputMismatchException, LexerNoViableAltException, NoViableAltException
 import { FailedPredicateException } from "antlr4ts/FailedPredicateException";
 import { RecognitionException } from "antlr4ts/RecognitionException";
 import { Recognizer } from "antlr4ts/Recognizer";
-import { Utils } from "./utils";
+import { getTokenSource } from "./utils";
 
 /**
  * The base error for the Kipper module.
@@ -111,7 +111,7 @@ export class KipperError extends Error {
 	public get tokenSrc(): string | undefined {
 		// Get the token source, if it was not set already - The fallback option requires this.antlrCtx to be set,
 		// otherwise it will default to undefined.
-		return this.tracebackData.tokenSrc ?? (this.antlrCtx ? Utils.getTokenSource(this.antlrCtx) : undefined);
+		return this.tracebackData.tokenSrc ?? (this.antlrCtx ? getTokenSource(this.antlrCtx) : undefined);
 	}
 }
 
@@ -346,7 +346,7 @@ export class BuiltInOverwriteError extends KipperError {
  * compilation is started without the required semantic data.
  */
 export class UnableToDetermineMetadataError extends KipperInternalError {
-	constructor() {
-		super(`Failed to determine metadata for one or more tokens. Did you forget to run 'semanticAnalysis'?`);
-	}
+  constructor() {
+    super(`Failed to determine metadata for one or more tokens. Did you forget to run 'semanticAnalysis'?`);
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,11 @@
 import { Interval } from "antlr4ts/misc/Interval";
 import { ParserRuleContext } from "antlr4ts";
 import {
-  CompilableParseToken,
-  CompoundStatement,
-  eligibleParentToken, KipperParseStream,
-  KipperProgramContext,
-  RootFileParseToken,
+	CompilableParseToken,
+	CompoundStatement,
+	eligibleParentToken,
+	KipperProgramContext,
+	RootFileParseToken,
 } from "./compiler";
 
 /**
@@ -14,19 +14,19 @@ import {
  * @since 0.4.0
  */
 export function getTokenSource(antlrCtx: ParserRuleContext): string {
-  let inputStream = antlrCtx.start.inputStream;
-  let start = antlrCtx.start.startIndex;
+	let inputStream = antlrCtx.start.inputStream;
+	let start = antlrCtx.start.startIndex;
 
-  // If {@link inputStream} is undefined, then we will try to fetch the text using {@link ParserRuleContext.text}
-  if (inputStream === undefined) {
-    return antlrCtx.text;
-  }
+	// If {@link inputStream} is undefined, then we will try to fetch the text using {@link ParserRuleContext.text}
+	if (inputStream === undefined) {
+		return antlrCtx.text;
+	}
 
-  // If {@link this.antlrCtx.stop} is defined, then use {@link this.antlrCtx.stop.stopIndex}, otherwise use
-  // the last index of the "virtual" file/buffer, which is {@link inputStream.size} - 2 (Accounting for the
-  // additional EOF at the end that we do not want, and the fact arrays start at 0)
-  let end = antlrCtx.stop !== undefined ? antlrCtx.stop.stopIndex : inputStream.size - 2;
-  return inputStream.getText(new Interval(start, end));
+	// If {@link this.antlrCtx.stop} is defined, then use {@link this.antlrCtx.stop.stopIndex}, otherwise use
+	// the last index of the "virtual" file/buffer, which is {@link inputStream.size} - 2 (Accounting for the
+	// additional EOF at the end that we do not want, and the fact arrays start at 0)
+	let end = antlrCtx.stop !== undefined ? antlrCtx.stop.stopIndex : inputStream.size - 2;
+	return inputStream.getText(new Interval(start, end));
 }
 
 /**
@@ -35,17 +35,17 @@ export function getTokenSource(antlrCtx: ParserRuleContext): string {
  * @since 0.4.0
  */
 export function determineScope(ctx: CompilableParseToken<any>): KipperProgramContext | CompoundStatement {
-  // Determine type by going up the parent structure, until a compound statement is hit or the root file parse
-  // token, which represents the entire programCtx.
-  let parent: eligibleParentToken = ctx.parent;
-  while (!(parent instanceof RootFileParseToken) && !(parent instanceof CompoundStatement)) {
-    parent = parent.parent;
-  }
+	// Determine type by going up the parent structure, until a compound statement is hit or the root file parse
+	// token, which represents the entire programCtx.
+	let parent: eligibleParentToken = ctx.parent;
+	while (!(parent instanceof RootFileParseToken) && !(parent instanceof CompoundStatement)) {
+		parent = parent.parent;
+	}
 
-  if (parent instanceof RootFileParseToken) {
-    return ctx.programCtx;
-  }
-  return parent;
+	if (parent instanceof RootFileParseToken) {
+		return ctx.programCtx;
+	}
+	return parent;
 }
 
 /**
@@ -53,5 +53,5 @@ export function determineScope(ctx: CompilableParseToken<any>): KipperProgramCon
  * @since 0.4.0
  */
 export function getNaturalOrZero(num: number): number {
-  return num < 0 ? 0 : num;
+	return num < 0 ? 0 : num;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,49 +1,57 @@
 import { Interval } from "antlr4ts/misc/Interval";
 import { ParserRuleContext } from "antlr4ts";
 import {
-	CompilableParseToken,
-	CompoundStatement,
-	eligibleParentToken,
-	KipperProgramContext,
-	RootFileParseToken,
+  CompilableParseToken,
+  CompoundStatement,
+  eligibleParentToken, KipperParseStream,
+  KipperProgramContext,
+  RootFileParseToken,
 } from "./compiler";
 
-export namespace Utils {
-	/**
-	 * Returns the token source for the passed {@link antlrCtx} instance.
-	 * @param antlrCtx The token antlr4 context.
-	 */
-	export function getTokenSource(antlrCtx: ParserRuleContext): string {
-		let inputStream = antlrCtx.start.inputStream;
-		let start = antlrCtx.start.startIndex;
+/**
+ * Returns the token source for the passed {@link antlrCtx} instance.
+ * @param antlrCtx The token antlr4 context.
+ * @since 0.4.0
+ */
+export function getTokenSource(antlrCtx: ParserRuleContext): string {
+  let inputStream = antlrCtx.start.inputStream;
+  let start = antlrCtx.start.startIndex;
 
-		// If {@link inputStream} is undefined, then we will try to fetch the text using {@link ParserRuleContext.text}
-		if (inputStream === undefined) {
-			return antlrCtx.text;
-		}
+  // If {@link inputStream} is undefined, then we will try to fetch the text using {@link ParserRuleContext.text}
+  if (inputStream === undefined) {
+    return antlrCtx.text;
+  }
 
-		// If {@link this.antlrCtx.stop} is defined, then use {@link this.antlrCtx.stop.stopIndex}, otherwise use
-		// the last index of the "virtual" file/buffer, which is {@link inputStream.size} - 2 (Accounting for the
-		// additional EOF at the end that we do not want, and the fact arrays start at 0)
-		let end = antlrCtx.stop !== undefined ? antlrCtx.stop.stopIndex : inputStream.size - 2;
-		return inputStream.getText(new Interval(start, end));
-	}
+  // If {@link this.antlrCtx.stop} is defined, then use {@link this.antlrCtx.stop.stopIndex}, otherwise use
+  // the last index of the "virtual" file/buffer, which is {@link inputStream.size} - 2 (Accounting for the
+  // additional EOF at the end that we do not want, and the fact arrays start at 0)
+  let end = antlrCtx.stop !== undefined ? antlrCtx.stop.stopIndex : inputStream.size - 2;
+  return inputStream.getText(new Interval(start, end));
+}
 
-	/**
-	 * Determine the scope of the token.
-	 * @param ctx The token ctx.
-	 */
-	export function determineScope(ctx: CompilableParseToken<any>): KipperProgramContext | CompoundStatement {
-		// Determine type by going up the parent structure, until a compound statement is hit or the root file parse
-		// token, which represents the entire programCtx.
-		let parent: eligibleParentToken = ctx.parent;
-		while (!(parent instanceof RootFileParseToken) && !(parent instanceof CompoundStatement)) {
-			parent = parent.parent;
-		}
+/**
+ * Determine the scope of the token.
+ * @param ctx The token ctx.
+ * @since 0.4.0
+ */
+export function determineScope(ctx: CompilableParseToken<any>): KipperProgramContext | CompoundStatement {
+  // Determine type by going up the parent structure, until a compound statement is hit or the root file parse
+  // token, which represents the entire programCtx.
+  let parent: eligibleParentToken = ctx.parent;
+  while (!(parent instanceof RootFileParseToken) && !(parent instanceof CompoundStatement)) {
+    parent = parent.parent;
+  }
 
-		if (parent instanceof RootFileParseToken) {
-			return ctx.programCtx;
-		}
-		return parent;
-	}
+  if (parent instanceof RootFileParseToken) {
+    return ctx.programCtx;
+  }
+  return parent;
+}
+
+/**
+ * Returns {@link num} unchanged if its positive, otherwise if its negative it will return 0.
+ * @since 0.4.0
+ */
+export function getNaturalOrZero(num: number): number {
+  return num < 0 ? 0 : num;
 }

--- a/test/module/parse-stream.test.ts
+++ b/test/module/parse-stream.test.ts
@@ -4,8 +4,8 @@ import { KipperParseStream } from "../../src";
 
 const fileLocation: string = `${__dirname}/../kipper-files/main.kip`;
 
-describe("KipperStreams", () => {
-  describe("fromString", () => {
+describe("KipperParseStream", () => {
+  describe("constructor", () => {
     it("Simple file initialisation", async () => {
       let fileContent = (await fs.readFile(fileLocation, "utf8" as BufferEncoding)).toString();
       let stream: KipperParseStream = new KipperParseStream(fileContent);
@@ -14,6 +14,20 @@ describe("KipperStreams", () => {
       assert(stream.stringContent === fileContent);
       assert(stream.charStream.sourceName === "anonymous-script");
       assert(stream.charStream.toString() === fileContent);
+    });
+  });
+
+  describe("fields", () => {
+    it("lines", () => {
+      const content = "1\r\n2\r3\n4";
+      let stream: KipperParseStream = new KipperParseStream(content);
+
+      assert(stream.name === "anonymous-script");
+      assert(stream.stringContent === content);
+      assert(stream.charStream.sourceName === "anonymous-script");
+      assert(stream.charStream.toString() === content);
+      assert(stream.lines.length == 4, "Expected three lines");
+      assert(JSON.stringify(stream.lines) === JSON.stringify(["1", "2", "3", "4"]), "Expected identical content");
     });
   });
 });


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it. Remove any non-checked option -->

- [x] Development or internal changes (These changes do not add new features or fixes bugs, but update the code in other ways)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary
<!-- Explain the reason for this pr, changes and solution briefly. -->

Removed unneeded namespace `Utils` from `utils.ts`. 

## Changes
<!-- Please explain the changes in this PR and their influence. If this fixes an issue, explain what fixed the issue. -->

- Removed namespace `Utils` and updated imports.
- Added new field `KipperParseStream.lines`, which returns the lines of code inside a `KipperParseStream` as an array.

<!-- Remove example text! -->

## Does this PR create new warnings?
<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Changelog
<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added). -->

### Added
- Getter field `KipperParseStream.lines` returning all lines in the source file as an array.
### Changed
- Namespace `Utils` and moved its methods into the global scope of the file to allow the following import scheme
  `import * as Utils from "@kipper/base/utils"`, where the user can themselves define the wanted scope identifier.

<!-- Remove any header with no item. -->

## Linked other issues or PRs
<!-- Include other issues and PRs that are related to this if any exist. -->

<!-- Default: -->
No linked issues.
