### PR TITLE
Updated target code generation system and added target-specific built-in functions generation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,7 @@
 	"rules": {
 		"linebreak-style": ["error", "unix"],
 		"max-params": 0,
-		"no-unused-vars": 1,
+    "no-unused-vars": [1, { "vars": "local", "args": "none" }],
 		"no-warning-comments": 0,
 		"no-useless-catch": 1,
 		"comma-dangle": 0,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   should from now on be the folder, where all the targets that are natively supported by Kipper should be located.
 - Moved all typescript-related target files to `kipper/core/src/targets/typescript` and split up the classes into
   their own files.
+- Updated built-in code generation behaviour
 - Renamed `builtIns` to `kipperRuntimeBuiltIns`.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   should from now on be the folder, where all the targets that are natively supported by Kipper should be located.
 - Moved all typescript-related target files to `kipper/core/src/targets/typescript` and split up the classes into
   their own files.
-- Updated built-in code generation behaviour in `KipperProgramContext.generateRequirements()`. This function 
-  generates the built-ins for a program using its `KipperTargetBuiltInGenerator`, which is specified in the 
+- Updated built-in code generation behaviour in `KipperProgramContext.generateRequirements()`. This function
+  generates the built-ins for a program using its `KipperTargetBuiltInGenerator`, which is specified in the
   `KipperCompileTarget`.
 - Renamed `builtIns` to `kipperRuntimeBuiltIns`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   should from now on be the folder, where all the targets that are natively supported by Kipper should be located.
 - Moved all typescript-related target files to `kipper/core/src/targets/typescript` and split up the classes into
   their own files.
-- Updated built-in code generation behaviour in `KipperProgramContext.generateRequirements()`. This function will try
-  to generate the dependencies for each built-in using its `KipperTargetBuiltInGenerator`.
+- Updated built-in code generation behaviour in `KipperProgramContext.generateRequirements()`. This function 
+  generates the built-ins for a program using its `KipperTargetBuiltInGenerator`, which is specified in the 
+  `KipperCompileTarget`.
 - Renamed `builtIns` to `kipperRuntimeBuiltIns`.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so will be blocked by the parser). This also includes a new expression class `BoolPrimaryExpression`, a new
   target-specific semantics function `KipperTargetSemanticAnalyser.boolPrimaryExpression` and target-specific
   translation function `KipperTargetCodeGenerator.boolPrimaryExpression`.
+- Implemented new class `KipperTargetBuiltInGenerator`, which updates the behaviour for generating built-in functions.
+  This function should also allow the use of built-in variables in the future and also provide a basis for dynamic
+  dependency generation for the Kipper built-ins. This means that targets can now specify themselves how the
+  built-in should be generated and can handle all type conversions, internal prefixes, name mangling etc. themselves.
 
 ### Changed
 
 - Updated error traceback generation algorithm to be more concise and useful. The algorithm will try from now on to mark
   the origin of the error in the source line, instead of only returning the characters causing the error.
+- Updated folder structure of built-in targets, by moving all target-related files to `kipper/core/src/targets`. This
+  should from now on be the folder, where all the targets that are natively supported by Kipper should be located.
+- Moved all typescript-related target files to `kipper/core/src/targets/typescript` and split up the classes into
+  their own files.
 
 ### Removed
 
 - Module `kipper/core/compiler/lib`, as the built-ins shall from now on be handled by each individual target instead
-  of the whole Kipper package to allow an implementation per target.
+  of the whole Kipper package to allow a unique specific implementation per target.
 - Removed the following deprecated errors and functions:
   - `UnknownFunctionIdentifierError`
   - `UnknownVariableIdentifierError`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   should from now on be the folder, where all the targets that are natively supported by Kipper should be located.
 - Moved all typescript-related target files to `kipper/core/src/targets/typescript` and split up the classes into
   their own files.
-- Updated built-in code generation behaviour
+- Updated built-in code generation behaviour in `KipperProgramContext.generateRequirements()`. This function will try
+  to generate the dependencies for each built-in using its `KipperTargetBuiltInGenerator`.
 - Renamed `builtIns` to `kipperRuntimeBuiltIns`.
 
 ### Removed
@@ -41,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `KipperSemanticChecker.functionIsDefined`
   - `KipperSemanticChecker.variableIsDefined`
 - Removed `BuiltInFunction.handler` as the core compiler will not handle code generation of Kipper built-ins (like 
-  for example `print`) anymore 
+  for example `print`) anymore.
 
 ## [0.7.0] - 2022-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `UnknownVariableIdentifierError`
   - `KipperSemanticChecker.functionIsDefined`
   - `KipperSemanticChecker.variableIsDefined`
