### PR TITLE
Updated compilation error tracebacks to be more concise and useful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Updated error traceback generation algorithm to be more concise and useful. The algorithm will try from now on to mark
+  the origin of the error in the source line, instead of only returning the characters causing the error.
+
 ### Removed
 
 - Removed the following deprecated errors and functions:

--- a/kipper/core/src/compiler/semantics/asserter.ts
+++ b/kipper/core/src/compiler/semantics/asserter.ts
@@ -9,6 +9,7 @@ import { KipperProgramContext } from "../program-ctx";
 import { CompilableParseToken } from "./tokens";
 import { KipperError } from "../../errors";
 import { LogLevel } from "../../logger";
+import { getParseRuleSource } from "../../utils";
 
 /**
  * Kipper Asserter, which is used to assert certain truths and throw {@link KipperError KipperErrors} in case that
@@ -51,9 +52,10 @@ export abstract class KipperAsserter {
 	protected assertError(error: KipperError): KipperError {
 		// Update error metadata
 		error.setMetadata({
-			location: { line: this.line ?? 1, col: this.col ?? 1 },
+			location: { line: this.line ?? 1, col: this.col ?? 0 },
 			filePath: this.programCtx.filePath,
-			tokenSrc: undefined,
+			tokenSrc: this.ctx ? getParseRuleSource(this.ctx.antlrRuleCtx) : undefined,
+			streamSrc: this.programCtx.stream,
 		});
 		error.antlrCtx = this.ctx?.antlrRuleCtx;
 


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it. Remove any non-checked option -->

- [x] New feature (Non-breaking change which adds functionality)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

<!-- Explain the reason for this pr, changes and solution briefly. -->

Implemented a better algorithm for handling errors, by trying to determine the origin of the error and marking it inside the original code line.

For example this PR changes the following error:

```bash
09:16:15 ERROR Traceback:
  File 'anonymous-script', line 1, col 13:
    i
    ^
UnknownIdentifierError: Unknown identifier 'i'.
09:16:15 FATAL Failed to compile 'anonymous-script'. 

``` 

to this:

```
09:16:15 ERROR Traceback:
  File 'anonymous-script', line 1, col 13:
    var x: num = i;
                 ^ 
UnknownIdentifierError: Unknown identifier 'i'. 
09:16:15 FATAL Failed to compile 'anonymous-script'. 
```

## Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

- Updated source code fetching algorithm for both syntax and semantic errors. 

<!-- Remove example text! -->

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Changelog

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added). -->

### Changed

- Updated error traceback generation algorithm to be more concise and useful. The algorithm will try from now on to mark the origin of the error in the source line, instead of only returning the characters causing the error.

<!-- Remove any header with no item. -->

## Linked other issues or PRs

<!-- Include other issues and PRs related to this if any exist. -->

<!-- Use this format: - [ ] #ISSUE_OR_PR -->

<!-- Default: -->

No linked issues.
