### PR TITLE
Added flag `--stringCode` to CLI commands `compile`, `run` and `analyse` to allow the use of Kipper code strings as command line arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `CompileAssert.validAssignment`, which asserts that a specific assignment is valid.
 - New errors:
   - `InvalidAssignmentError`, which is thrown when an invalid assignment is used.
+  - `KipperInvalidInputError`, which is thrown when passing invalid input to the Kipper cli.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Implemented code generation for declarations, definitions and value assignments.
+- Implemented code generation for declarations, definitions and value assignments as explained in
+  [#26](https://github.com/Luna-Klatzer/Kipper/issues/26).
 - Implemented semantic analysis for `AssignmentExpression` and `VariableDeclaration`.
 - New field `VariableDeclarationSemantics.value`, which represents the expression that was assigned at declaration.
   This field is `undefined` if `VariableDeclarationSemantics.isDefined` is `false`.
+- New `@kipper/cli` flag `--stringCode`, which can be used as a replacement for the argument `file` as explained in
+  [#100](https://github.com/Luna-Klatzer/Kipper/issues/100). (Available for `kipper analyse`, `kipper compile` and
+  `kipper run`).
 - New functions:
   - `CompileAssert.validAssignment`, which asserts that a specific assignment is valid.
 - New errors:
@@ -21,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed bug [#104](https://github.com/Luna-Klatzer/Kipper/issues/104), which caused errors to be not thrown
-  when using arithmetic expression using strings in combination with other incomplete types. 
+  when using arithmetic expression using strings in combination with other incomplete types.
 
 ## [0.6.1] - 2022-05-17
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 ![](./img/Kipper-Logo-with-head.png)
 
 # Content
+
 - [How to contribute to Kipper](#how-to-contribute-to-kipper)
   - [Using issues to propose changes](#using-issues-to-propose-changes)
     - [Bug issue](#bug-issue)
@@ -24,7 +25,7 @@
 
 Welcome to the Kipper contribution guide!
 
-This is a contribution guide for newcomers, but also experienced developers, which explains the basics of how to 
+This is a contribution guide for newcomers, but also experienced developers, which explains the basics of how to
 contribute to Kipper, how to use issues/PRs and how to modify the source code.
 
 Before starting, thank you for showing interest in this guide! I ([@Luna-Klatzer](https://github.com/Luna-Klatzer))
@@ -33,30 +34,30 @@ appreciate any help with this project and am happy to help if there are any ques
 ## Using issues to propose changes
 
 One of the first things that must be done before contributing to Kipper is to open an issue, or look at
-existing issues or PRs. 
+existing issues or PRs.
 
 - In case you are working on someone else's issue or PR, it is important to read through the details of the issue or PR
   and get to know what should be done, and how other people proposed to do it.
-- In case you are creating your own issue, it is important to think through how your change matters and what they 
+- In case you are creating your own issue, it is important to think through how your change matters and what they
   should do. This is vital for others to understand how to work on your issue and give feedback/recommendations.
 
 ### Bug issue
 
-If you are working on or creating a bug issue, it is important to try and reproduce the issue using tests or sample 
+If you are working on or creating a bug issue, it is important to try and reproduce the issue using tests or sample
 projects that recreate the situation that the bug was encountered in.
 
-In case you are creating a bug issue, it is also important to provide steps on how to reproduce the issue and info 
-about your environment. The [bug issue template](https://github.com/Luna-Klatzer/Kipper/issues/new/choose) will help you 
+In case you are creating a bug issue, it is also important to provide steps on how to reproduce the issue and info
+about your environment. The [bug issue template](https://github.com/Luna-Klatzer/Kipper/issues/new/choose) will help you
 with that.
 
 ### Feature issue
 
-If you are working on or creating a feature issue, it is important to understand the details behind the proposed 
-feature and its possible implementation. If you are going through someone else's issue, it's good to write additional 
+If you are working on or creating a feature issue, it is important to understand the details behind the proposed
+feature and its possible implementation. If you are going through someone else's issue, it's good to write additional
 questions, recommendations, ideas or criticism as a comment under the issue.
 
-In case you are creating a feature issue it is also important to provide info on how you exactly want it to work and 
-what your changes will do (More on that in [Using PRs to add new changes](#using-prs-to-add-new-changes)). 
+In case you are creating a feature issue it is also important to provide info on how you exactly want it to work and
+what your changes will do (More on that in [Using PRs to add new changes](#using-prs-to-add-new-changes)).
 
 ## Using PRs to add new changes
 
@@ -77,16 +78,17 @@ PR changes based on the [Keep a Changelog format]([Keep a Changelog](https://kee
 ## Basic structure of Kipper
 
 Kipper is split up into multiple packages, which are contained in the main monorepo `kipper` that depends on
-*all* Kipper sub-packages.
+_all_ Kipper sub-packages.
 
 ### Monorepo structure using pnpm
 
-To work on Kipper and properly work in the monorepo structure you will need to install and use `pnpm`, which 
-provides the tools for managing a monorepo. 
+To work on Kipper and properly work in the monorepo structure you will need to install and use `pnpm`, which
+provides the tools for managing a monorepo.
 
 Pnpm supports like npm `package.json` scripts, which are heavily used in the process of managing Kipper.
 
 Overview of important basic scripts:
+
 - `pnpm test` - Tests Kipper using the files in `/test/`.
 - `pnpm build` - Builds all Kipper packages in the `/kipper/` folder.
 - `pnpm run browserify` - Builds the browser standalone script `kipper-standalone.js`.
@@ -95,12 +97,12 @@ Overview of important basic scripts:
 
 ### `@kipper/core` package
 
-The core package is, as already in the name, the core of Kipper, as it contains the lexer, parser, semantic 
+The core package is, as already in the name, the core of Kipper, as it contains the lexer, parser, semantic
 analysers, code translators and the classes and functions needed for interacting with the compiler.
 
 ### `@kipper/cli` package
 
-The CLI package is the command line interface for interacting with the Kipper compiler using pre-defined commands. It 
+The CLI package is the command line interface for interacting with the Kipper compiler using pre-defined commands. It
 is not as customisable, but it provides a lot of simple and easy to use functionality over a command line.
 
 ## Kipper compilation targets
@@ -108,38 +110,39 @@ is not as customisable, but it provides a lot of simple and easy to use function
 Kipper is primarily designed to translate to TypeScript code, though currently it is planned to also support other
 targets, like native JavaScript or AssemblyScript to allow more diverse targets and support a bigger ecosystem.
 
-For the moment though, the only target is TypeScript, which is defined in the file `/compiler/target/typescript` of 
-`@kipper/core`. This target also is the default target that will be used for every compilation, unless another target 
+For the moment though, the only target is TypeScript, which is defined in the file `/compiler/target/typescript` of
+`@kipper/core`. This target also is the default target that will be used for every compilation, unless another target
 is specified in `CompileConfig`.
 
 ## Configuring the compiler
 
-The Kipper compiler uses a configuration interface `CompileConfig` to configure the compilation of a program. This 
-interface can be passed as an argument to `KipperCompiler.compile()`, where it will be put into a 
+The Kipper compiler uses a configuration interface `CompileConfig` to configure the compilation of a program. This
+interface can be passed as an argument to `KipperCompiler.compile()`, where it will be put into a
 `CompilerEvaluatedOptions` that merges both the default configuration with the user defined configuration.
 
-*Currently, configuring `KipperCompiler.syntaxAnalyse()` is not supported, as it does not yet support semantic analysis.
-This should be implemented in future releases.*
+_Currently, configuring `KipperCompiler.syntaxAnalyse()` is not supported, as it does not yet support semantic analysis.
+This should be implemented in future releases._
 
 ## How to add new compiler functionality
 
 If you want to add new functionality for the Kipper compiler, you can easily do that in multiple ways:
+
 - If you want to add new syntax, you will have to edit the Antlr4 `/kipper/core/Kipper.g4` file and update the
   `KipperFileListener`, which goes through the generated parse tree of Kipper and determines what items
-  should be added to the `RootFileParseToken` (represents the root item of the entire file, which contains all 
+  should be added to the `RootFileParseToken` (represents the root item of the entire file, which contains all
   statements and declarations as children).
 - If you want to update the compiler logic and semantics, you will have to work in the `/compiler/tokens` folder
   of `@kipper/core`, where the logical tokens are contained that represent expressions, declarations and statements.
-- If you want to update the default translation to TypeScript, you will have to work in the 
+- If you want to update the default translation to TypeScript, you will have to work in the
   `/compiler/target/typescript` file, which contains the semantic analyser and target code generator for TypeScript.
 - If you want to work on a new target or add any other functionality, you should add new files that extend the existing
   functionality and files.
 
 ### Add or update semantics
 
-The semantics of a token is usually represented using an interface that defines what metadata must be present for an 
-instance to be compilable. This semantic data interface is passed to the abstract generic class 
-`CompilableParsenToken<Semantics>` as a generic type parameter, which then defines the semantic data that must be 
+The semantics of a token is usually represented using an interface that defines what metadata must be present for an
+instance to be compilable. This semantic data interface is passed to the abstract generic class
+`CompilableParsenToken<Semantics>` as a generic type parameter, which then defines the semantic data that must be
 present.
 
 Usually the semantic interfaces of Kipper tokens are defined right above, like for example:
@@ -151,13 +154,13 @@ export interface AdditiveExpressionSemantics extends ArithmeticExpressionSemanti
 	operator: KipperAdditiveOperator;
 }
 
-export class AdditiveExpression extends Expression<AdditiveExpressionSemantics> { 
-  // ...
+export class AdditiveExpression extends Expression<AdditiveExpressionSemantics> {
+	// ...
 }
 ```
 
-These semantics then are per default processed using the async function `primarySemanticAnalysis()`. This function 
-should always evaluate and define the semantics by setting the field `CompilableParseToken.semanticData`. Though to 
+These semantics then are per default processed using the async function `primarySemanticAnalysis()`. This function
+should always evaluate and define the semantics by setting the field `CompilableParseToken.semanticData`. Though to
 avoid unexpected errors, when using the semantic data they should always be fetched using
 `CompilableParseToken.ensureSemanticDataExists()`, which throws an error in case they are undefined.
 
@@ -167,9 +170,9 @@ writing semantic analysis and check functions anywhere outside those functions a
 
 #### Updating target specific semantic checks
 
-In case that a target (targets are for example TypeScript) has specific semantic logic that must be upheld, a 
-`KipperTargetSemanticAnalyser` is used, which can do additional checks on specific tokens. Each program 
-(`KipperProgramContext`) has one `KipperCompileTarget` set, which defines how Kipper should be translated. This class 
+In case that a target (targets are for example TypeScript) has specific semantic logic that must be upheld, a
+`KipperTargetSemanticAnalyser` is used, which can do additional checks on specific tokens. Each program
+(`KipperProgramContext`) has one `KipperCompileTarget` set, which defines how Kipper should be translated. This class
 also defines a `KipperTargetSemanticAnalyser`, where target-specific semantic can be checked.
 
 To update or add target specific semantic checks, you can update the corresponding functions for the tokens.
@@ -181,13 +184,12 @@ Throwing errors in Kipper is handled similarly to how mocha tests works. A truth
 and if it's not then an error is thrown. This behaviour is handled using the `CompileAssert` class and `KipperProgramContext.assert()` function.
 
 For example (Code snippet from the class `FunctionDeclaration`):
+
 ```
 this.programCtx.assert(this).typeExists(this.semanticData.returnType);
 ```
 
 ### Add or update token translation
-
-
 
 ## Testing
 
@@ -196,13 +198,13 @@ If you want to make sure your new changes or new functionality works, you will h
 
 ```markdown
 module/
- - cli/
- - core/
+
+- cli/
+- core/
 ```
 
 Please add tests for a package to the correlating test folder e.g. make sure CLI tests are in `/cli/` and core tests in
 `/core/`.
-
 
 ### How to write tests
 
@@ -211,18 +213,18 @@ Tests are written using mocha and chai, so you can easily add new tests in exist
 - To add a new test file, create `name.test.ts` and write there your tests
 - To add a new test namespace, use `describe` with a new unique name:
   ```ts
-  describe(name, () => { 
-   // Add tests here
-  })
+  describe(name, () => {
+  	// Add tests here
+  });
   ```
 - To add a single test, use `it` inside a `describe` with a new unique test name:
   ```ts
   describe(name, () => {
-    it(name, () => { // Use 'async ()' in case you need async functionality
-    
-    });
-  })
-  ``` 
+  	it(name, () => {
+  		// Use 'async ()' in case you need async functionality
+  	});
+  });
+  ```
 - To add an assertion/expectation, use `assert(truth);` inside a test.
 
 If you need ideas how to write good tests, look at the exiting ones and try to get an idea what may

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # The Kipper programming language - `kipper`
 
 [![Version](https://img.shields.io/npm/v/kipper?label=release&color=%23cd2620&logo=npm)](https://npmjs.org/package/kipper)
-![](https://img.shields.io/badge/Coverage-76%25-5A7302.svg?style=flat&logoColor=white&color=blue&prefix=$coverage$)
+![](https://img.shields.io/badge/Coverage-74%25-5A7302.svg?style=flat&logoColor=white&color=blue&prefix=$coverage$)
 [![Issues](https://img.shields.io/github/issues/Luna-Klatzer/Kipper)](https://github.com/Luna-Klatzer/Kipper/issues)
 [![License](https://img.shields.io/github/license/Luna-Klatzer/Kipper?color=cyan)](https://github.com/Luna-Klatzer/Kipper/blob/main/LICENSE)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FLuna-Klatzer%2FKipper.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FLuna-Klatzer%2FKipper?ref=badge_shield)

--- a/kipper/cli/src/commands/analyse.ts
+++ b/kipper/cli/src/commands/analyse.ts
@@ -27,7 +27,6 @@ export default class Analyse extends Command {
 
 	static flags = {
 		encoding: flags.string({
-			char: "e",
 			default: "utf8",
 			description: `The encoding that should be used to read the file (${KipperEncodings.join()}).`,
 			parse: verifyEncoding,

--- a/kipper/cli/src/commands/compile.ts
+++ b/kipper/cli/src/commands/compile.ts
@@ -5,11 +5,12 @@
  * @since 0.0.5
  */
 import { Command, flags } from "@oclif/command";
-import { KipperCompiler, KipperParseStream } from "@kipper/core";
+import { ArgumentError, KipperCompiler, KipperParseStream } from "@kipper/core";
 import { KipperLogger } from "@kipper/core";
 import { defaultCliEmitHandler } from "../logger";
 import { KipperEncoding, KipperEncodings, KipperParseFile, verifyEncoding } from "../file-stream";
 import { writeCompilationResult } from "../compile";
+import { KipperInvalidInputError } from "../errors";
 
 export default class Compile extends Command {
 	static description = "Compiles a Kipper program.";
@@ -20,7 +21,7 @@ export default class Compile extends Command {
 	static args = [
 		{
 			name: "file",
-			required: true,
+			required: false,
 			description: "The file that should be compiled.",
 		},
 	];
@@ -29,10 +30,15 @@ export default class Compile extends Command {
 		encoding: flags.string({
 			default: "utf8",
 			description: `The encoding that should be used to read the file (${KipperEncodings.join()}).`,
+			parse: verifyEncoding,
 		}),
 		outputDir: flags.string({
 			default: "build",
-			description: `The build directory where the compiled files should be placed. If the path does not exist, it will be created.`,
+			description:
+				"The build directory where the compiled files should be placed. If the path does not exist, it will be created.",
+		}),
+		stringCode: flags.string({
+			description: "The content of a Kipper file that can be passed as a replacement for the 'file' argument.",
 		}),
 	};
 
@@ -41,16 +47,27 @@ export default class Compile extends Command {
 		const logger = new KipperLogger(defaultCliEmitHandler);
 		const compiler = new KipperCompiler(logger);
 
-		// Ensure the encoding is valid
-		verifyEncoding(flags.encoding);
+		// Fetch the file
+		let file: KipperParseFile | KipperParseStream;
+		if (args.file) {
+			file = await KipperParseFile.fromFile(args.file, flags.encoding as KipperEncoding);
+		} else if (flags.stringCode) {
+			file = await new KipperParseStream(flags.stringCode);
+		} else {
+			throw new KipperInvalidInputError("Argument 'file' or flag 'stringCode' must be populated. Aborting...");
+		}
 
 		// Start timer for processing
 		const startTime: number = new Date().getTime();
 
-		// Analyse the file
-		const file: KipperParseFile = await KipperParseFile.fromFile(args.file, flags.encoding as KipperEncoding);
+		// Compile the file
 		const result = await compiler.compile(
-			new KipperParseStream(file.stringContent, file.name, file.absolutePath, file.charStream),
+			new KipperParseStream(
+				file.stringContent,
+				file.name,
+				file instanceof KipperParseFile ? file.absolutePath : file.filePath,
+				file.charStream,
+			),
 		);
 
 		await writeCompilationResult(result, file, flags.outputDir, flags.encoding as KipperEncoding);

--- a/kipper/cli/src/compile.ts
+++ b/kipper/cli/src/compile.ts
@@ -4,7 +4,7 @@
  * @copyright 2021-2022 Luna Klatzer
  * @since 0.1.0
  */
-import { KipperCompileResult } from "@kipper/core";
+import { KipperCompileResult, KipperParseStream } from "@kipper/core";
 import { constants, promises as fs } from "fs";
 import { KipperFileWriteError } from "./errors";
 import * as path from "path";
@@ -13,19 +13,19 @@ import { KipperEncoding, KipperParseFile } from "./file-stream";
 /**
  * Writes the file that exist inside the {@link KipperCompileResult compilation result}.
  * @param result The result instance containing the program metadata.
- * @param srcFile The source parse file.
+ * @param srcFile The source parse file or stream.
  * @param outputDir The output dir where the files should be placed. This will be created if it does not exist.
  * @param encoding The encoding to write the file with.
  * @returns The path to the output file.
  */
 export async function writeCompilationResult(
 	result: KipperCompileResult,
-	srcFile: KipperParseFile,
+	srcFile: KipperParseFile | KipperParseStream,
 	outputDir: string,
 	encoding: KipperEncoding,
 ): Promise<string> {
 	const buildPath = path.resolve(outputDir);
-	const outPath = `${buildPath}/${srcFile.path.name}.ts`;
+	const outPath = `${buildPath}/${srcFile instanceof KipperParseFile ? srcFile.path.name : srcFile.name}.ts`;
 	try {
 		// Create the directory if it does not exist
 		try {

--- a/kipper/cli/src/errors.ts
+++ b/kipper/cli/src/errors.ts
@@ -47,3 +47,13 @@ export class KipperFileWriteError extends KipperCLIError {
 		super(`Failed to write file '${filePath}'.`);
 	}
 }
+
+/**
+ * Represents an error that is thrown whenever invalid input is passed to the cli.
+ * @since 0.7.0
+ */
+export class KipperInvalidInputError extends KipperCLIError {
+	constructor(err: string) {
+		super(err);
+	}
+}


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it. Remove any non-checked option -->

- [x] New feature (Non-breaking change which adds functionality)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

<!-- Explain the reason for this pr, changes and solution briefly. -->

Implemented new flag `--stringCode` which can be used instead of a file when using a Kipper CLI command.

Closes #100

## Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, explain what fixed the issue. -->

- Added new flag `--stringCode` to CLI commands `compile`, `run` and `analyse`. In case both `file` and `--stringCode` are used, `file` will be given higher priority and used instead of the string.

<!-- Remove example text! -->

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->
No.

<!-- Remove example text! -->

## Changelog

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added). -->

### Added

- New `@kipper/cli` flag `--stringCode`, which can be used as a replacement for the argument `file` as explained in
  [#100](https://github.com/Luna-Klatzer/Kipper/issues/100). (Available for `kipper analyse`, `kipper compile` and
  `kipper run`).
- New error `KipperInvalidInputError`, which is thrown when passing invalid input to the Kipper cli.

<!-- Remove any header with no item. -->

## Linked other issues or PRs

- [x] #100 