-- Removed `BuiltInFunction.handler` as the core compiler will not handle code generation of Kipper built-ins (like 
+- Removed `BuiltInFunction.handler` as the core compiler will not handle code generation of Kipper built-ins (like
   for example `print`) anymore.
 
 ## [0.7.0] - 2022-05-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This function should also allow the use of built-in variables in the future and also provide a basis for dynamic
   dependency generation for the Kipper built-ins. This means that targets can now specify themselves how the
   built-in should be generated and can handle all type conversions, internal prefixes, name mangling etc. themselves.
+- New field `KipperCompileTarget.builtInGenerator`, which will store the built-in generator for each target.
 
 ### Changed
 
@@ -27,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   should from now on be the folder, where all the targets that are natively supported by Kipper should be located.
 - Moved all typescript-related target files to `kipper/core/src/targets/typescript` and split up the classes into
   their own files.
+- Renamed `builtIns` to `kipperRuntimeBuiltIns`.
 
 ### Removed
 
@@ -37,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `UnknownVariableIdentifierError`
   - `KipperSemanticChecker.functionIsDefined`
   - `KipperSemanticChecker.variableIsDefined`
+- Removed `BuiltInFunction.handler` as the core compiler will not handle code generation of Kipper built-ins (like 
+  for example `print`) anymore 
 
 ## [0.7.0] - 2022-05-22
 

--- a/kipper/core/src/compiler/compile-target.ts
+++ b/kipper/core/src/compiler/compile-target.ts
@@ -5,7 +5,7 @@
  * @since 0.5.0
  */
 
-import { KipperTargetCodeGenerator } from "./translation";
+import { KipperTargetBuiltInGenerator, KipperTargetCodeGenerator } from "./translation";
 import { KipperTargetSemanticAnalyser } from "./semantics";
 
 /**
@@ -17,14 +17,17 @@ export class KipperCompileTarget {
 	public readonly targetName: string;
 	public readonly semanticAnalyser: KipperTargetSemanticAnalyser;
 	public readonly codeGenerator: KipperTargetCodeGenerator;
+	public readonly builtInGenerator: KipperTargetBuiltInGenerator;
 
 	constructor(
 		targetName: string,
 		semanticAnalyser: KipperTargetSemanticAnalyser,
 		codeGenerator: KipperTargetCodeGenerator,
+		builtInGenerator: KipperTargetBuiltInGenerator,
 	) {
 		this.targetName = targetName;
 		this.semanticAnalyser = semanticAnalyser;
 		this.codeGenerator = codeGenerator;
+		this.builtInGenerator = builtInGenerator;
 	}
 }

--- a/kipper/core/src/compiler/compiler.ts
+++ b/kipper/core/src/compiler/compiler.ts
@@ -10,9 +10,9 @@ import { KipperLexer, KipperParser } from "./parser";
 import { KipperLogger, LogLevel } from "../logger";
 import { KipperParseStream } from "./parser";
 import { KipperProgramContext } from "./program-ctx";
-import { BuiltInFunction, builtIns } from "./built-ins";
+import { BuiltInFunction, kipperRuntimeBuiltIns } from "./runtime-built-ins";
 import { KipperCompileTarget } from "./compile-target";
-import { TypeScriptTarget } from "./targets/typescript";
+import { TypeScriptTarget } from "../targets/typescript";
 
 /**
  * Compilation Configuration for a Kipper program. This interface will be wrapped using {@link CompilerEvaluatedOptions}
@@ -62,10 +62,10 @@ export class CompilerEvaluatedOptions implements CompileConfig {
 	 * @since 0.2.0
 	 */
 	public static readonly defaults = {
-		globals: builtIns, // Assume node if it's not a browser
+		globals: kipperRuntimeBuiltIns,
 		extendGlobals: [],
 		fileName: "anonymous-script",
-		target: new TypeScriptTarget(),
+		target: new TypeScriptTarget(), // Default target is TypeScript
 	};
 
 	/**

--- a/kipper/core/src/compiler/index.ts
+++ b/kipper/core/src/compiler/index.ts
@@ -8,7 +8,7 @@
 export * as parser from "./parser";
 export * as semantics from "./semantics";
 export * as translation from "./translation";
-export * from "./built-ins";
+export * from "./runtime-built-ins";
 export * from "./parser";
 export * from "./semantics";
 export * from "./translation";

--- a/kipper/core/src/compiler/program-ctx.ts
+++ b/kipper/core/src/compiler/program-ctx.ts
@@ -375,9 +375,9 @@ export class KipperProgramContext {
 
 	/**
 	 * Generates the required code for the execution of this Kipper program.
-   *
-   * This primarily includes the Kipper built-ins, which require
-   * {@link KipperTargetBuiltInGenerator target-specific dependency and code generation}.
+	 *
+	 * This primarily includes the Kipper built-ins, which require
+	 * {@link KipperTargetBuiltInGenerator target-specific dependency and code generation}.
 	 * @private
 	 */
 	private async generateRequirements(): Promise<Array<Array<string>>> {

--- a/kipper/core/src/compiler/program-ctx.ts
+++ b/kipper/core/src/compiler/program-ctx.ts
@@ -19,12 +19,13 @@ import {
 	ScopeVariableDeclaration,
 	TranslatedCodeLine,
 } from "./semantics";
-import { BuiltInFunction } from "./built-ins";
+import { BuiltInFunction } from "./runtime-built-ins";
 import { KipperLogger } from "../logger";
 import { UndefinedSemanticsError } from "../errors";
 import { KipperCompileTarget } from "./compile-target";
 import { KipperSemanticChecker } from "./semantics/semantic-checker";
 import { KipperTypeChecker } from "./semantics";
+import { KipperTargetBuiltInGenerator } from "./translation";
 
 /**
  * The program context class used to represent a program for a compilation.
@@ -378,11 +379,11 @@ export class KipperProgramContext {
 	 * @private
 	 */
 	private async generateRequirements(): Promise<Array<Array<string>>> {
-		let code: Array<Array<string>> = [];
+		let code: Array<TranslatedCodeLine> = [];
 
 		// Generating the code for the global functions
-		for (let global of this._builtInGlobals) {
-			code = [...code, global.handler];
+		for (let globalSpec of this._builtInGlobals) {
+			code = [...code, ...(await this.target.builtInGenerator.getHandlerFunction(globalSpec.identifier)(globalSpec))];
 		}
 		return code;
 	}

--- a/kipper/core/src/compiler/program-ctx.ts
+++ b/kipper/core/src/compiler/program-ctx.ts
@@ -25,7 +25,6 @@ import { UndefinedSemanticsError } from "../errors";
 import { KipperCompileTarget } from "./compile-target";
 import { KipperSemanticChecker } from "./semantics/semantic-checker";
 import { KipperTypeChecker } from "./semantics";
-import { KipperTargetBuiltInGenerator } from "./translation";
 
 /**
  * The program context class used to represent a program for a compilation.
@@ -375,7 +374,10 @@ export class KipperProgramContext {
 	}
 
 	/**
-	 * Generates the required code for the execution of this kipper program
+	 * Generates the required code for the execution of this Kipper program.
+   *
+   * This primarily includes the Kipper built-ins, which require
+   * {@link KipperTargetBuiltInGenerator target-specific dependency and code generation}.
 	 * @private
 	 */
 	private async generateRequirements(): Promise<Array<Array<string>>> {

--- a/kipper/core/src/compiler/program-ctx.ts
+++ b/kipper/core/src/compiler/program-ctx.ts
@@ -385,7 +385,7 @@ export class KipperProgramContext {
 
 		// Generating the code for the global functions
 		for (let builtInSpec of this._builtInGlobals) {
-      // Fetch the function for handling this built-in
+			// Fetch the function for handling this built-in
 			const func: (funcSpec: BuiltInFunction) => Promise<Array<TranslatedCodeLine>> = Reflect.get(
 				this.target.builtInGenerator,
 				builtInSpec.identifier,

--- a/kipper/core/src/compiler/program-ctx.ts
+++ b/kipper/core/src/compiler/program-ctx.ts
@@ -384,8 +384,13 @@ export class KipperProgramContext {
 		let code: Array<TranslatedCodeLine> = [];
 
 		// Generating the code for the global functions
-		for (let globalSpec of this._builtInGlobals) {
-			code = [...code, ...(await this.target.builtInGenerator.getHandlerFunction(globalSpec.identifier)(globalSpec))];
+		for (let builtInSpec of this._builtInGlobals) {
+      // Fetch the function for handling this built-in
+			const func: (funcSpec: BuiltInFunction) => Promise<Array<TranslatedCodeLine>> = Reflect.get(
+				this.target.builtInGenerator,
+				builtInSpec.identifier,
+			);
+			code = [...code, ...(await func(builtInSpec))];
 		}
 		return code;
 	}

--- a/kipper/core/src/compiler/runtime-built-ins.ts
+++ b/kipper/core/src/compiler/runtime-built-ins.ts
@@ -54,26 +54,8 @@ export interface BuiltInFunction {
 	 */
 	args: Array<BuiltInFunctionArgument>;
 	/**
-	 * The TypeScript code that will be inserted at the beginning of the Kipper program. This should contain the
-	 * implementation for the function identifier, prefixed by `'_kipperGlobal_'`.
-	 *
-	 * @example
-	 *  // Example of a string that may be passed
-	 *  const yourFunction: Function = {
-	 *    identifier: "print",
-	 *    args: [{
-	 *      type: "str" as KipperType
-	 *    }],
-	 *    handler: `function _kipperGlobal_print(arg1: string): void {
-	 *      console.log(arg1);
-	 *      return;
-	 *    }
-	 *    `
-	 *  };
-	 */
-	handler: Array<string>;
-	/**
-	 * The expected return of the function. If the return type is "void", then the function will not return anything.
+	 * The expected return of the function. If the return type is {@link KipperVoidType void}, then the function will not
+	 * return anything.
 	 */
 	returnType: KipperType;
 }
@@ -81,10 +63,10 @@ export interface BuiltInFunction {
 /**
  * Contains all the built-in functions in Kipper that are available per default in every program.
  *
- * This contains *every* builtin
+ * This contains *every* builtin that also must be implemented by every target in the {@link }
  * @since 0.7.0
  */
-export const builtIns: Record<string, BuiltInFunction> = {
+export const kipperRuntimeBuiltIns: Record<string, BuiltInFunction> = {
 	print: {
 		identifier: "print",
 		args: [
@@ -93,7 +75,6 @@ export const builtIns: Record<string, BuiltInFunction> = {
 				type: "str",
 			},
 		],
-		handler: ["function _kipperGlobal_print(msg: string): void { console.log(msg); }"],
 		returnType: "void",
 	},
 };

--- a/kipper/core/src/compiler/semantics/const.ts
+++ b/kipper/core/src/compiler/semantics/const.ts
@@ -8,7 +8,7 @@
 import type { KipperProgramContext } from "../program-ctx";
 import type { CompoundStatement } from "./tokens";
 import type { ScopeFunctionDeclaration, ScopeVariableDeclaration } from "./scope-declaration";
-import type { BuiltInFunction } from "../built-ins";
+import type { BuiltInFunction } from "../runtime-built-ins";
 
 /**
  * If this variable is true, then this environment is assumed to be inside a browser and special browser support should

--- a/kipper/core/src/compiler/semantics/type-checker.ts
+++ b/kipper/core/src/compiler/semantics/type-checker.ts
@@ -11,7 +11,7 @@ import { Expression, ExpressionSemantics, ParameterDeclaration } from "./tokens"
 import { KipperFunction, kipperReturnTypes, KipperType, kipperTypes } from "./const";
 import { InvalidArgumentTypeError, InvalidReturnTypeError, TypeError, UnknownTypeError } from "../../errors";
 import { ScopeVariableDeclaration } from "./scope-declaration";
-import type { BuiltInFunctionArgument } from "../built-ins";
+import type { BuiltInFunctionArgument } from "../runtime-built-ins";
 import type { KipperProgramContext } from "../program-ctx";
 
 /**

--- a/kipper/core/src/compiler/translation/built-ins-generator.ts
+++ b/kipper/core/src/compiler/translation/built-ins-generator.ts
@@ -1,0 +1,38 @@
+/**
+ * Generator for the Kipper built-ins that are specific for a target.
+ * @since 0.8.0
+ */
+import { TranslatedCodeLine } from "../semantics";
+import { BuiltInFunction } from "../runtime-built-ins";
+import { KipperInternalError } from "../../errors";
+
+/**
+ * Generator for the Kipper built-ins that are specific for a target.
+ * @since 0.8.0
+ */
+export abstract class KipperTargetBuiltInGenerator {
+	/**
+	 * Returns the handler for the specified built-in identifier. The identifier **must** be defined in
+	 * {@link kipperRuntimeBuiltIns}, otherwise there will not be an implementation provided and this function
+	 * will throw an {@link KipperInternalError}.
+	 *
+	 * @param identifier
+	 * @since 0.8.0
+	 */
+	getHandlerFunction(identifier: string): (funcSpec: BuiltInFunction) => Promise<Array<TranslatedCodeLine>> {
+		switch (identifier) {
+			case "print":
+				return this.print;
+			default:
+				throw new KipperInternalError(`Unknown built-in function identifier '${identifier}'`);
+		}
+	}
+
+	/**
+	 * Print function which provides default IO output.
+	 * @param funcSpec The specification for the function. This contains the overall metadata for the function that
+	 * should be followed. This is auto-inserted by the code-generator in {@link KipperProgramContext}.
+	 * @since 0.8.0
+	 */
+	abstract print(funcSpec: BuiltInFunction): Promise<Array<TranslatedCodeLine>>;
+}

--- a/kipper/core/src/compiler/translation/built-ins-generator.ts
+++ b/kipper/core/src/compiler/translation/built-ins-generator.ts
@@ -4,30 +4,18 @@
  */
 import { TranslatedCodeLine } from "../semantics";
 import { BuiltInFunction } from "../runtime-built-ins";
-import { KipperInternalError } from "../../errors";
 
 /**
  * Generator for the Kipper built-ins that are specific for a target.
+ *
+ * This class must be specified when using a {@link KipperCompileTarget} and is used to generate the required built-in
+ * functions that can be called during runtime in the target language.
+ *
+ * The functions in this class are automatically called by {@link KipperProgramContext.generateRequirements} when used
+ * inside a {@link KipperProgramContext}, so there is no need to call it yourself.
  * @since 0.8.0
  */
 export abstract class KipperTargetBuiltInGenerator {
-	/**
-	 * Returns the handler for the specified built-in identifier. The identifier **must** be defined in
-	 * {@link kipperRuntimeBuiltIns}, otherwise there will not be an implementation provided and this function
-	 * will throw an {@link KipperInternalError}.
-	 *
-	 * @param identifier
-	 * @since 0.8.0
-	 */
-	getHandlerFunction(identifier: string): (funcSpec: BuiltInFunction) => Promise<Array<TranslatedCodeLine>> {
-		switch (identifier) {
-			case "print":
-				return this.print;
-			default:
-				throw new KipperInternalError(`Unknown built-in function identifier '${identifier}'`);
-		}
-	}
-
 	/**
 	 * Print function which provides default IO output.
 	 * @param funcSpec The specification for the function. This contains the overall metadata for the function that

--- a/kipper/core/src/compiler/translation/index.ts
+++ b/kipper/core/src/compiler/translation/index.ts
@@ -4,3 +4,4 @@
  */
 
 export * from "./code-generator";
+export * from "./built-ins-generator";

--- a/kipper/core/src/targets/typescript/built-in-generator.ts
+++ b/kipper/core/src/targets/typescript/built-in-generator.ts
@@ -1,0 +1,26 @@
+/**
+ * The TypeScript target-specific built-ins generator for generating the code that allows for the use of built-in
+ * functions.
+ * @author Luna Klatzer
+ * @copyright 2021-2022 Luna Klatzer
+ * @since 0.8.0
+ */
+import { BuiltInFunction, KipperTargetBuiltInGenerator, TranslatedCodeLine } from "../../compiler/";
+import { getTypeScriptBuiltInIdentifier, getTypeScriptType } from "./tools";
+
+/**
+ * The TypeScript target-specific built-ins generator for generating the code that allows for the use of built-in
+ * functions.
+ * @since 0.8.0
+ */
+export class TypeScriptTargetBuiltInGenerator extends KipperTargetBuiltInGenerator {
+	async print(funcSpec: BuiltInFunction): Promise<Array<TranslatedCodeLine>> {
+		// Translate the function signature into TypeScript
+		const type: string = getTypeScriptType(funcSpec.returnType);
+		const identifier: string = getTypeScriptBuiltInIdentifier(funcSpec.identifier);
+		const args: Array<string> = funcSpec.args.map((arg) => `${arg.identifier}: ${getTypeScriptType(arg.type)}`);
+
+		// Define the function signature and its body. We will simply use 'console.log(msg)' for printing out IO.
+		return [[`function ${identifier}(${args.join("")}): ${type}`], [`{ console.log(msg); }`]];
+	}
+}

--- a/kipper/core/src/targets/typescript/code-generator.ts
+++ b/kipper/core/src/targets/typescript/code-generator.ts
@@ -1,247 +1,53 @@
 /**
- * Defines the TypeScript translation target for the Kipper language.
+ * The TypeScript target-specific code generator for translating Kipper into TypeScript.
  * @author Luna Klatzer
  * @copyright 2021-2022 Luna Klatzer
- * @since 0.5.0
+ * @since 0.8.0
  */
-import { KipperCompileTarget } from "../compile-target";
-import { KipperTargetSemanticAnalyser } from "../semantics";
-import { KipperTargetCodeGenerator } from "../translation";
 import {
-	type AdditiveExpression,
-	type ArraySpecifierExpression,
-	type AssignmentExpression,
-	type BoolPrimaryExpression,
-	type CastOrConvertExpression,
-	type CharacterPrimaryExpression,
-	type CompoundStatement,
-	type ConditionalExpression,
-	type EqualityExpression,
-	type ExpressionStatement,
-	type FStringPrimaryExpression,
-	type FunctionCallPostfixExpression,
-	type FunctionDeclaration,
-	type IdentifierPrimaryExpression,
-	type IncrementOrDecrementExpression,
-	type IncrementOrDecrementUnaryExpression,
-	type IterationStatement,
-	type JumpStatement,
-	type ListPrimaryExpression,
-	type LogicalAndExpression,
-	type LogicalOrExpression,
-	type MultiplicativeExpression,
-	type NumberPrimaryExpression,
-	type OperatorModifiedUnaryExpression,
-	type ParameterDeclaration,
-	type RelationalExpression,
-	type SelectionStatement,
-	type StringPrimaryExpression,
-	type TangledPrimaryExpression,
-	type VariableDeclaration,
-} from "../semantics";
-import {
-	kipperBoolType,
-	kipperCharType,
-	kipperFuncType,
-	kipperListType,
-	kipperNumType,
-	kipperStrType,
-	KipperType,
-	kipperVoidType,
+	AdditiveExpression,
+	ArraySpecifierExpression,
+	AssignmentExpression,
+	BoolPrimaryExpression,
+	CastOrConvertExpression,
+	CharacterPrimaryExpression,
+	CompoundStatement,
+	ConditionalExpression,
+	EqualityExpression,
+	ExpressionStatement,
+	FStringPrimaryExpression,
+	FunctionCallPostfixExpression,
+	FunctionDeclaration,
+	IdentifierPrimaryExpression,
+	IncrementOrDecrementExpression,
+	IncrementOrDecrementUnaryExpression,
+	IterationStatement,
+	JumpStatement,
+	KipperTargetCodeGenerator,
+	ListPrimaryExpression,
+	LogicalAndExpression,
+	LogicalOrExpression,
+	MultiplicativeExpression,
+	NumberPrimaryExpression,
+	OperatorModifiedUnaryExpression,
+	ParameterDeclaration,
+	RelationalExpression,
 	ScopeFunctionDeclaration,
+	SelectionStatement,
+	StringPrimaryExpression,
+	TangledPrimaryExpression,
 	TranslatedCodeLine,
 	TranslatedCodeToken,
 	TranslatedExpression,
-} from "../semantics";
-import { KipperNotImplementedError } from "../../errors";
+	VariableDeclaration,
+} from "../../compiler";
+import { getTypeScriptBuiltInIdentifier, getTypeScriptType } from "./tools";
 
-export class TypeScriptTarget extends KipperCompileTarget {
-	constructor(
-		semanticAnalyser: TypeScriptTargetSemanticAnalyser = new TypeScriptTargetSemanticAnalyser(),
-		codeGenerator: TypeScriptTargetCodeGenerator = new TypeScriptTargetCodeGenerator(),
-	) {
-		super("typescript", semanticAnalyser, codeGenerator);
-	}
-}
-
-export class TypeScriptTargetSemanticAnalyser extends KipperTargetSemanticAnalyser {
-	/**
-	 * Performs typescript-specific semantic analysis for {@link CompoundStatement} instances.
-	 */
-	compoundStatement = async (token: CompoundStatement) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link SelectionStatement} instances.
-	 */
-	selectionStatement = async (token: SelectionStatement) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link ExpressionStatement} instances.
-	 */
-	expressionStatement = async (token: ExpressionStatement) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link IterationStatement} instances.
-	 */
-	iterationStatement = async (token: IterationStatement) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link JumpStatement} instances.
-	 */
-	jumpStatement = async (token: JumpStatement) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link ParameterDeclaration} instances.
-	 */
-	parameterDeclaration = async (token: ParameterDeclaration) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link FunctionDeclaration} instances.
-	 */
-	functionDeclaration = async (token: FunctionDeclaration) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link VariableDeclaration} instances.
-	 */
-	variableDeclaration = async (token: VariableDeclaration) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link NumberPrimaryExpression} instances.
-	 */
-	numberPrimaryExpression = async (token: NumberPrimaryExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link CharacterPrimaryExpression} instances.
-	 */
-	characterPrimaryExpression = async (token: CharacterPrimaryExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link ListPrimaryExpression} instances.
-	 */
-	listPrimaryExpression = async (token: ListPrimaryExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link IdentifierPrimaryExpression} instances.
-	 */
-	identifierPrimaryExpression = async (token: IdentifierPrimaryExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link StringPrimaryExpression} instances.
-	 */
-	stringPrimaryExpression = async (token: StringPrimaryExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link FStringPrimaryExpression} instances.
-	 */
-	fStringPrimaryExpression = async (token: FStringPrimaryExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link BoolPrimaryExpression} instances.
-	 */
-	boolPrimaryExpression = async (token: BoolPrimaryExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link TangledPrimaryExpression} instances.
-	 */
-	tangledPrimaryExpression = async (token: TangledPrimaryExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link ArraySpecifierExpression} instances.
-	 */
-	arraySpecifierExpression = async (token: ArraySpecifierExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link IncrementOrDecrementExpression} instances.
-	 */
-	incrementOrDecrementExpression = async (token: IncrementOrDecrementExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link FunctionCallPostfixExpression} instances.
-	 */
-	functionCallPostfixExpression = async (token: FunctionCallPostfixExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link IncrementOrDecrementUnaryExpression} instances.
-	 */
-	incrementOrDecrementUnaryExpression = async (token: IncrementOrDecrementUnaryExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link OperatorModifiedUnaryExpression} instances.
-	 */
-	operatorModifiedUnaryExpression = async (token: OperatorModifiedUnaryExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link CastOrConvertExpression} instances.
-	 */
-	castOrConvertExpression = async (token: CastOrConvertExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link MultiplicativeExpression} instances.
-	 */
-	multiplicativeExpression = async (token: MultiplicativeExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link AdditiveExpression} instances.
-	 */
-	additiveExpression = async (token: AdditiveExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link RelationalExpression} instances.
-	 */
-	relationalExpression = async (token: RelationalExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link EqualityExpression} instances.
-	 */
-	equalityExpression = async (token: EqualityExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link LogicalAndExpression} instances.
-	 */
-	logicalAndExpression = async (token: LogicalAndExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link LogicalOrExpression} instances.
-	 */
-	logicalOrExpression = async (token: LogicalOrExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link ConditionalExpression} instances.
-	 */
-	conditionalExpression = async (token: ConditionalExpression) => {};
-
-	/**
-	 * Performs typescript-specific semantic analysis for {@link AssignmentExpression} instances.
-	 */
-	assignmentExpression = async (token: AssignmentExpression) => {};
-}
-
+/**
+ * The TypeScript target-specific code generator for translating Kipper into TypeScript.
+ * @since 0.8.0
+ */
 export class TypeScriptTargetCodeGenerator extends KipperTargetCodeGenerator {
-	/**
-	 * Fetches the typescript equivalent for a {@link KipperType}.
-	 * @param kipperType The type to get the equivalent for.
-	 * @since 0.7.0
-	 */
-	async getTypeScriptType(kipperType: KipperType): Promise<string> {
-		switch (kipperType) {
-			case kipperVoidType:
-				return "void";
-			case kipperFuncType:
-				throw new KipperNotImplementedError(
-					"Lambda functions have not been implemented for TypeScript translation yet.",
-				);
-			case kipperBoolType:
-				return "boolean";
-			case kipperCharType:
-			case kipperStrType:
-				return "string";
-			case kipperNumType:
-				return "number";
-			case kipperListType:
-				throw new KipperNotImplementedError("Kipper lists have not been implemented for TypeScript translation yet.");
-		}
-	}
-
 	/**
 	 * Translates a {@link CompoundStatement} into the typescript language.
 	 */
@@ -306,7 +112,7 @@ export class TypeScriptTargetCodeGenerator extends KipperTargetCodeGenerator {
 		const semanticData = token.ensureSemanticDataExists();
 
 		const storage = semanticData.storageType === "const" ? "const" : "let";
-		const tsType = await this.getTypeScriptType(semanticData.valueType);
+		const tsType = getTypeScriptType(semanticData.valueType);
 		const assign = semanticData.value ? await semanticData.value.translateCtxAndChildren() : [];
 
 		// Only add ' = EXP' if assignValue is defined
@@ -413,13 +219,13 @@ export class TypeScriptTargetCodeGenerator extends KipperTargetCodeGenerator {
 	functionCallPostfixExpression = async (token: FunctionCallPostfixExpression): Promise<TranslatedExpression> => {
 		// Get the function and semantic data
 		const semanticData = token.ensureSemanticDataExists();
-		const tokenChildren = token.ensureTokenChildrenExist();
 		const func = token.programCtx.semanticCheck(token).getExistingFunction(semanticData.identifier);
 
 		// Add lib identifier prefix '_kipperGlobal_'
-		const identifier = func instanceof ScopeFunctionDeclaration ? func.identifier : `_kipperGlobal_${func.identifier}`;
+		const identifier =
+			func instanceof ScopeFunctionDeclaration ? func.identifier : getTypeScriptBuiltInIdentifier(func.identifier);
 
-		// Compile the arguments
+		// Generate the arguments
 		let args: Array<TranslatedCodeToken> = [];
 		for (const i of semanticData.args) {
 			// Generating the code for each expression and adding a whitespace for primitive formatting

--- a/kipper/core/src/targets/typescript/index.ts
+++ b/kipper/core/src/targets/typescript/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Defines the TypeScript translation target for the Kipper language.
+ * @author Luna Klatzer
+ * @copyright 2021-2022 Luna Klatzer
+ * @since 0.8.0
+ */
+import { KipperCompileTarget } from "../../compiler";
+import { TypeScriptTargetSemanticAnalyser } from "./semantic-analyser";
+import { TypeScriptTargetCodeGenerator } from "./code-generator";
+import { TypeScriptTargetBuiltInGenerator } from "./built-in-generator";
+
+export class TypeScriptTarget extends KipperCompileTarget {
+	constructor(
+		semanticAnalyser: TypeScriptTargetSemanticAnalyser = new TypeScriptTargetSemanticAnalyser(),
+		codeGenerator: TypeScriptTargetCodeGenerator = new TypeScriptTargetCodeGenerator(),
+		builtInGenerator: TypeScriptTargetBuiltInGenerator = new TypeScriptTargetBuiltInGenerator(),
+	) {
+		super("typescript", semanticAnalyser, codeGenerator, builtInGenerator);
+	}
+}
+
+export { TypeScriptTargetSemanticAnalyser } from "./semantic-analyser";
+export { TypeScriptTargetCodeGenerator } from "./code-generator";

--- a/kipper/core/src/targets/typescript/semantic-analyser.ts
+++ b/kipper/core/src/targets/typescript/semantic-analyser.ts
@@ -1,0 +1,195 @@
+/**
+ * The TypeScript target-specific semantic analyser.
+ * @author Luna Klatzer
+ * @copyright 2021-2022 Luna Klatzer
+ * @since 0.8.0
+ */
+import {
+	AdditiveExpression,
+	ArraySpecifierExpression,
+	AssignmentExpression,
+	BoolPrimaryExpression,
+	CastOrConvertExpression,
+	CharacterPrimaryExpression,
+	CompoundStatement,
+	ConditionalExpression,
+	EqualityExpression,
+	ExpressionStatement,
+	FStringPrimaryExpression,
+	FunctionCallPostfixExpression,
+	FunctionDeclaration,
+	IdentifierPrimaryExpression,
+	IncrementOrDecrementExpression,
+	IncrementOrDecrementUnaryExpression,
+	IterationStatement,
+	JumpStatement,
+	KipperTargetSemanticAnalyser,
+	ListPrimaryExpression,
+	LogicalAndExpression,
+	LogicalOrExpression,
+	MultiplicativeExpression,
+	NumberPrimaryExpression,
+	OperatorModifiedUnaryExpression,
+	ParameterDeclaration,
+	RelationalExpression,
+	SelectionStatement,
+	StringPrimaryExpression,
+	TangledPrimaryExpression,
+	VariableDeclaration,
+} from "../../compiler";
+
+/**
+ * The TypeScript target-specific semantic analyser.
+ * @since 0.8.0
+ */
+export class TypeScriptTargetSemanticAnalyser extends KipperTargetSemanticAnalyser {
+	/**
+	 * Performs typescript-specific semantic analysis for {@link CompoundStatement} instances.
+	 */
+	compoundStatement = async (token: CompoundStatement) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link SelectionStatement} instances.
+	 */
+	selectionStatement = async (token: SelectionStatement) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link ExpressionStatement} instances.
+	 */
+	expressionStatement = async (token: ExpressionStatement) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link IterationStatement} instances.
+	 */
+	iterationStatement = async (token: IterationStatement) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link JumpStatement} instances.
+	 */
+	jumpStatement = async (token: JumpStatement) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link ParameterDeclaration} instances.
+	 */
+	parameterDeclaration = async (token: ParameterDeclaration) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link FunctionDeclaration} instances.
+	 */
+	functionDeclaration = async (token: FunctionDeclaration) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link VariableDeclaration} instances.
+	 */
+	variableDeclaration = async (token: VariableDeclaration) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link NumberPrimaryExpression} instances.
+	 */
+	numberPrimaryExpression = async (token: NumberPrimaryExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link CharacterPrimaryExpression} instances.
+	 */
+	characterPrimaryExpression = async (token: CharacterPrimaryExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link ListPrimaryExpression} instances.
+	 */
+	listPrimaryExpression = async (token: ListPrimaryExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link IdentifierPrimaryExpression} instances.
+	 */
+	identifierPrimaryExpression = async (token: IdentifierPrimaryExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link StringPrimaryExpression} instances.
+	 */
+	stringPrimaryExpression = async (token: StringPrimaryExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link FStringPrimaryExpression} instances.
+	 */
+	fStringPrimaryExpression = async (token: FStringPrimaryExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link BoolPrimaryExpression} instances.
+	 */
+	boolPrimaryExpression = async (token: BoolPrimaryExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link TangledPrimaryExpression} instances.
+	 */
+	tangledPrimaryExpression = async (token: TangledPrimaryExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link ArraySpecifierExpression} instances.
+	 */
+	arraySpecifierExpression = async (token: ArraySpecifierExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link IncrementOrDecrementExpression} instances.
+	 */
+	incrementOrDecrementExpression = async (token: IncrementOrDecrementExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link FunctionCallPostfixExpression} instances.
+	 */
+	functionCallPostfixExpression = async (token: FunctionCallPostfixExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link IncrementOrDecrementUnaryExpression} instances.
+	 */
+	incrementOrDecrementUnaryExpression = async (token: IncrementOrDecrementUnaryExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link OperatorModifiedUnaryExpression} instances.
+	 */
+	operatorModifiedUnaryExpression = async (token: OperatorModifiedUnaryExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link CastOrConvertExpression} instances.
+	 */
+	castOrConvertExpression = async (token: CastOrConvertExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link MultiplicativeExpression} instances.
+	 */
+	multiplicativeExpression = async (token: MultiplicativeExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link AdditiveExpression} instances.
+	 */
+	additiveExpression = async (token: AdditiveExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link RelationalExpression} instances.
+	 */
+	relationalExpression = async (token: RelationalExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link EqualityExpression} instances.
+	 */
+	equalityExpression = async (token: EqualityExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link LogicalAndExpression} instances.
+	 */
+	logicalAndExpression = async (token: LogicalAndExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link LogicalOrExpression} instances.
+	 */
+	logicalOrExpression = async (token: LogicalOrExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link ConditionalExpression} instances.
+	 */
+	conditionalExpression = async (token: ConditionalExpression) => {};
+
+	/**
+	 * Performs typescript-specific semantic analysis for {@link AssignmentExpression} instances.
+	 */
+	assignmentExpression = async (token: AssignmentExpression) => {};
+}

