### PR TITLE
v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,8 +73,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#110](https://github.com/Luna-Klatzer/Kipper/issues/109).
 - Option to use unary expressions for the left-hand side of an assignment expression in Kipper.g4. (Only identifiers
   may be used.)
-- Option to redeclare variables. From on a variable declaration can only be done once and afterwards the variable may 
-  only be overwritten or modified, but not re-declared. This should help make Kipper have a similar behaviour to 
+- Option to redeclare variables. From on a variable declaration can only be done once and afterwards the variable may
+  only be overwritten or modified, but not re-declared. This should help make Kipper have a similar behaviour to
   TypeScript.
 
 ## [0.6.1] - 2022-05-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated logger messages.
+- Optimised Kipper parsing and lexing process by updating the parsing behaviour in Kipper.g4. Kipper should handle
+  standard expressions a lot faster from no on.
 - Fixed bug [#104](https://github.com/Luna-Klatzer/Kipper/issues/104), which caused an invalid evaluation of the return
   type of string additive expressions causing invalid type errors when used with other expressions.
 - Fixed CLI issues with unrecognisable non-printable unicode characters, which caused errors with the Antlr4 Parser and
@@ -50,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   expressions with the same operator (`N + N + N`) resulting in incomplete TypeScript code.
 - Fixed bug [#111](https://github.com/Luna-Klatzer/Kipper/issues/111), which caused an invalid evaluation of the
   return type of string expressions.
+- Updated logger messages.
 - Updated `compiler` folder structure of the core package:
   - `compiler/parser` from now on contains everything parser and lexer-related.
   - `compiler/parser/antlr` from now on contains the Antlr4 generated parser and lexer files.
@@ -71,6 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#110](https://github.com/Luna-Klatzer/Kipper/issues/109).
 - Option to use unary expressions for the left-hand side of an assignment expression in Kipper.g4. (Only identifiers
   may be used.)
+- Option to redeclare variables. From on a variable declaration can only be done once and afterwards the variable may 
+  only be overwritten or modified, but not re-declared. This should help make Kipper have a similar behaviour to 
+  TypeScript.
 
 ## [0.6.1] - 2022-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2022-05-22
 
 ### Added
 
@@ -462,7 +462,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated file structure to separate `commands` (for `oclif`) and `compiler` (for the compiler source-code)
 
-[unreleased]: https://github.com/Luna-Klatzer/Kipper/compare/0.5.1...HEAD
+[unreleased]: https://github.com/Luna-Klatzer/Kipper/compare/0.7.0..HEAD
+[0.7.0]: https://github.com/Luna-Klatzer/Kipper/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/Luna-Klatzer/Kipper/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/Luna-Klatzer/Kipper/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/Luna-Klatzer/Kipper/compare/v0.4.0...v0.5.0

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -106,6 +106,8 @@ If antlr4 is not installed, install it from here: https://www.antlr.org/
 
    ### Removed
    ```
+   
+   Also update the links at the bottom of the CHANGELOG.md file to properly link the releases to the GitHub pages!
 
 3. Updated the static `version` identifiers in the `src/index.ts` files of each child package:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # The Kipper programming language - `kipper`
 
 [![Version](https://img.shields.io/npm/v/kipper?label=release&color=%23cd2620&logo=npm)](https://npmjs.org/package/kipper)
-![](https://img.shields.io/badge/Coverage-76%25-5A7302.svg?style=flat&logoColor=white&color=blue&prefix=$coverage$)
+![](https://img.shields.io/badge/Coverage-75%25-5A7302.svg?style=flat&logoColor=white&color=blue&prefix=$coverage$)
 [![Issues](https://img.shields.io/github/issues/Luna-Klatzer/Kipper)](https://github.com/Luna-Klatzer/Kipper/issues)
 [![License](https://img.shields.io/github/license/Luna-Klatzer/Kipper?color=cyan)](https://github.com/Luna-Klatzer/Kipper/blob/main/LICENSE)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FLuna-Klatzer%2FKipper.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FLuna-Klatzer%2FKipper?ref=badge_shield)

--- a/kipper/cli/README.md
+++ b/kipper/cli/README.md
@@ -14,10 +14,11 @@ simple and straightforward coding similar to TypeScript and Python! 🦊
 [![Issues](https://img.shields.io/github/issues/Luna-Klatzer/Kipper)](https://github.com/Luna-Klatzer/Kipper/issues)
 
 <!-- toc -->
-* [Kipper CLI - `@kipper/cli`](#kipper-cli---kippercli)
-* [Kipper Docs](#kipper-docs)
-* [Usage](#usage)
-* [Commands](#commands)
+
+- [Kipper CLI - `@kipper/cli`](#kipper-cli---kippercli)
+- [Kipper Docs](#kipper-docs)
+- [Usage](#usage)
+- [Commands](#commands)
 <!-- tocstop -->
 
 # Kipper Docs
@@ -27,6 +28,7 @@ Proper documentation for the Kipper language is available [here](https://wmc-ahi
 # Usage
 
 <!-- usage -->
+
 ```sh-session
 $ npm install -g @kipper/cli
 $ kipper COMMAND
@@ -38,17 +40,19 @@ USAGE
   $ kipper COMMAND
 ...
 ```
+
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-* [`kipper analyse [FILE]`](#kipper-analyse-file)
-* [`kipper compile [FILE]`](#kipper-compile-file)
-* [`kipper help [COMMAND]`](#kipper-help-command)
-* [`kipper run [FILE]`](#kipper-run-file)
-* [`kipper update [CHANNEL]`](#kipper-update-channel)
-* [`kipper version`](#kipper-version)
+
+- [`kipper analyse [FILE]`](#kipper-analyse-file)
+- [`kipper compile [FILE]`](#kipper-compile-file)
+- [`kipper help [COMMAND]`](#kipper-help-command)
+- [`kipper run [FILE]`](#kipper-run-file)
+- [`kipper update [CHANNEL]`](#kipper-update-channel)
+- [`kipper version`](#kipper-version)
 
 ## `kipper analyse [FILE]`
 
@@ -165,6 +169,7 @@ USAGE
 ```
 
 _See code: [src/commands/version.ts](https://github.com/Luna-Klatzer/Kipper/blob/v0.7.0-rc.0/kipper/cli/src/commands/version.ts)_
+
 <!-- commandsstop -->
 
 ## Copyright and License

--- a/kipper/cli/README.md
+++ b/kipper/cli/README.md
@@ -14,11 +14,10 @@ simple and straightforward coding similar to TypeScript and Python! 🦊
 [![Issues](https://img.shields.io/github/issues/Luna-Klatzer/Kipper)](https://github.com/Luna-Klatzer/Kipper/issues)
 
 <!-- toc -->
-
-- [Kipper CLI - `@kipper/cli`](#kipper-cli---kippercli)
-- [Kipper Docs](#kipper-docs)
-- [Usage](#usage)
-- [Commands](#commands)
+* [Kipper CLI - `@kipper/cli`](#kipper-cli---kippercli)
+* [Kipper Docs](#kipper-docs)
+* [Usage](#usage)
+* [Commands](#commands)
 <!-- tocstop -->
 
 # Kipper Docs
@@ -28,7 +27,6 @@ Proper documentation for the Kipper language is available [here](https://wmc-ahi
 # Usage
 
 <!-- usage -->
-
 ```sh-session
 $ npm install -g @kipper/cli
 $ kipper COMMAND
@@ -40,19 +38,17 @@ USAGE
   $ kipper COMMAND
 ...
 ```
-
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-
-- [`kipper analyse [FILE]`](#kipper-analyse-file)
-- [`kipper compile [FILE]`](#kipper-compile-file)
-- [`kipper help [COMMAND]`](#kipper-help-command)
-- [`kipper run [FILE]`](#kipper-run-file)
-- [`kipper update [CHANNEL]`](#kipper-update-channel)
-- [`kipper version`](#kipper-version)
+* [`kipper analyse [FILE]`](#kipper-analyse-file)
+* [`kipper compile [FILE]`](#kipper-compile-file)
+* [`kipper help [COMMAND]`](#kipper-help-command)
+* [`kipper run [FILE]`](#kipper-run-file)
+* [`kipper update [CHANNEL]`](#kipper-update-channel)
+* [`kipper version`](#kipper-version)
 
 ## `kipper analyse [FILE]`
 
@@ -72,7 +68,7 @@ OPTIONS
                                parameter.
 ```
 
-_See code: [src/commands/analyse.ts](https://github.com/Luna-Klatzer/Kipper/blob/v0.7.0-rc.0/kipper/cli/src/commands/analyse.ts)_
+_See code: [src/commands/analyse.ts](https://github.com/Luna-Klatzer/Kipper/blob/v0.7.0/kipper/cli/src/commands/analyse.ts)_
 
 ## `kipper compile [FILE]`
 
@@ -94,7 +90,7 @@ OPTIONS
   -s, --stringCode=stringCode  The content of a Kipper file that can be passed as a replacement for the 'file' argument.
 ```
 
-_See code: [src/commands/compile.ts](https://github.com/Luna-Klatzer/Kipper/blob/v0.7.0-rc.0/kipper/cli/src/commands/compile.ts)_
+_See code: [src/commands/compile.ts](https://github.com/Luna-Klatzer/Kipper/blob/v0.7.0/kipper/cli/src/commands/compile.ts)_
 
 ## `kipper help [COMMAND]`
 
@@ -111,7 +107,7 @@ OPTIONS
   -n, --nested-commands  Include all nested commands in the output.
 ```
 
-_See code: [src/commands/help.ts](https://github.com/Luna-Klatzer/Kipper/blob/v0.7.0-rc.0/kipper/cli/src/commands/help.ts)_
+_See code: [src/commands/help.ts](https://github.com/Luna-Klatzer/Kipper/blob/v0.7.0/kipper/cli/src/commands/help.ts)_
 
 ## `kipper run [FILE]`
 
@@ -134,7 +130,7 @@ OPTIONS
                                parameter.
 ```
 
-_See code: [src/commands/run.ts](https://github.com/Luna-Klatzer/Kipper/blob/v0.7.0-rc.0/kipper/cli/src/commands/run.ts)_
+_See code: [src/commands/run.ts](https://github.com/Luna-Klatzer/Kipper/blob/v0.7.0/kipper/cli/src/commands/run.ts)_
 
 ## `kipper update [CHANNEL]`
 
@@ -157,7 +153,7 @@ EXAMPLES
   [object Object]
 ```
 
-_See code: [src/commands/update.ts](https://github.com/Luna-Klatzer/Kipper/blob/v0.7.0-rc.0/kipper/cli/src/commands/update.ts)_
+_See code: [src/commands/update.ts](https://github.com/Luna-Klatzer/Kipper/blob/v0.7.0/kipper/cli/src/commands/update.ts)_
 
 ## `kipper version`
 
@@ -168,8 +164,7 @@ USAGE
   $ kipper version
 ```
 
-_See code: [src/commands/version.ts](https://github.com/Luna-Klatzer/Kipper/blob/v0.7.0-rc.0/kipper/cli/src/commands/version.ts)_
-
+_See code: [src/commands/version.ts](https://github.com/Luna-Klatzer/Kipper/blob/v0.7.0/kipper/cli/src/commands/version.ts)_
 <!-- commandsstop -->
 
 ## Copyright and License

--- a/kipper/cli/README.md
+++ b/kipper/cli/README.md
@@ -34,7 +34,7 @@ $ npm install -g @kipper/cli
 $ kipper COMMAND
 running command...
 $ kipper (--version)
-@kipper/cli/0.7.0-rc.0 win32-x64 node-v16.15.0
+@kipper/cli/0.7.0 win32-x64 node-v16.15.0
 $ kipper --help [COMMAND]
 USAGE
   $ kipper COMMAND

--- a/kipper/cli/README.md
+++ b/kipper/cli/README.md
@@ -14,10 +14,11 @@ simple and straightforward coding similar to TypeScript and Python! 🦊
 [![Issues](https://img.shields.io/github/issues/Luna-Klatzer/Kipper)](https://github.com/Luna-Klatzer/Kipper/issues)
 
 <!-- toc -->
-* [Kipper CLI - `@kipper/cli`](#kipper-cli---kippercli)
-* [Kipper Docs](#kipper-docs)
-* [Usage](#usage)
-* [Commands](#commands)
+
+- [Kipper CLI - `@kipper/cli`](#kipper-cli---kippercli)
+- [Kipper Docs](#kipper-docs)
+- [Usage](#usage)
+- [Commands](#commands)
 <!-- tocstop -->
 
 # Kipper Docs
@@ -27,6 +28,7 @@ Proper documentation for the Kipper language is available [here](https://wmc-ahi
 # Usage
 
 <!-- usage -->
+
 ```sh-session
 $ npm install -g @kipper/cli
 $ kipper COMMAND
@@ -38,17 +40,19 @@ USAGE
   $ kipper COMMAND
 ...
 ```
+
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-* [`kipper analyse [FILE]`](#kipper-analyse-file)
-* [`kipper compile [FILE]`](#kipper-compile-file)
-* [`kipper help [COMMAND]`](#kipper-help-command)
-* [`kipper run [FILE]`](#kipper-run-file)
-* [`kipper update [CHANNEL]`](#kipper-update-channel)
-* [`kipper version`](#kipper-version)
+
+- [`kipper analyse [FILE]`](#kipper-analyse-file)
+- [`kipper compile [FILE]`](#kipper-compile-file)
+- [`kipper help [COMMAND]`](#kipper-help-command)
+- [`kipper run [FILE]`](#kipper-run-file)
+- [`kipper update [CHANNEL]`](#kipper-update-channel)
+- [`kipper version`](#kipper-version)
 
 ## `kipper analyse [FILE]`
 
@@ -165,6 +169,7 @@ USAGE
 ```
 
 _See code: [src/commands/version.ts](https://github.com/Luna-Klatzer/Kipper/blob/v0.7.0/kipper/cli/src/commands/version.ts)_
+
 <!-- commandsstop -->
 
 ## Copyright and License

--- a/kipper/cli/package.json
+++ b/kipper/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kipper/cli",
   "description": "The Kipper Command Line Interface (CLI) to interact with the Kipper compiler.",
-  "version": "0.7.0-rc.0",
+  "version": "0.7.0",
   "author": "Luna-Klatzer @Luna-Klatzer",
   "bin": {
     "kipper": "./bin/run"

--- a/kipper/cli/src/index.ts
+++ b/kipper/cli/src/index.ts
@@ -14,7 +14,7 @@ export * as help from "./help";
 // eslint-disable-next-line no-unused-vars
 export const name = "@kipper/cli";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.7.0-rc.0";
+export const version = "0.7.0";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/core/package.json
+++ b/kipper/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kipper/core",
   "description": "The Kipper programming language and compiler for the browser and Node.js! 🦊",
-  "version": "0.7.0-rc.0",
+  "version": "0.7.0",
   "author": "Luna-Klatzer @Luna-Klatzer",
   "dependencies": {
     "antlr4ts": "^0.5.0-alpha.4",

--- a/kipper/core/src/compiler/program-ctx.ts
+++ b/kipper/core/src/compiler/program-ctx.ts
@@ -439,8 +439,9 @@ export class KipperProgramContext {
 
 		// Check that the identifier is not used by some other definition and that there has not been a previous definition.
 		if (token instanceof VariableDeclaration) {
+			// May not redeclare a variable
 			this.semanticCheck(token).functionIdentifierNotDeclared(identifier);
-			this.semanticCheck(token).variableIdentifierNotDefined(identifier);
+			this.semanticCheck(token).variableIdentifierNotDeclared(identifier);
 		} else {
 			this.semanticCheck(token).variableIdentifierNotDeclared(identifier);
 			this.semanticCheck(token).functionIdentifierNotDefined(identifier);

--- a/kipper/core/src/index.ts
+++ b/kipper/core/src/index.ts
@@ -16,7 +16,7 @@ export * as utils from "./utils";
 // eslint-disable-next-line no-unused-vars
 export const name = "@kipper/core";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.7.0-rc.0";
+export const version = "0.7.0";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kipper",
   "description": "The Kipper programming language! 🦊",
-  "version": "0.7.0-rc.0",
+  "version": "0.7.0",
   "author": "Luna-Klatzer @Luna-Klatzer",
   "dependencies": {
     "@kipper/core": "workspace:~",

--- a/test/kipper-files/variable-declaration.kip
+++ b/test/kipper-files/variable-declaration.kip
@@ -1,7 +1,7 @@
 /* Variable declaration */
 var name: str;
 
-/* Variable definition */
-var name: str = "4";
+/* Variable assignment */
+name = "4";
 
 call print(name);


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it. Remove any non-checked option -->

- [x] Development or internal changes (These changes do not add new features or fixes bugs, but update the code in other ways)
- [x] Bug fix (Non-breaking change which fixes an issue)
- [x] New feature (Non-breaking change which adds functionality)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

<!-- Explain the reason for this pr, changes and solution briefly. -->

Merges the full v0.7.0 update into main.

## Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

- Implementation and support for variable declarations, definitions and assignments.
- Identifier references and improved type checking for arithmetic, assignments and function calls.
- New class `KipperTypeChecker` responsible for handling type checking in Kipper code.
- New class `KipperSemanticChecker` responsible for handling general semantic analysis, and integrity and cohesion checks.
- New simplified single character flags for the CLI.
- New flag `-s/--stringCode` for using the CLI.
- Improved and updated logging for the core package and the CLI.
- Many bug fixes.

<!-- Remove example text! -->

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Changelog

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added). -->

### Added

- Implemented code generation for declarations, definitions and variable assignments
  ([#26](https://github.com/Luna-Klatzer/Kipper/issues/26)).
- Implemented semantic analysis for `AssignmentExpression` and `VariableDeclaration`.
- Implemented support for identifiers references, which means variables can now be used in the following contexts:
  - As a function call argument: `call print(identifier)`
  - As a value in an arithmetic expression: `identifier + identifier` or `identifier + 5`
- Implemented CLI flag `-s/--stringCode`, which can be used as a replacement for the argument `file`.
  ([#100](https://github.com/Luna-Klatzer/Kipper/issues/100)). This flag is available for `kipper analyse`,
  `kipper compile` and `kipper run`)
- Implemented single char flags for the CLI ([#109](https://github.com/Luna-Klatzer/Kipper/issues/109)).
- Additional metadata and stack info when non-compiler errors are thrown during runtime in the CLI.
- New fields:
  - `VariableDeclarationSemantics.value`, which represents the expression that was assigned in the definition.
    This field is `undefined` if `VariableDeclarationSemantics.isDefined` is `false`.
- New functions:
  - `CompileAssert.validAssignment()`, which asserts that an assignment expression is valid.
  - `abstract CompilableParseToken.semanticTypeChecking()`, which must be implemented by every child and should serve
    as a separate semantic type checking step outside of `primarySemanticAnalysis()`.
- New classes:
  - `KipperAsserter`, which is an abstract base class that represents a class that can be used to assert certain truths
    and handle/throw compile errors.
  - `KipperTypeChecker` and `KipperSemanticChecker`, which perform specialised semantic checking and verify logical
    integrity and cohesion. These two classes replace `CompileAssert`.
- New errors:
  - `InvalidAssignmentError`, which is thrown when an invalid assignment is used.
  - `KipperInvalidInputError`, which is thrown when passing invalid input to the Kipper cli.

### Changed

- Optimised Kipper parsing and lexing process by updating the parsing behaviour in Kipper.g4. Kipper should handle
  standard expressions a lot faster from no on.
- Fixed bug [#104](https://github.com/Luna-Klatzer/Kipper/issues/104), which caused an invalid evaluation of the return
  type of string additive expressions causing invalid type errors when used with other expressions.
- Fixed CLI issues with unrecognisable non-printable unicode characters, which caused errors with the Antlr4 Parser and
  Lexer, when reading files using the `utf16le` encoding.
- Fixed NULL character issue [#114](https://github.com/Luna-Klatzer/Kipper/pull/114) when writing TypeScript code onto
  files using the `utf16le` encoding. From now on a buffer will be created using the proper encoding (also for
  `ascii` and `utf8`) that should be properly writable to a file.
- Fixed incomplete translation bug [#118](https://github.com/Luna-Klatzer/Kipper/issues/118) of chained arithmetic
  expressions with the same operator (`N + N + N`) resulting in incomplete TypeScript code.
- Fixed bug [#111](https://github.com/Luna-Klatzer/Kipper/issues/111), which caused an invalid evaluation of the
  return type of string expressions.
- Updated logger messages.
- Updated `compiler` folder structure of the core package:
  - `compiler/parser` from now on contains everything parser and lexer-related.
  - `compiler/parser/antlr` from now on contains the Antlr4 generated parser and lexer files.
  - `compiler/semantics` from now on contains everything semantics related, such as the file listener, the Kipper
    tokens, logical constants etc.
  - `compiler/translation` from now on contains the classes and tools used for translating Kipper code into another
    language.
  - `compiler/targets` from now on contains the existing targets for Kipper, such as `typescript`.
  - `compiler/lib` from now on contains the standard library and built-ins for Kipper.
  - `compiler/lib/import` from now on contains the default importable libraries for Kipper.
- Renamed:
  - Error `InvalidTypeError` to `TypeError`.
  - Function `KipperProgramContext.addNewGlobalScopeEntry` to `addGlobalVariable()`.
  - Function `CompoundStatement.addNewLocalVariable` to `addLocalVariable()`.

### Removed

- Unnecessary traceback when encountering Kipper runtime errors as explained in
  [#110](https://github.com/Luna-Klatzer/Kipper/issues/109).
- Option to use unary expressions for the left-hand side of an assignment expression in Kipper.g4. (Only identifiers
  may be used.)
- Option to redeclare variables. From on a variable declaration can only be done once and afterwards the variable may
  only be overwritten or modified, but not re-declared. This should help make Kipper have a similar behaviour to
  TypeScript.

<!-- Remove any header with no item. -->

## Linked other issues or PRs

<!-- Include other issues and PRs related to this if any exist. -->

- [x] #125 
- [x] #124 
- [x] #123   
- [x] #120 
- [x] #111  
- [x] #119 
- [x] #118
- [x] #115 
- [x] #110
- [x] #114 
- [x] #113 
- [x] #109 
- [x] #112 
- [x] #100 
- [x] #106 
- [x] #104 
- [x] #101 
- [x] #26   
