### PR TITLE
Fixed NULL character bug when writing generated TypeScript code onto files using the `utf16le` encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   when using arithmetic expression using strings in combination with other incomplete types.
 - Fixed issues with non-printable unicode characters in the Kipper CLI when reading UTF-16 files, which caused errors
   with the Antlr4 Parser and Lexer.
+- Fixed NULL character issue when writing generated code onto files using the `utf16le` encoding. From now on a buffer
+  will be created using the proper encoding (also for `ascii` and `utf8`) that should be properly writable to a file.
 
 ## [0.6.1] - 2022-05-17
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # The Kipper programming language - `kipper`
 
 [![Version](https://img.shields.io/npm/v/kipper?label=release&color=%23cd2620&logo=npm)](https://npmjs.org/package/kipper)
-![](https://img.shields.io/badge/Coverage-74%25-5A7302.svg?style=flat&logoColor=white&color=blue&prefix=$coverage$)
+![](https://img.shields.io/badge/Coverage-76%25-5A7302.svg?style=flat&logoColor=white&color=blue&prefix=$coverage$)
 [![Issues](https://img.shields.io/github/issues/Luna-Klatzer/Kipper)](https://github.com/Luna-Klatzer/Kipper/issues)
 [![License](https://img.shields.io/github/license/Luna-Klatzer/Kipper?color=cyan)](https://github.com/Luna-Klatzer/Kipper/blob/main/LICENSE)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FLuna-Klatzer%2FKipper.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FLuna-Klatzer%2FKipper?ref=badge_shield)

--- a/kipper/cli/src/compile.ts
+++ b/kipper/cli/src/compile.ts
@@ -34,7 +34,20 @@ export async function writeCompilationResult(
 			await fs.mkdir(buildPath);
 		}
 
-		await fs.writeFile(outPath, result.write(), { encoding: encoding });
+    // Write the output code
+    const code = result.write();
+
+    // Create a buffer with the proper encoding that can be written to a file
+    let buffer: Buffer;
+    if (encoding === 'utf16le') {
+      buffer = Buffer.from(`\ufeff${code}`, 'utf16le');
+    } else if (encoding === 'utf8') {
+      buffer = Buffer.from(code, 'utf8');
+    } else {
+      buffer = Buffer.from(code, 'ascii');
+    }
+
+		await fs.writeFile(outPath, buffer, { encoding: encoding });
 	} catch (e) {
 		throw new KipperFileWriteError(outPath);
 	}

--- a/kipper/cli/src/compile.ts
+++ b/kipper/cli/src/compile.ts
@@ -34,18 +34,18 @@ export async function writeCompilationResult(
 			await fs.mkdir(buildPath);
 		}
 
-    // Write the output code
-    const code = result.write();
+		// Write the output code
+		const code = result.write();
 
-    // Create a buffer with the proper encoding that can be written to a file
-    let buffer: Buffer;
-    if (encoding === 'utf16le') {
-      buffer = Buffer.from(`\ufeff${code}`, 'utf16le');
-    } else if (encoding === 'utf8') {
-      buffer = Buffer.from(code, 'utf8');
-    } else {
-      buffer = Buffer.from(code, 'ascii');
-    }
+		// Create a buffer with the proper encoding that can be written to a file
+		let buffer: Buffer;
+		if (encoding === "utf16le") {
+			buffer = Buffer.from(`\ufeff${code}`, "utf16le");
+		} else if (encoding === "utf8") {
+			buffer = Buffer.from(code, "utf8");
+		} else {
+			buffer = Buffer.from(code, "ascii");
+		}
 
 		await fs.writeFile(outPath, buffer, { encoding: encoding });
 	} catch (e) {


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it. Remove any non-checked option -->

- [x] Bug fix (Non-breaking change which fixes an issue)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

<!-- Explain the reason for this pr, changes and solution briefly. -->

Fixed NULL character issue when writing generated code onto files using the `utf16le` encoding.

## Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

- Fixed `utf16le` file writing issue in `@kipper/cli`.

<!-- Remove example text! -->

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Changelog

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added). -->

### Changed

- Fixed NULL character issue when writing generated code onto files using the `utf16le` encoding. From now on a buffer
  will be created using the proper encoding (also for `ascii` and `utf8`) that should be properly writable to a file.

<!-- Remove any header with no item. -->

## Linked other issues or PRs

<!-- Include other issues and PRs that are related to this if any exist. -->

<!-- Use this format: - [ ] #ISSUE_OR_PR -->

<!-- Default: -->

No linked issues.