--- a/kipper/core/src/targets/typescript/tools.ts
+++ b/kipper/core/src/targets/typescript/tools.ts
@@ -1,0 +1,49 @@
+/**
+ * Tools for handling the translation of Kipper to TypeScript.
+ * @author Luna Klatzer
+ * @copyright 2021-2022 Luna Klatzer
+ * @since 0.8.0
+ */
+import {
+	kipperBoolType,
+	kipperCharType,
+	kipperFuncType,
+	kipperListType,
+	kipperNumType,
+	kipperStrType,
+	KipperType,
+	kipperVoidType,
+} from "../../compiler";
+import { KipperNotImplementedError } from "../../errors";
+
+/**
+ * Fetches the typescript equivalent for a {@link KipperType}.
+ * @param kipperType The type to get the equivalent for.
+ * @since 0.8.0
+ */
+export function getTypeScriptType(kipperType: KipperType): string {
+	switch (kipperType) {
+		case kipperVoidType:
+			return "void";
+		case kipperFuncType:
+			throw new KipperNotImplementedError("Lambda functions have not been implemented for TypeScript translation yet.");
+		case kipperBoolType:
+			return "boolean";
+		case kipperCharType:
+		case kipperStrType:
+			return "string";
+		case kipperNumType:
+			return "number";
+		case kipperListType:
+			throw new KipperNotImplementedError("Kipper lists have not been implemented for TypeScript translation yet.");
+	}
+}
+
+/**
+ * Fetches the reserved identifier for the translated code.
+ * @param identifier The identifier to translate to its TypeScript form.
+ * @since 0.8.0
+ */
+export function getTypeScriptBuiltInIdentifier(identifier: string): string {
+	return `__kipper_${identifier}`;
+}

