### PR TITLE
Removed unnecessary cli traceback when encountering compiler runtime errors in Kipper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#100](https://github.com/Luna-Klatzer/Kipper/issues/100). (Available for `kipper analyse`, `kipper compile` and
   `kipper run`).
 - Implemented single char flags as explained in [#109](https://github.com/Luna-Klatzer/Kipper/issues/109).
+- Tracebacks for non-compiler errors that occur during runtime in `@kipper/cli`.
 - New functions:
   - `CompileAssert.validAssignment`, which asserts that a specific assignment is valid.
 - New errors:
@@ -32,7 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with the Antlr4 Parser and Lexer.
 - Fixed NULL character issue when writing generated code onto files using the `utf16le` encoding. From now on a buffer
   will be created using the proper encoding (also for `ascii` and `utf8`) that should be properly writable to a file.
-- Removed unnecessary traceback when encountering Kipper runtime errors as explained in
+
+### Removed
+
+- Unnecessary traceback when encountering Kipper runtime errors as explained in
   [#110](https://github.com/Luna-Klatzer/Kipper/issues/109).
 
 ## [0.6.1] - 2022-05-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with the Antlr4 Parser and Lexer.
 - Fixed NULL character issue when writing generated code onto files using the `utf16le` encoding. From now on a buffer
   will be created using the proper encoding (also for `ascii` and `utf8`) that should be properly writable to a file.
+- Removed unnecessary traceback when encountering Kipper runtime errors as explained in
+  [#110](https://github.com/Luna-Klatzer/Kipper/issues/109).
 
 ## [0.6.1] - 2022-05-17
 

--- a/kipper/cli/src/commands/compile.ts
+++ b/kipper/cli/src/commands/compile.ts
@@ -5,7 +5,7 @@
  * @since 0.0.5
  */
 import { Command, flags } from "@oclif/command";
-import { ArgumentError, KipperCompiler, KipperParseStream } from "@kipper/core";
+import { KipperCompiler, KipperParseStream } from "@kipper/core";
 import { KipperLogger } from "@kipper/core";
 import { defaultCliEmitHandler } from "../logger";
 import { KipperEncoding, KipperEncodings, KipperParseFile, verifyEncoding } from "../file-stream";

--- a/kipper/cli/src/commands/compile.ts
+++ b/kipper/cli/src/commands/compile.ts
@@ -5,9 +5,9 @@
  * @since 0.0.5
  */
 import { Command, flags } from "@oclif/command";
-import { KipperCompiler, KipperParseStream } from "@kipper/core";
+import { KipperCompiler, KipperCompileResult, KipperError, KipperParseStream } from "@kipper/core";
 import { KipperLogger } from "@kipper/core";
-import { defaultCliEmitHandler } from "../logger";
+import { defaultCliEmitHandler, defaultCliLogger } from "../logger";
 import { KipperEncoding, KipperEncodings, KipperParseFile, verifyEncoding } from "../file-stream";
 import { writeCompilationResult } from "../compile";
 import { KipperInvalidInputError } from "../errors";
@@ -64,19 +64,29 @@ export default class Compile extends Command {
 		const startTime: number = new Date().getTime();
 
 		// Compile the file
-		const result = await compiler.compile(
-			new KipperParseStream(
-				file.stringContent,
-				file.name,
-				file instanceof KipperParseFile ? file.absolutePath : file.filePath,
-				file.charStream,
-			),
-		);
+		let result: KipperCompileResult;
+		try {
+			// Run the file
+			result = await compiler.compile(
+				new KipperParseStream(
+					file.stringContent,
+					file.name,
+					file instanceof KipperParseFile ? file.absolutePath : file.filePath,
+					file.charStream,
+				),
+			);
 
-		await writeCompilationResult(result, file, flags.outputDir, flags.encoding as KipperEncoding);
+			await writeCompilationResult(result, file, flags.outputDir, flags.encoding as KipperEncoding);
 
-		// Finished!
-		const duration: number = (new Date().getTime() - startTime) / 1000;
-		await logger.info(`Finished code compilation in ${duration}s.`);
+			// Finished!
+			const duration: number = (new Date().getTime() - startTime) / 1000;
+			await logger.info(`Finished code compilation in ${duration}s.`);
+		} catch (e) {
+			// In case the error is of type KipperError, exit the program, as the logger should have already handled the
+			// output of the error and traceback.
+			if (!(e instanceof KipperError)) {
+				defaultCliLogger.fatal(`Encountered unexpected internal error: \n${(<Error>e).stack}`);
+			}
+		}
 	}
 }

--- a/kipper/cli/src/logger.ts
+++ b/kipper/cli/src/logger.ts
@@ -31,7 +31,7 @@ export const defaultCliLogger: Logger = new Logger(defaultKipperLoggerConfig);
 export function defaultCliEmitHandler(level: LogLevel, msg: string): ILogObject {
 	switch (level) {
 		case LogLevel.FATAL:
-			return defaultCliLogger.trace(msg);
+			return defaultCliLogger.fatal(msg);
 		case LogLevel.ERROR:
 			return defaultCliLogger.error(msg);
 		case LogLevel.WARN:

--- a/test/module/cli/analyse.test.ts
+++ b/test/module/cli/analyse.test.ts
@@ -23,20 +23,6 @@ describe("analyse", () => {
 			.stderr()
 			.stdout()
 			.command(["analyse", invalidFilePath])
-			.catch((err) => {
-				expect(err instanceof KipperSyntaxError, "Expected proper syntax error");
-
-				// Every data field should be filled
-				expect((<KipperSyntaxError<any>>err).stack).to.not.be.undefined;
-				expect((<KipperSyntaxError<any>>err).line).to.not.be.undefined;
-				expect((<KipperSyntaxError<any>>err).col).to.not.be.undefined;
-				expect((<KipperSyntaxError<any>>err).filePath).to.not.be.undefined;
-				expect((<KipperSyntaxError<any>>err).tokenSrc).to.not.be.undefined;
-				expect((<KipperSyntaxError<any>>err).getTraceback().includes("Unknown")).to.be.false;
-
-				// The path should be passed down to the error
-				expect((<KipperSyntaxError<any>>err).filePath).to.equal(invalidFilePath, "Paths should match");
-			})
 			.it("Invalid syntax", (ctx) => {
 				expect(ctx.stdout).to.length.greaterThan(0);
 				expect(ctx.stdout).to.contain("Starting syntax check for 'invalid.kip'.");


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it. Remove any non-checked option -->

- [x] Bug fix (Non-breaking change which fixes an issue)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

<!-- Explain the reason for this pr, changes and solution briefly. -->

Removed unnecessary cli traceback when encountering compiler runtime errors in Kipper that were thrown in the core package of Kipper.

Closes #110 <!-- Remove this if this is not a bug fix PR -->

## Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

- Added tracebacks for non-compiler errors that occur during runtime in `@kipper/cli`.
- Removed unnecessary traceback when encountering Kipper runtime errors and replaced the logging function from `trace` to `fatal`.

<!-- Remove example text! -->

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Changelog

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added). -->

## Linked other issues or PRs

- [x] #110
