### PR TITLE
Fixed bug causing no error to be thrown when using invalid arithmetic expressions, where the first expression is of type string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New errors:
   - `InvalidAssignmentError`, which is thrown when an invalid assignment is used.
 
+### Changed
+
+- Fixed bug [#104](https://github.com/Luna-Klatzer/Kipper/issues/104), which caused errors to be not thrown
+  when using arithmetic expression using strings in combination with other incomplete types. 
+
 ## [0.6.1] - 2022-05-17
 
 ### Added

--- a/kipper/core/src/compiler/program-ctx.ts
+++ b/kipper/core/src/compiler/program-ctx.ts
@@ -297,13 +297,20 @@ export class CompileAssert {
 	 * @param exp2 The second expression.
 	 * @param op The arithmetic operation that is performed.
 	 */
-	public arithmeticExpressionValid(exp1: Expression<any>, exp2: Expression<any>, op: KipperArithmeticOperator): void {
-		const exp1Type = exp1.semanticData.evaluatedType;
-		const exp2Type = exp2.semanticData.evaluatedType;
+	public arithmeticExpressionValid(
+		exp1: Expression<ExpressionSemantics>,
+		exp2: Expression<ExpressionSemantics>,
+		op: KipperArithmeticOperator,
+	): void {
+		const exp1Type = exp1.ensureSemanticDataExists().evaluatedType;
+		const exp2Type = exp2.ensureSemanticDataExists().evaluatedType;
 		if (exp1Type !== exp2Type) {
 			// String-like types can use '+' to concat strings
-			const typeCheck = (t: KipperType) => t === exp1Type;
-			if (op === kipperPlusOperator && kipperStrLikeTypes.find(typeCheck) && kipperStrLikeTypes.find(typeCheck)) {
+			if (
+				op === kipperPlusOperator &&
+				kipperStrLikeTypes.find((t: KipperType) => t === exp1Type) &&
+				kipperStrLikeTypes.find((t: KipperType) => t === exp2Type)
+			) {
 				return;
 			}
 


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it. Remove any non-checked option -->

- [x] Bug fix (Non-breaking change which fixes an issue)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

<!-- Explain the reason for this pr, changes and solution briefly. -->

Fixes arithmetic bug causing no error to be thrown when using invalid arithmetic expressions, where the first expression/value is of type string and contains incompatible types, for example `str` and `num`.

Closes #104 <!-- Remove this if this is not a bug fix PR -->

## Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, explain what fixed the issue. -->

- Fixed #104.

<!-- Remove example text! -->

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Changelog

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added). -->

### Changed

- Fixed bug [#104](https://github.com/Luna-Klatzer/Kipper/issues/104), which caused errors to be not thrown
  when using arithmetic expression using strings in combination with other incomplete types. 


<!-- Remove any header with no item. -->

## Linked other issues or PRs

<!-- Include other issues and PRs that are related to this if any exist. -->

- [x] #104