--- a/test/module/core/errors.test.ts
+++ b/test/module/core/errors.test.ts
@@ -68,8 +68,8 @@ describe("Kipper errors", () => {
 				);
 
 				// Duplicate identifier
-				programCtx.registerGlobals({ identifier: "i", args: [], handler: [""], returnType: "void" });
-				programCtx.registerGlobals({ identifier: "i", args: [], handler: [""], returnType: "void" });
+				programCtx.registerGlobals({ identifier: "i", args: [], returnType: "void" });
+				programCtx.registerGlobals({ identifier: "i", args: [], returnType: "void" });
 			} catch (e) {
 				assert((<KipperError>e).constructor.name === "InvalidGlobalError", "Expected proper error");
 				assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
@@ -90,7 +90,7 @@ describe("Kipper errors", () => {
 				);
 
 				// Register new global
-				programCtx.registerGlobals({ identifier: "i", args: [], handler: [""], returnType: "void" });
+				programCtx.registerGlobals({ identifier: "i", args: [], returnType: "void" });
 				await programCtx.compileProgram();
 			} catch (e) {
 				assert((<KipperError>e).constructor.name === "BuiltInOverwriteError", "Expected proper error");


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it. Remove any non-checked option -->

- [x] New feature (Non-breaking change which adds functionality)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

<!-- Explain the reason for this pr, changes and solution briefly. -->

Implemented a new system of generating code and built-in function dependencies. 


More specifically, this PR introduces a new class `KipperTargetBuiltInGenerator`, which will handle the generation of built-ins per target and allow for a specific generation that depends on each target specification. 

That means the core compiler will from on not handle generation and translation of built-in functions anymore and mostly pass the code generation to the targets, which should generate based on a `funcSpec` (from `kipperRuntimeBuiltIns`) the required function that may be called during runtime by the compiled program.

## Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

- Implemented new `KipperTargetBuiltInGenerator` and updated handling of built-in generation using `KipperProgramContext.generateRequirements()`.
- Updated TypeScript target file structure and implemented generation of built-ins using `TypeScriptTargetBuiltInGenerator`.

<!-- Remove example text! -->

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Changelog

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added). -->

### Added

- Implemented new class `KipperTargetBuiltInGenerator`, which updates the behaviour for generating built-in functions.
  This function should also allow the use of built-in variables in the future and also provide a basis for dynamic
  dependency generation for the Kipper built-ins. This means that targets can now specify themselves how the
  built-in should be generated and can handle all type conversions, internal prefixes, name mangling etc. themselves.
- New field `KipperCompileTarget.builtInGenerator`, which will store the built-in generator for each target.

### Changed

- Updated folder structure of built-in targets, by moving all target-related files to `kipper/core/src/targets`. This
  should from now on be the folder, where all the targets that are natively supported by Kipper should be located.
- Moved all typescript-related target files to `kipper/core/src/targets/typescript` and split up the classes into
  their own files.
- Updated built-in code generation behaviour in `KipperProgramContext.generateRequirements()`. This function generates the built-ins for a program using its `KipperTargetBuiltInGenerator`, which is specified in the `KipperCompileTarget`.
- Renamed `builtIns` to `kipperRuntimeBuiltIns`.

### Removed

- Removed `BuiltInFunction.handler` as the core compiler will not handle code generation of Kipper built-ins (like for example `print`) anymore.

<!-- Remove any header with no item. -->

## Linked other issues or PRs

<!-- Include other issues and PRs related to this if any exist. -->

<!-- Use this format: - [ ] #ISSUE_OR_PR -->

<!-- Default: -->

No linked issues.
