### PR TITLE
Added support for binary, octal and hex numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#173](https://github.com/Luna-Klatzer/Kipper/issues/173)).
 - Implemented code generation for tangled expressions.
   ([#203](https://github.com/Luna-Klatzer/Kipper/issues/203))
+- Added support for hex, binary and octal numbers. (Only minor changes, as previously the syntax for binary, octal and 
+	hex numbers was already added.) ([#184](https://github.com/Luna-Klatzer/Kipper/issues/184))
 
 ## [0.8.3] - 2022-06-18
 

--- a/kipper/core/Kipper.g4
+++ b/kipper/core/Kipper.g4
@@ -374,23 +374,28 @@ DecimalConstant
 
 fragment
 BinaryConstant
-		:		'0' [bB] [0-1]+
+		:		'0' [bB] BinaryDigit+
 		;
 
 fragment
 OctalConstant
-    :   '0' [oO] OctalDigit*
+    :   '0' [oO] OctalDigit+
     ;
 
 fragment
 HexadecimalConstant
-    :    '0' [xX] HexadecimalDigitSequence
+    :    '0' [xX] HexadecimalDigit+
     ;
 
 fragment
 NonzeroDigit
     :   [1-9]
     ;
+
+fragment
+BinaryDigit
+	  :		[0-1]
+	  ;
 
 fragment
 OctalDigit
@@ -430,11 +435,6 @@ Sign
 
 DigitSequence
     :   Digit+
-    ;
-
-fragment
-HexadecimalDigitSequence
-    :   HexadecimalDigit+
     ;
 
 CharacterConstant

--- a/kipper/core/src/compiler/semantics/language/expressions.ts
+++ b/kipper/core/src/compiler/semantics/language/expressions.ts
@@ -255,8 +255,16 @@ export interface NumberPrimaryExpressionSemantics extends ExpressionSemantics {
 	 */
 	evaluatedType: KipperNumType;
 	/**
-	 * The value of the constant number expression. We don't bother converting this to a number, since it's an unnecessary
-	 * conversion.
+	 * The value of the constant number expression.
+	 *
+	 * This can be either:
+	 * - A Default 10-base number (N)
+	 * - A Float 10-base number (N.N)
+	 * - A Hex 16-base number (0xN)
+	 * - A Octal 8-base number (0oN)
+	 * - A Binary 2-base number (0bN)
+	 * - An Exponent 10-base number (NeN)
+	 * - An Exponent Float 10-base number (N.NeN)
 	 * @since 0.5.0
 	 */
 	value: string;


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it. Remove any non-checked option -->

- [x] New feature (Non-breaking change which adds functionality)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

<!-- Explain the reason for this pr, changes and solution briefly. -->

Added proper support for binary, octal and hex numbers. 

(Only minor changes, as previously the syntax for binary, octal and hex numbers was already added.)

Closes #184 

## Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

- Updated `Kipper.g4` and added explicit lexer rule `BinaryDigit`.
- Added comment in `NumberPrimaryExpression` explaining the possible numbers that can be stored inside a number.

<!-- Remove example text! -->

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Changelog

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added). -->

<!-- ### Added -->
<!-- ### Changed -->
<!-- ### Removed -->

<!-- Default: -->

None.

<!-- Remove any header with no item. -->

## Linked other issues or PRs

<!-- Include other issues and PRs related to this if any exist. -->

- [x] #184 