### PR TITLE
Fixed const assignment bug which allowed assignments to read-only variables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 - New errors:
-  - `ReadOnlyAssignmentTypeError`, which is thrown when a read-only (constant) variable is being
+  - `ReadOnlyAssignmentTypeError`, which is thrown whenever a read-only (constant) variable is being
     assigned to.
-  - `InvalidAssignmentTypeError`, which is thrown when an assignment has mismatching types that
+  - `InvalidAssignmentTypeError`, which is thrown whenever an assignment has mismatching types that
     are not compatible.
+  - `UndefinedConstantError`, which is thrown whenever a constant declaration is not defined. (Constants
+    may not be undefined).
 
 ## Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## Added
+
+- New errors:
+  - `ReadOnlyAssignmentTypeError`, which is thrown when a read-only (constant) variable is being
+    assigned to.
+  - `InvalidAssignmentTypeError`, which is thrown when an assignment has mismatching types that
+    are not compatible.
+
+## Updated
+
+- Fixed const assignment bug [#188](https://github.com/Luna-Klatzer/Kipper/issues/188), which allowed assignments to
+  read-only (constant) variables.
+- Fixed invalid identifier translation of built-in references in the TypeScript target.
+- Renamed:
+  - `InvalidConversionError` to `InvalidConversionTypeError`
+  - `InvalidArithmeticOperationError` to `InvalidArithmeticOperationTypeError`
+- Set display error name of `InvalidArithmeticOperationTypeError` to `TypeError`.
+
 ## [0.8.2] - 2022-06-14
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   read-only (constant) variables.
 - Fixed invalid identifier translation of built-in references in the TypeScript target.
 - Renamed:
+	- `KipperProgramContext.registerGlobals()` to `registerBuiltIns`.
   - `InvalidConversionError` to `InvalidConversionTypeError`
   - `InvalidArithmeticOperationError` to `InvalidArithmeticOperationTypeError`
 - Set display error name of `InvalidArithmeticOperationTypeError` to `TypeError`.

--- a/kipper/cli/README.md
+++ b/kipper/cli/README.md
@@ -16,10 +16,11 @@ straightforward, simple, secure and type-safe coding similar to TypeScript, Rust
 [![oclif](https://img.shields.io/badge/cli-oclif-brightgreen.svg)](https://oclif.io)
 
 <!-- toc -->
-* [Kipper CLI - `@kipper/cli`](#kipper-cli---kippercli)
-* [Kipper Docs](#kipper-docs)
-* [Usage](#usage)
-* [Commands](#commands)
+
+- [Kipper CLI - `@kipper/cli`](#kipper-cli---kippercli)
+- [Kipper Docs](#kipper-docs)
+- [Usage](#usage)
+- [Commands](#commands)
 <!-- tocstop -->
 
 # Kipper Docs
@@ -29,6 +30,7 @@ Proper documentation for the Kipper language is available [here](https://wmc-ahi
 # Usage
 
 <!-- usage -->
+
 ```sh-session
 $ npm install -g @kipper/cli
 $ kipper COMMAND
@@ -40,17 +42,19 @@ USAGE
   $ kipper COMMAND
 ...
 ```
+
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-* [`kipper analyse [FILE]`](#kipper-analyse-file)
-* [`kipper compile [FILE]`](#kipper-compile-file)
-* [`kipper help [COMMAND]`](#kipper-help-command)
-* [`kipper run [FILE]`](#kipper-run-file)
-* [`kipper update [CHANNEL]`](#kipper-update-channel)
-* [`kipper version`](#kipper-version)
+
+- [`kipper analyse [FILE]`](#kipper-analyse-file)
+- [`kipper compile [FILE]`](#kipper-compile-file)
+- [`kipper help [COMMAND]`](#kipper-help-command)
+- [`kipper run [FILE]`](#kipper-run-file)
+- [`kipper update [CHANNEL]`](#kipper-update-channel)
+- [`kipper version`](#kipper-version)
 
 ## `kipper analyse [FILE]`
 
@@ -180,6 +184,7 @@ USAGE
 ```
 
 _See code: [src/commands/version.ts](https://github.com/Luna-Klatzer/Kipper/blob/v0.8.2/kipper/cli/src/commands/version.ts)_
+
 <!-- commandsstop -->
 
 ## Copyright and License

--- a/kipper/core/src/compiler/compiler.ts
+++ b/kipper/core/src/compiler/compiler.ts
@@ -283,7 +283,7 @@ export class KipperCompiler {
 			// If there are builtIns to register, register them
 			let globals = [...config.builtIns, ...config.extendBuiltIns];
 			if (globals.length > 0) {
-				fileCtx.registerGlobals(globals);
+				fileCtx.registerBuiltIns(globals);
 			}
 			this.logger.debug(
 				`Registered ${globals.length} global function${globals.length === 1 ? "" : "s"} for the program '${

--- a/kipper/core/src/compiler/global-scope.ts
+++ b/kipper/core/src/compiler/global-scope.ts
@@ -9,6 +9,7 @@ import { Scope } from "./scope";
 import { FunctionDeclaration, VariableDeclaration } from "./semantics";
 import { ScopeFunctionDeclaration, ScopeVariableDeclaration } from "./scope-declaration";
 import type { KipperProgramContext } from "./program-ctx";
+import { BuiltInFunction } from "./runtime-built-ins";
 
 /**
  * The global scope of a {@link KipperProgramContext}, which contains the global variables and functions of a
@@ -16,8 +17,31 @@ import type { KipperProgramContext } from "./program-ctx";
  * @since 0.8.0
  */
 export class GlobalScope extends Scope {
+	protected readonly _localFunctions: Array<ScopeFunctionDeclaration>;
+	protected readonly _localVariables: Array<ScopeVariableDeclaration>;
+	protected readonly _builtInFunctions: Array<BuiltInFunction>;
+
 	constructor(public programCtx: KipperProgramContext) {
 		super();
+		this._localVariables = [];
+		this._localFunctions = [];
+		this._builtInFunctions = [];
+	}
+
+	/**
+	 * All 'local' functions in the global scope. This also includes built-in functions.
+	 * @since 0.8.0
+	 */
+	public get localFunctions(): Array<ScopeFunctionDeclaration> {
+		return this._localFunctions;
+	}
+
+	/**
+	 * All 'local' variables in the global scope.
+	 * @since 0.8.0
+	 */
+	public get localVariables(): Array<ScopeVariableDeclaration> {
+		return this._localVariables;
 	}
 
 	public addFunction(declaration: FunctionDeclaration): ScopeFunctionDeclaration {

--- a/kipper/core/src/compiler/program-ctx.ts
+++ b/kipper/core/src/compiler/program-ctx.ts
@@ -503,19 +503,20 @@ export class KipperProgramContext {
 	 *
 	 * Globals must be registered *before* {@link compileProgram} is run to properly include them in the result code.
 	 */
-	public registerGlobals(newGlobals: BuiltInFunction | Array<BuiltInFunction>) {
+	public registerBuiltIns(newBuiltIns: BuiltInFunction | Array<BuiltInFunction>) {
 		// If the function is not an array already, make it one
-		if (!(newGlobals instanceof Array)) {
-			newGlobals = [newGlobals];
+		if (!(newBuiltIns instanceof Array)) {
+			newBuiltIns = [newBuiltIns];
 		}
 
 		// Make sure the global is valid and doesn't interfere with other identifiers
-		for (let g of newGlobals) {
-			// Use line 1 and col 1, as this is a pre-processing error.
+		for (let g of newBuiltIns) {
+			// If an error occurs, line 1 and col 1 will be used, as the ctx is undefined.
 			this.semanticCheck(undefined).globalCanBeRegistered(g.identifier);
 		}
 
-		this.builtIns.push(...newGlobals);
+		// Add new built-ins
+		this.builtIns.push(...newBuiltIns);
 	}
 
 	/**

--- a/kipper/core/src/compiler/scope-declaration.ts
+++ b/kipper/core/src/compiler/scope-declaration.ts
@@ -36,7 +36,7 @@ export abstract class ScopeDeclaration {
 }
 
 /**
- * Represents the definition of a variable scope entry that may be a child of the global scope or local scope.
+ * Represents a variable scope entry that may be a child of the global scope or local scope.
  * @since 0.1.0
  */
 export class ScopeVariableDeclaration extends ScopeDeclaration {

--- a/kipper/core/src/compiler/scope-declaration.ts
+++ b/kipper/core/src/compiler/scope-declaration.ts
@@ -36,8 +36,7 @@ export abstract class ScopeDeclaration {
 }
 
 /**
- * Represents the definition of a scope entry that may be a child of the global scope, a function scope or compound
- * statement scope.
+ * Represents the definition of a variable scope entry that may be a child of the global scope or local scope.
  * @since 0.1.0
  */
 export class ScopeVariableDeclaration extends ScopeDeclaration {
@@ -61,21 +60,21 @@ export class ScopeVariableDeclaration extends ScopeDeclaration {
 	}
 
 	/**
-	 * The identifier of this entry.
+	 * The identifier of this variable.
 	 */
 	public get identifier(): string {
 		return this.semanticData.identifier;
 	}
 
 	/**
-	 * The variable type or return type of this scope entry.
+	 * The variable type or return type of this variable.
 	 */
 	public get type(): KipperType {
 		return this.semanticData.valueType;
 	}
 
 	/**
-	 * The storage type of this scope entry.
+	 * The storage type of this variable.
 	 */
 	public get storageType(): KipperStorageType {
 		return this.semanticData.storageType;

--- a/kipper/core/src/compiler/scope.ts
+++ b/kipper/core/src/compiler/scope.ts
@@ -14,8 +14,8 @@ import type { FunctionDeclaration, VariableDeclaration } from "./semantics";
  * @since 0.8.0
  */
 export abstract class Scope {
-	private readonly _localFunctions: Array<ScopeFunctionDeclaration>;
-	private readonly _localVariables: Array<ScopeVariableDeclaration>;
+	protected readonly _localFunctions: Array<ScopeFunctionDeclaration>;
+	protected readonly _localVariables: Array<ScopeVariableDeclaration>;
 
 	public constructor() {
 		this._localFunctions = [];

--- a/kipper/core/src/compiler/semantics/language/definitions.ts
+++ b/kipper/core/src/compiler/semantics/language/definitions.ts
@@ -388,6 +388,10 @@ export class VariableDeclaration extends Declaration<VariableDeclarationSemantic
 			value: assignValue,
 		};
 
+		// If the storage type is 'const' ensure that the variable has a value set.
+		this.programCtx.semanticCheck(this).validDeclaration(this);
+
+		// Add scope variable entry
 		await this.scope.addVariable(this);
 	}
 

--- a/kipper/core/src/compiler/semantics/processor/semantic-checker.ts
+++ b/kipper/core/src/compiler/semantics/processor/semantic-checker.ts
@@ -17,7 +17,7 @@ import {
 	FunctionDefinitionAlreadyExistsError,
 	IdentifierAlreadyUsedByFunctionError,
 	IdentifierAlreadyUsedByVariableError,
-	InvalidArithmeticOperationError,
+	InvalidArithmeticOperationTypeError,
 	InvalidAssignmentError,
 	InvalidGlobalError,
 	KipperNotImplementedError,
@@ -25,7 +25,7 @@ import {
 	UnknownIdentifierError,
 	VariableDefinitionAlreadyExistsError,
 	InvalidAmountOfArgumentsError,
-	InvalidConversionError,
+	InvalidConversionTypeError,
 } from "../../../errors";
 import {
 	kipperPlusOperator,
@@ -37,7 +37,6 @@ import {
 	type KipperType,
 } from "../const";
 import type { KipperProgramContext } from "../../program-ctx";
-import type { BuiltInFunction } from "../../runtime-built-ins";
 import { ScopeDeclaration, ScopeFunctionDeclaration, ScopeVariableDeclaration } from "../../scope-declaration";
 import { KipperSemanticsAsserter } from "../semantics-asserter";
 
@@ -49,25 +48,6 @@ import { KipperSemanticsAsserter } from "../semantics-asserter";
 export class KipperSemanticChecker extends KipperSemanticsAsserter {
 	constructor(programCtx: KipperProgramContext) {
 		super(programCtx);
-	}
-
-	/**
-	 * Tries to
-	 * @param identifier The identifier to search for.
-	 * @param scopeCtx The scopeCtx to search in.
-	 * @since 0.8.0
-	 */
-	private getDeclaration(
-		identifier: string,
-		scopeCtx?: CompoundStatement,
-	): ScopeFunctionDeclaration | ScopeVariableDeclaration | BuiltInFunction | undefined {
-		return (
-			(scopeCtx // First try to fetch from the local scope if it is defined
-				? scopeCtx.localScope.getVariableRecursively(identifier)
-				: this.programCtx.globalScope.getDeclaration(identifier)) ??
-			this.programCtx.globalScope.getDeclaration(identifier) ?? // Fall back to looking globally
-			this.programCtx.getBuiltInFunction(identifier) // Fall back to searching through built-in functions
-		);
 	}
 
 	/**
@@ -211,7 +191,7 @@ export class KipperSemanticChecker extends KipperSemanticsAsserter {
 			}
 
 			// If types are not matching, and they are not of string-like types, throw an error
-			throw this.assertError(new InvalidArithmeticOperationError(exp1Type, exp2Type));
+			throw this.assertError(new InvalidArithmeticOperationTypeError(exp1Type, exp2Type));
 		}
 	}
 
@@ -327,7 +307,7 @@ export class KipperSemanticChecker extends KipperSemanticsAsserter {
 		})();
 		// In case that the type are not the same and no conversion is possible, throw an error!
 		if (!(originalType === type) && !viableConversion) {
-			throw this.assertError(new InvalidConversionError(originalType, type));
+			throw this.assertError(new InvalidConversionTypeError(originalType, type));
 		}
 	}
 }

--- a/kipper/core/src/compiler/semantics/processor/semantic-checker.ts
+++ b/kipper/core/src/compiler/semantics/processor/semantic-checker.ts
@@ -10,7 +10,8 @@ import {
 	type CompoundStatement,
 	type Expression,
 	type ExpressionSemantics,
-	IdentifierPrimaryExpression, VariableDeclaration
+	IdentifierPrimaryExpression,
+	VariableDeclaration,
 } from "../language";
 import {
 	BuiltInOverwriteError,
@@ -25,7 +26,8 @@ import {
 	UnknownIdentifierError,
 	VariableDefinitionAlreadyExistsError,
 	InvalidAmountOfArgumentsError,
-	InvalidConversionTypeError, UndefinedConstantError
+	InvalidConversionTypeError,
+	UndefinedConstantError,
 } from "../../../errors";
 import {
 	kipperPlusOperator,
@@ -299,9 +301,7 @@ export class KipperSemanticChecker extends KipperSemanticsAsserter {
 	public validDeclaration(decl: VariableDeclaration): void {
 		const declSemanticData = decl.getSemanticData();
 		if (declSemanticData.storageType === "const" && !declSemanticData.isDefined) {
-			throw this.assertError(
-				new UndefinedConstantError("Constant declarations must be defined.")
-			);
+			throw this.assertError(new UndefinedConstantError("Constant declarations must be defined."));
 		}
 	}
 

--- a/kipper/core/src/compiler/semantics/processor/semantic-checker.ts
+++ b/kipper/core/src/compiler/semantics/processor/semantic-checker.ts
@@ -10,7 +10,7 @@ import {
 	type CompoundStatement,
 	type Expression,
 	type ExpressionSemantics,
-	IdentifierPrimaryExpression,
+	IdentifierPrimaryExpression, VariableDeclaration
 } from "../language";
 import {
 	BuiltInOverwriteError,
@@ -25,7 +25,7 @@ import {
 	UnknownIdentifierError,
 	VariableDefinitionAlreadyExistsError,
 	InvalidAmountOfArgumentsError,
-	InvalidConversionTypeError,
+	InvalidConversionTypeError, UndefinedConstantError
 } from "../../../errors";
 import {
 	kipperPlusOperator,
@@ -289,6 +289,19 @@ export class KipperSemanticChecker extends KipperSemanticsAsserter {
 	public validFunctionCallArguments(func: KipperFunction, args: Array<Expression<any>>): void {
 		if (func.args.length != args.length) {
 			throw this.assertError(new InvalidAmountOfArgumentsError(func.identifier, func.args.length, args.length));
+		}
+	}
+
+	/**
+	 * Asserts that the variable declaration is valid.
+	 * @param decl The variable declaration.
+	 */
+	public validDeclaration(decl: VariableDeclaration): void {
+		const declSemanticData = decl.getSemanticData();
+		if (declSemanticData.storageType === "const" && !declSemanticData.isDefined) {
+			throw this.assertError(
+				new UndefinedConstantError("Constant declarations must be defined.")
+			);
 		}
 	}
 

--- a/kipper/core/src/errors.ts
+++ b/kipper/core/src/errors.ts
@@ -447,17 +447,29 @@ export class InvalidConversionTypeError extends TypeError {
  */
 export class UnknownTypeError extends TypeError {
 	constructor(type: string) {
-		super(`Unknown type '${type}'!`);
+		super(`Unknown type '${type}'.`);
 	}
 }
 
 /**
- * Error that is thrown whenever an assignment expression is invalid.
+ * Error that is thrown whenever a constant declaration is not defined.
+ * @since 0.8.3
+ */
+export class UndefinedConstantError extends KipperError {
+	constructor(msg: string) {
+		super(msg);
+		this.name = "UndefinedConstantError";
+	}
+}
+
+/**
+ * Error that is thrown whenever an assignment expression is semantically invalid.
  * @since 0.7.0
  */
 export class InvalidAssignmentError extends KipperError {
 	constructor(msg: string) {
 		super(msg);
+		this.name = "InvalidAssignmentError";
 	}
 }
 

--- a/kipper/core/src/errors.ts
+++ b/kipper/core/src/errors.ts
@@ -14,8 +14,8 @@ import type {
 import type { FailedPredicateException } from "antlr4ts/FailedPredicateException";
 import type { RecognitionException } from "antlr4ts/RecognitionException";
 import type { Recognizer } from "antlr4ts/Recognizer";
+import type { KipperParseStream } from "./compiler";
 import { getParseRuleSource } from "./utils";
-import { KipperParseStream } from "./compiler";
 
 /**
  * The core error for the Kipper module.
@@ -395,10 +395,9 @@ export class InvalidReturnTypeError extends TypeError {
  * interact with one another.
  * @since 0.6.0
  */
-export class InvalidArithmeticOperationError extends TypeError {
+export class InvalidArithmeticOperationTypeError extends TypeError {
 	constructor(firstType: string, secondType: string) {
 		super(`Invalid arithmetic operation between types '${firstType}' and '${secondType}'.`);
-		this.name = "InvalidArithmeticOperationError";
 	}
 }
 
@@ -414,10 +413,30 @@ export class InvalidArgumentTypeError extends TypeError {
 }
 
 /**
+ * Error that is thrown whenever an assignments consists of invalid types.
+ * @since 0.8.3
+ */
+export class InvalidAssignmentTypeError extends TypeError {
+	constructor(leftExpType: string, rightExpType: string) {
+		super(`Type '${leftExpType}' is not assignable to type '${rightExpType}'.`);
+	}
+}
+
+/**
+ * Error that is thrown whenever a read-only variable is being assigned to.
+ * @since 0.8.3
+ */
+export class ReadOnlyAssignmentTypeError extends TypeError {
+	constructor(identifier: string) {
+		super(`'${identifier}' is read-only and may not be assigned to.`);
+	}
+}
+
+/**
  * Error that is thrown whenever a conversion is used that is not supported.
  * @since 0.8.0
  */
-export class InvalidConversionError extends TypeError {
+export class InvalidConversionTypeError extends TypeError {
 	constructor(originalType: string, destType: string) {
 		super(`Type conversion from '${originalType}' to '${destType}' is not allowed.`);
 	}

--- a/kipper/core/src/targets/typescript/code-generator.ts
+++ b/kipper/core/src/targets/typescript/code-generator.ts
@@ -165,7 +165,16 @@ export class TypeScriptTargetCodeGenerator extends KipperTargetCodeGenerator {
 	identifierPrimaryExpression = async (node: IdentifierPrimaryExpression): Promise<TranslatedExpression> => {
 		const semanticData = node.getSemanticData();
 
-		return [semanticData.identifier];
+		// Get the identifier of the reference
+		let identifier = semanticData.identifier;
+
+		// If the identifier is not found in the global scope, assume it's a built-in function and format the identifier
+		// accordingly.
+		if (!node.programCtx.globalScope.getDeclaration(identifier)) {
+			identifier = getTypeScriptBuiltInIdentifier(identifier);
+		}
+
+		return [identifier];
 	};
 
 	/**
@@ -363,10 +372,19 @@ export class TypeScriptTargetCodeGenerator extends KipperTargetCodeGenerator {
 	assignmentExpression = async (node: AssignmentExpression): Promise<TranslatedExpression> => {
 		const semanticData = node.getSemanticData();
 
-		const identifier = semanticData.identifier.getSemanticData().identifier;
-		const assignValue = await semanticData.value.translateCtxAndChildren();
+		// Get the identifier of the reference
+		let identifier = semanticData.identifier.getSemanticData().identifier;
 
-		// Only add ' = EXP' if assignValue is defined
-		return [identifier, " ", "=", " ", ...assignValue];
+		// If the identifier is not found in the global scope, assume it's a built-in function and format the identifier
+		// accordingly.
+		if (!node.programCtx.globalScope.getDeclaration(identifier)) {
+			identifier = getTypeScriptBuiltInIdentifier(identifier);
+		}
+
+		// The expression that is assigned to the reference
+		const assignExp = await semanticData.value.translateCtxAndChildren();
+
+		// Only add ' = EXP' if assignExpression is defined
+		return [identifier, " ", "=", " ", ...assignExp];
 	};
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,7 @@ packages:
       treeverse: 1.0.4
       walk-up-path: 1.0.0
     transitivePeerDependencies:
+      - bluebird
       - supports-color
     dev: true
 
@@ -462,6 +463,8 @@ packages:
       promise-retry: 2.0.1
       semver: 7.3.7
       which: 2.0.2
+    transitivePeerDependencies:
+      - bluebird
     dev: true
 
   /@npmcli/installed-package-contents/1.0.7:
@@ -492,6 +495,7 @@ packages:
       pacote: 12.0.3
       semver: 7.3.7
     transitivePeerDependencies:
+      - bluebird
       - supports-color
     dev: true
 
@@ -539,6 +543,7 @@ packages:
       node-gyp: 8.4.1
       read-package-json-fast: 2.0.3
     transitivePeerDependencies:
+      - bluebird
       - supports-color
     dev: true
 
@@ -1778,6 +1783,8 @@ packages:
       ssri: 8.0.1
       tar: 6.1.11
       unique-filename: 1.1.1
+    transitivePeerDependencies:
+      - bluebird
     dev: true
 
   /cacache/16.0.7:
@@ -1802,6 +1809,8 @@ packages:
       ssri: 9.0.0
       tar: 6.1.11
       unique-filename: 1.1.1
+    transitivePeerDependencies:
+      - bluebird
     dev: true
 
   /cached-path-relative/1.1.0:
@@ -4130,6 +4139,7 @@ packages:
       socks-proxy-agent: 6.2.0
       ssri: 9.0.0
     transitivePeerDependencies:
+      - bluebird
       - supports-color
     dev: true
 
@@ -4154,6 +4164,7 @@ packages:
       socks-proxy-agent: 6.2.0
       ssri: 8.0.1
     transitivePeerDependencies:
+      - bluebird
       - supports-color
     dev: true
 
@@ -4520,6 +4531,7 @@ packages:
       tar: 6.1.11
       which: 2.0.2
     transitivePeerDependencies:
+      - bluebird
       - supports-color
     dev: true
 
@@ -4623,6 +4635,7 @@ packages:
       minizlib: 2.1.2
       npm-package-arg: 8.1.5
     transitivePeerDependencies:
+      - bluebird
       - supports-color
     dev: true
 
@@ -4753,6 +4766,7 @@ packages:
       yeoman-generator: 5.6.1_yeoman-environment@3.9.1
       yosay: 2.0.2
     transitivePeerDependencies:
+      - bluebird
       - encoding
       - supports-color
     dev: true
@@ -4924,6 +4938,7 @@ packages:
       ssri: 8.0.1
       tar: 6.1.11
     transitivePeerDependencies:
+      - bluebird
       - supports-color
     dev: true
 
@@ -5143,6 +5158,11 @@ packages:
 
   /promise-inflight/1.0.1:
     resolution: {integrity: sha1-mEcocL8igTL8vdhoEputEsPAKeM=}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
     dev: true
 
   /promise-retry/2.0.1:
@@ -6262,7 +6282,6 @@ packages:
     resolution: {integrity: sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: false
 
   /uglify-js/3.16.0:
     resolution: {integrity: sha512-FEikl6bR30n0T3amyBh3LoiBdqHRy/f4H80+My34HOesOKyHfOsxAPAxOoqC0JUnC1amnO0IwkYC3sko51caSw==}
@@ -6815,6 +6834,7 @@ packages:
       textextensions: 5.15.0
       untildify: 4.0.0
     transitivePeerDependencies:
+      - bluebird
       - supports-color
     dev: true
 

--- a/test/module/core/compiler.test.ts
+++ b/test/module/core/compiler.test.ts
@@ -386,15 +386,6 @@ describe("KipperCompiler", () => {
 					assert(instance.programCtx.stream === stream, "Expected matching streams");
 					assert(instance.write().includes("let x: number;"), "Expected different TypeScript code");
 				});
-
-				it("const", async () => {
-					const stream = new KipperParseStream("const x: num;");
-					const instance: KipperCompileResult = await compiler.compile(stream);
-
-					assert(instance.programCtx);
-					assert(instance.programCtx.stream === stream, "Expected matching streams");
-					assert(instance.write().includes("const x: number;"), "Expected different TypeScript code");
-				});
 			});
 
 			describe("Definition", () => {

--- a/test/module/core/errors.test.ts
+++ b/test/module/core/errors.test.ts
@@ -68,8 +68,8 @@ describe("Kipper errors", () => {
 				);
 
 				// Duplicate identifier
-				programCtx.registerGlobals({ identifier: "i", args: [], returnType: "void" });
-				programCtx.registerGlobals({ identifier: "i", args: [], returnType: "void" });
+				programCtx.registerBuiltIns({ identifier: "i", args: [], returnType: "void" });
+				programCtx.registerBuiltIns({ identifier: "i", args: [], returnType: "void" });
 			} catch (e) {
 				assert((<KipperError>e).constructor.name === "InvalidGlobalError", "Expected proper error");
 				assert((<KipperError>e).line !== undefined, "Expected existing 'line' meta field");
@@ -90,7 +90,7 @@ describe("Kipper errors", () => {
 				);
 
 				// Register new global
-				programCtx.registerGlobals({ identifier: "i", args: [], returnType: "void" });
+				programCtx.registerBuiltIns({ identifier: "i", args: [], returnType: "void" });
 				await programCtx.compileProgram();
 			} catch (e) {
 				assert((<KipperError>e).constructor.name === "BuiltInOverwriteError", "Expected proper error");
@@ -378,366 +378,438 @@ describe("Kipper errors", () => {
 			});
 		});
 
-		describe("InvalidArithmeticOperationError", () => {
+		describe("InvalidArithmeticOperationTypeError", () => {
 			describe("Error", () => {
 				it("str+num", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('"3" + 4;'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("str-num", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('"3" - 4;'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("str*num", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('"3" * 4;'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("str**num", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('"3" ** 4;'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("str/num", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('"3" / 4;'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("str%num", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('"3" % 4;'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("num+str", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('4 + "3";'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("num-str", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('4 - "3";'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("num*str", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('4 * "3";'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("num**str", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('4 ** "3";'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("num/str", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('4 / "3";'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("num%str", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('4 % "3";'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("str+bool", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('"3" + true;'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("str-bool", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('"3" - true;'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("str*bool", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('"3" * true;'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("str**bool", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('"3" ** true;'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("str/bool", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('"3" / true;'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("str%bool", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('"3" % true;'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("bool+str", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('true + "3";'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("bool-str", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('true - "3";'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("bool*str", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('true * "3";'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("bool**str", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('true ** "3";'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("bool/str", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('true / "3";'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 
 				it("bool%str", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('true % "3";'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidArithmeticOperationError", "Expected proper error");
-						assert((<KipperError>e).name === "InvalidArithmeticOperationError", "Expected proper error");
+						assert(
+							(<KipperError>e).constructor.name === "InvalidArithmeticOperationTypeError",
+							"Expected proper error",
+						);
+						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
 						assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidArithmeticOperationError'");
+					assert(false, "Expected 'InvalidArithmeticOperationTypeError'");
 				});
 			});
 
@@ -747,7 +819,7 @@ describe("Kipper errors", () => {
 						try {
 							await new KipperCompiler().compile('"3" + "3";');
 						} catch (e) {
-							assert(false, "Expected no 'InvalidArithmeticOperationError'");
+							assert(false, "Expected no 'InvalidArithmeticOperationTypeError'");
 						}
 					});
 
@@ -755,7 +827,7 @@ describe("Kipper errors", () => {
 						try {
 							await new KipperCompiler().compile("3 + 3;");
 						} catch (e) {
-							assert(false, "Expected no 'InvalidArithmeticOperationError'");
+							assert(false, "Expected no 'InvalidArithmeticOperationTypeError'");
 						}
 					});
 				});
@@ -845,7 +917,7 @@ describe("Kipper errors", () => {
 						try {
 							await new KipperCompiler().compile(new KipperParseStream('var x: num; x = "5";'));
 						} catch (e) {
-							assert((<KipperError>e).constructor.name === "TypeError", "Expected proper error");
+							assert((<KipperError>e).constructor.name === "InvalidAssignmentTypeError", "Expected proper error");
 							assert((<KipperError>e).name === "TypeError", "Expected proper error");
 							assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 							assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
@@ -860,7 +932,7 @@ describe("Kipper errors", () => {
 						try {
 							await new KipperCompiler().compile(new KipperParseStream("var x: str; x = 5;"));
 						} catch (e) {
-							assert((<KipperError>e).constructor.name === "TypeError", "Expected proper error");
+							assert((<KipperError>e).constructor.name === "InvalidAssignmentTypeError", "Expected proper error");
 							assert((<KipperError>e).name === "TypeError", "Expected proper error");
 							assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 							assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
@@ -892,13 +964,13 @@ describe("Kipper errors", () => {
 			});
 		});
 
-		describe("InvalidConversionError", () => {
+		describe("InvalidConversionTypeError", () => {
 			describe("Error", () => {
 				it("str as func", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream('"5" as func;'));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidConversionError", "Expected proper error");
+						assert((<KipperError>e).constructor.name === "InvalidConversionTypeError", "Expected proper error");
 						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
@@ -906,14 +978,14 @@ describe("Kipper errors", () => {
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidConversionError'");
+					assert(false, "Expected 'InvalidConversionTypeError'");
 				});
 
 				it("num as func", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream("5 as func;"));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidConversionError", "Expected proper error");
+						assert((<KipperError>e).constructor.name === "InvalidConversionTypeError", "Expected proper error");
 						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
@@ -921,14 +993,14 @@ describe("Kipper errors", () => {
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidConversionError'");
+					assert(false, "Expected 'InvalidConversionTypeError'");
 				});
 
 				it("bool as func", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream("true as func;"));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidConversionError", "Expected proper error");
+						assert((<KipperError>e).constructor.name === "InvalidConversionTypeError", "Expected proper error");
 						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
@@ -936,14 +1008,14 @@ describe("Kipper errors", () => {
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidConversionError'");
+					assert(false, "Expected 'InvalidConversionTypeError'");
 				});
 
 				it("func as str", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream("print as str;"));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidConversionError", "Expected proper error");
+						assert((<KipperError>e).constructor.name === "InvalidConversionTypeError", "Expected proper error");
 						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
@@ -951,14 +1023,14 @@ describe("Kipper errors", () => {
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidConversionError'");
+					assert(false, "Expected 'InvalidConversionTypeError'");
 				});
 
 				it("func as num", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream("print as bool;"));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidConversionError", "Expected proper error");
+						assert((<KipperError>e).constructor.name === "InvalidConversionTypeError", "Expected proper error");
 						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
@@ -966,14 +1038,14 @@ describe("Kipper errors", () => {
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidConversionError'");
+					assert(false, "Expected 'InvalidConversionTypeError'");
 				});
 
 				it("func as bool", async () => {
 					try {
 						await new KipperCompiler().compile(new KipperParseStream("print as bool;"));
 					} catch (e) {
-						assert((<KipperError>e).constructor.name === "InvalidConversionError", "Expected proper error");
+						assert((<KipperError>e).constructor.name === "InvalidConversionTypeError", "Expected proper error");
 						assert((<KipperError>e).name === "TypeError", "Expected proper error");
 						assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
 						assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
@@ -981,7 +1053,7 @@ describe("Kipper errors", () => {
 						assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
 						return;
 					}
-					assert(false, "Expected 'InvalidConversionError'");
+					assert(false, "Expected 'InvalidConversionTypeError'");
 				});
 			});
 
@@ -990,7 +1062,7 @@ describe("Kipper errors", () => {
 					try {
 						await new KipperCompiler().compile("5 as str;");
 					} catch (e) {
-						assert(false, "Expected no 'InvalidConversionError'");
+						assert(false, "Expected no 'InvalidConversionTypeError'");
 					}
 				});
 
@@ -998,7 +1070,7 @@ describe("Kipper errors", () => {
 					try {
 						await new KipperCompiler().compile('"5" as num;');
 					} catch (e) {
-						assert(false, "Expected no 'InvalidConversionError'");
+						assert(false, "Expected no 'InvalidConversionTypeError'");
 					}
 				});
 
@@ -1006,7 +1078,7 @@ describe("Kipper errors", () => {
 					try {
 						await new KipperCompiler().compile("true as str;");
 					} catch (e) {
-						assert(false, "Expected no 'InvalidConversionError'");
+						assert(false, "Expected no 'InvalidConversionTypeError'");
 					}
 				});
 
@@ -1014,7 +1086,7 @@ describe("Kipper errors", () => {
 					try {
 						await new KipperCompiler().compile("true as num;");
 					} catch (e) {
-						assert(false, "Expected no 'InvalidConversionError'");
+						assert(false, "Expected no 'InvalidConversionTypeError'");
 					}
 				});
 			});
@@ -1041,6 +1113,31 @@ describe("Kipper errors", () => {
 					await new KipperCompiler().compile('var valid: str = "3";');
 				} catch (e) {
 					assert(false, "Expected no 'ReservedIdentifierOverwriteError'");
+				}
+			});
+		});
+
+		describe("ReadOnlyAssignmentTypeError", () => {
+			it("Error", async () => {
+				try {
+					await new KipperCompiler().compile(new KipperParseStream(`const invalid: str = "3"; invalid = "5";`));
+				} catch (e) {
+					assert((<KipperError>e).constructor.name === "ReadOnlyAssignmentTypeError", "Expected proper error");
+					assert((<KipperError>e).name === "TypeError", "Expected proper error");
+					assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
+					assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
+					assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
+					assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
+					return;
+				}
+				assert(false, "Expected 'ReadOnlyAssignmentTypeError'");
+			});
+
+			it("NoError", async () => {
+				try {
+					await new KipperCompiler().compile('var valid: str = "3"; valid = "5";');
+				} catch (e) {
+					assert(false, "Expected no 'ReadOnlyAssignmentTypeError'");
 				}
 			});
 		});

--- a/test/module/core/errors.test.ts
+++ b/test/module/core/errors.test.ts
@@ -1141,5 +1141,30 @@ describe("Kipper errors", () => {
 				}
 			});
 		});
+
+		describe("UndefinedConstantError", () => {
+			it("Error", async () => {
+				try {
+					await new KipperCompiler().compile(new KipperParseStream(`const invalid: str;`));
+				} catch (e) {
+					assert((<KipperError>e).constructor.name === "UndefinedConstantError", "Expected proper error");
+					assert((<KipperError>e).name === "UndefinedConstantError", "Expected proper error");
+					assert((<KipperError>e).line != undefined, "Expected existing 'line' meta field");
+					assert((<KipperError>e).col != undefined, "Expected existing 'col' meta field");
+					assert((<KipperError>e).tokenSrc != undefined, "Expected existing 'tokenSrc' meta field");
+					assert((<KipperError>e).filePath != undefined, "Expected existing 'filePath' meta field");
+					return;
+				}
+				assert(false, "Expected 'UndefinedConstantError'");
+			});
+
+			it("NoError", async () => {
+				try {
+					await new KipperCompiler().compile('const valid: str = "3";');
+				} catch (e) {
+					assert(false, "Expected no 'UndefinedConstantError'");
+				}
+			});
+		});
 	});
 });

--- a/test/module/core/program-ctx.test.ts
+++ b/test/module/core/program-ctx.test.ts
@@ -24,7 +24,7 @@ describe("KipperProgramContext", async () => {
 			assert(programCtx.builtIns.length === 0, "Expected builtIns to be empty");
 
 			// Register builtIns
-			programCtx.registerGlobals(EvaluatedCompileOptions.defaults.builtIns.print);
+			programCtx.registerBuiltIns(EvaluatedCompileOptions.defaults.builtIns.print);
 
 			// Make sure a single global exists
 			assert(programCtx.builtIns.length == 1, "Expe`cted one global to exist");
@@ -37,13 +37,13 @@ describe("KipperProgramContext", async () => {
 			assert(programCtx.builtIns.length === 0, "Expected builtIns to be empty");
 
 			// Register already registered global again
-			programCtx.registerGlobals(EvaluatedCompileOptions.defaults.builtIns.print);
+			programCtx.registerBuiltIns(EvaluatedCompileOptions.defaults.builtIns.print);
 
 			// Make sure a single global exists
 			assert(programCtx.builtIns.length == 1, "Expected one global to exist");
 
 			try {
-				programCtx.registerGlobals(EvaluatedCompileOptions.defaults.builtIns.print);
+				programCtx.registerBuiltIns(EvaluatedCompileOptions.defaults.builtIns.print);
 			} catch (e) {
 				if (e instanceof InvalidGlobalError) {
 					return;
@@ -66,7 +66,7 @@ describe("KipperProgramContext", async () => {
 			assert(programCtx.getBuiltInFunction("id") === undefined, "No built-in should exist");
 
 			// Register builtIns and check again
-			programCtx.registerGlobals(EvaluatedCompileOptions.defaults.builtIns.print);
+			programCtx.registerBuiltIns(EvaluatedCompileOptions.defaults.builtIns.print);
 			assert(programCtx.getBuiltInFunction("") === undefined, "No built-in should exist");
 			assert(programCtx.getBuiltInFunction("id") === undefined, "No built-in should exist");
 		});
@@ -75,7 +75,7 @@ describe("KipperProgramContext", async () => {
 			const programCtx: KipperProgramContext = await new KipperCompiler().parse(stream);
 
 			// Register builtIns and check again
-			programCtx.registerGlobals(EvaluatedCompileOptions.defaults.builtIns.print);
+			programCtx.registerBuiltIns(EvaluatedCompileOptions.defaults.builtIns.print);
 			assert(
 				programCtx.getBuiltInFunction("print") === EvaluatedCompileOptions.defaults.builtIns.print,
 				"The built-in function 'print' should be returned.",


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it. Remove any non-checked option -->

- [x] Bug fix (Non-breaking change which fixes an issue)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

<!-- Explain the reason for this pr, changes and solution briefly. -->

Fixes const assignment bug, which allowed assignments to read-only (constant) variables and added `UndefinedConstantError`, which will be thrown if a constant variable is not defined/initialised.

Closes #188

## Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

- Fixed #188.
- Fixed invalid identifier translation of built-in references in the TypeScript target.
- Added new error `UndefinedConstantError`, which will be thrown if a constant variable is not defined/initialised (constants must always have a value set).

<!-- Remove example text! -->

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Changelog

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added). -->

## Added

- New errors:
  - `ReadOnlyAssignmentTypeError`, which is thrown whenever a read-only (constant) variable is being
    assigned to.
  - `InvalidAssignmentTypeError`, which is thrown whenever an assignment has mismatching types that
    are not compatible.
  - `UndefinedConstantError`, which is thrown whenever a constant declaration is not defined. (Constants
    may not be undefined).

## Updated

- Fixed const assignment bug [#188](https://github.com/Luna-Klatzer/Kipper/issues/188), which allowed assignments to
  read-only (constant) variables.
- Fixed invalid identifier translation of built-in references in the TypeScript target.
- Renamed:
  - `KipperProgramContext.registerGlobals()` to `registerBuiltIns`.
  - `InvalidConversionError` to `InvalidConversionTypeError`
  - `InvalidArithmeticOperationError` to `InvalidArithmeticOperationTypeError`
- Set display error name of `InvalidArithmeticOperationTypeError` to `TypeError`.


<!-- Remove any header with no item. -->

## Linked other issues or PRs

<!-- Include other issues and PRs related to this if any exist. -->
- [x] #188 
