### PR TITLE
Added partial support for semantic analysis warnings using `CompilableASTNode.checkForWarnings()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,8 +94,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `KipperTypeChecker.validRelationalExpression`, which ensures a `RelationalExpression` is semantically valid.
   - `KipperTypeChecker.validUnaryExpression`, which ensures a `UnaryExpression` is semantically valid.
 - New fields:
+  - `KipperCompileResult.warnings`, which contains a list of all warnings that were found during the compilation of a
+    program.
   - `KipperError.isWarning`, which if true defines the error as non-fatal warning that does not prevent the 
-		compilation from continuing.
+    compilation from continuing.
   - `KipperProgramContext.warnings`, which contains all warnings that have been found in the program.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `!` (Logical NOT Operator)
   - `+` (Plus Operator)
   - `-` (Minus Operator)
-- Compiler Warnings by allowing `KipperError` instances to be warnings if `isWarning` is set to true and 
+- Compiler Warnings by allowing `KipperError` instances to be warnings if `isWarning` is set to true and
   implementing AST-based checks for warnings using the new function `CompilableASTNode.checkForWarnings()`.
   ([#199](https://github.com/Luna-Klatzer/Kipper/issues/199))
 - Support for hex, binary and octal numbers. (Only minor changes, as previously the syntax for binary, octal and
@@ -93,10 +93,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `CompilableASTNode.checkForWarnings()`, which checks for warnings in an AST Node.
   - `KipperTypeChecker.validRelationalExpression`, which ensures a `RelationalExpression` is semantically valid.
   - `KipperTypeChecker.validUnaryExpression`, which ensures a `UnaryExpression` is semantically valid.
-- New fields:
+- New fields/properties:
   - `KipperCompileResult.warnings`, which contains a list of all warnings that were found during the compilation of a
     program.
-  - `KipperError.isWarning`, which if true defines the error as non-fatal warning that does not prevent the 
+  - `KipperError.isWarning`, which if true defines the error as non-fatal warning that does not prevent the
     compilation from continuing.
   - `KipperProgramContext.warnings`, which contains all warnings that have been found in the program.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `CompilableASTNode.checkForWarnings()`, which checks for warnings in an AST Node.
   - `KipperTypeChecker.validRelationalExpression`, which ensures a `RelationalExpression` is semantically valid.
   - `KipperTypeChecker.validUnaryExpression`, which ensures a `UnaryExpression` is semantically valid.
-- New fields:
+- New fields/properties:
   - `KipperCompileResult.warnings`, which contains a list of all warnings that were found during the compilation of a
     program.
   - `KipperError.isWarning`, which if true defines the error as non-fatal warning that does not prevent the 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `!` (Logical NOT Operator)
   - `+` (Plus Operator)
   - `-` (Minus Operator)
-- Compiler Warnings by allowing `KipperError` instances to be warnings if `isWarning` is set to true and
-  implementing AST-based checks for warnings using the new function `CompilableASTNode.checkForWarnings()`.
+- Partial support for compiler warnings by allowing `KipperError` instances to be warnings if `isWarning` is set to
+  true and implementing AST-based checks for warnings using the new function `CompilableASTNode.checkForWarnings()`.
+  ([#199](https://github.com/Luna-Klatzer/Kipper/issues/199))
+- New flag `-w/--warnings` in the commands `compile`, `run` and `analyse`, which enables logger warnings.
   ([#199](https://github.com/Luna-Klatzer/Kipper/issues/199))
 - Support for hex, binary and octal numbers. (Only minor changes, as previously the syntax for binary, octal and
   hex numbers was already added.) ([#184](https://github.com/Luna-Klatzer/Kipper/issues/184))
@@ -91,14 +93,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `TracebackMetadata`, which defines the required data for a full traceback in a `KipperError`.
 - New functions:
   - `CompilableASTNode.checkForWarnings()`, which checks for warnings in an AST Node.
-  - `KipperTypeChecker.validRelationalExpression`, which ensures a `RelationalExpression` is semantically valid.
-  - `KipperTypeChecker.validUnaryExpression`, which ensures a `UnaryExpression` is semantically valid.
+  - `KipperTypeChecker.validRelationalExpression()`, which ensures a `RelationalExpression` is semantically valid.
+  - `KipperTypeChecker.validUnaryExpression()`, which ensures a `UnaryExpression` is semantically valid.
+  - `KipperProgramContext.addWarning()`, which adds a warning to the program context.
+  - `KipperLogger.reportWarning()`, which reports a warning with its traceback to the consoles.
 - New fields/properties:
+  - `CompileConfig.warnings`, which if set to true enables warnings and stores them in `KipperCompileResult.warnings`.
+  - `EvaluatedCompileOptions.warnings`, which if set to true enables warnings and stores them in
+    `KipperCompileResult.warnings`.
   - `KipperCompileResult.warnings`, which contains a list of all warnings that were found during the compilation of a
     program.
   - `KipperError.isWarning`, which if true defines the error as non-fatal warning that does not prevent the
     compilation from continuing.
   - `KipperProgramContext.warnings`, which contains all warnings that have been found in the program.
+  - `KipperLogger.reportWarnings`, which if set to true will report warnings to the console.
+  - `KipperProgramContext.reportWarnings`, which if set to true will run warning checks on the AST nodes of the program.
 
 ### Changed
 
@@ -111,6 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ParserASTNode.getTokenChildren()` to `getAntlrRuleChildren()`.
   - `Scope.localVariables` to `variables`.
   - `Scope.localFunctions` to `functions`.
+- Updated logging messages and shortened them to be more concise.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `!` (Logical NOT Operator)
   - `+` (Plus Operator)
   - `-` (Minus Operator)
+- Compiler Warnings by allowing `KipperError` instances to be warnings if `isWarning` is set to true and 
+  implementing AST-based checks for warnings using the new function `CompilableASTNode.checkForWarnings()`.
+  ([#199](https://github.com/Luna-Klatzer/Kipper/issues/199))
 - Support for hex, binary and octal numbers. (Only minor changes, as previously the syntax for binary, octal and
   hex numbers was already added.) ([#184](https://github.com/Luna-Klatzer/Kipper/issues/184))
 - New errors:
@@ -85,9 +88,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ComparativeExpressionSemantics`, which defines the semantic data of a comparative expression.
   - `LogicalExpressionSemantics`, which defines the semantics of a logical expression.
   - `UnaryExpressionSemantics`, which defines the base semantics for every unary expression.
+  - `TracebackMetadata`, which defines the required data for a full traceback in a `KipperError`.
 - New functions:
-  - `KipperTypeChecker.validRelationalExpression`.
-  - `KipperTypeChecker.validUnaryExpression`.
+  - `CompilableASTNode.checkForWarnings()`, which checks for warnings in an AST Node.
+  - `KipperTypeChecker.validRelationalExpression`, which ensures a `RelationalExpression` is semantically valid.
+  - `KipperTypeChecker.validUnaryExpression`, which ensures a `UnaryExpression` is semantically valid.
+- New fields:
+  - `KipperError.isWarning`, which if true defines the error as non-fatal warning that does not prevent the 
+		compilation from continuing.
+  - `KipperProgramContext.warnings`, which contains all warnings that have been found in the program.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # The Kipper programming language - `kipper`
 
 [![Version](https://img.shields.io/npm/v/kipper?label=release&color=%23cd2620&logo=npm)](https://npmjs.org/package/kipper)
-![](https://img.shields.io/badge/Coverage-83%25-83A603.svg?style=flat&logoColor=white&color=blue&prefix=$coverage$)
+![](https://img.shields.io/badge/Coverage-81%25-83A603.svg?style=flat&logoColor=white&color=blue&prefix=$coverage$)
 [![Issues](https://img.shields.io/github/issues/Luna-Klatzer/Kipper)](https://github.com/Luna-Klatzer/Kipper/issues)
 [![License](https://img.shields.io/github/license/Luna-Klatzer/Kipper?color=cyan)](https://github.com/Luna-Klatzer/Kipper/blob/main/LICENSE)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FLuna-Klatzer%2FKipper.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FLuna-Klatzer%2FKipper?ref=badge_shield)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # The Kipper programming language - `kipper`
 
 [![Version](https://img.shields.io/npm/v/kipper?label=release&color=%23cd2620&logo=npm)](https://npmjs.org/package/kipper)
-![](https://img.shields.io/badge/Coverage-81%25-83A603.svg?style=flat&logoColor=white&color=blue&prefix=$coverage$)
+![](https://img.shields.io/badge/Coverage-82%25-83A603.svg?style=flat&logoColor=white&color=blue&prefix=$coverage$)
 [![Issues](https://img.shields.io/github/issues/Luna-Klatzer/Kipper)](https://github.com/Luna-Klatzer/Kipper/issues)
 [![License](https://img.shields.io/github/license/Luna-Klatzer/Kipper?color=cyan)](https://github.com/Luna-Klatzer/Kipper/blob/main/LICENSE)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FLuna-Klatzer%2FKipper.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FLuna-Klatzer%2FKipper?ref=badge_shield)

--- a/kipper/cli/README.md
+++ b/kipper/cli/README.md
@@ -16,10 +16,11 @@ straightforward, simple, secure and type-safe coding similar to TypeScript, Rust
 [![oclif](https://img.shields.io/badge/cli-oclif-brightgreen.svg)](https://oclif.io)
 
 <!-- toc -->
-* [Kipper CLI - `@kipper/cli`](#kipper-cli---kippercli)
-* [Kipper Docs](#kipper-docs)
-* [Usage](#usage)
-* [Commands](#commands)
+
+- [Kipper CLI - `@kipper/cli`](#kipper-cli---kippercli)
+- [Kipper Docs](#kipper-docs)
+- [Usage](#usage)
+- [Commands](#commands)
 <!-- tocstop -->
 
 # Kipper Docs
@@ -29,6 +30,7 @@ Proper documentation for the Kipper language is available [here](https://wmc-ahi
 # Usage
 
 <!-- usage -->
+
 ```sh-session
 $ npm install -g @kipper/cli
 $ kipper COMMAND
@@ -40,17 +42,19 @@ USAGE
   $ kipper COMMAND
 ...
 ```
+
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-* [`kipper analyse [FILE]`](#kipper-analyse-file)
-* [`kipper compile [FILE]`](#kipper-compile-file)
-* [`kipper help [COMMAND]`](#kipper-help-command)
-* [`kipper run [FILE]`](#kipper-run-file)
-* [`kipper update [CHANNEL]`](#kipper-update-channel)
-* [`kipper version`](#kipper-version)
+
+- [`kipper analyse [FILE]`](#kipper-analyse-file)
+- [`kipper compile [FILE]`](#kipper-compile-file)
+- [`kipper help [COMMAND]`](#kipper-help-command)
+- [`kipper run [FILE]`](#kipper-run-file)
+- [`kipper update [CHANNEL]`](#kipper-update-channel)
+- [`kipper version`](#kipper-version)
 
 ## `kipper analyse [FILE]`
 
@@ -180,6 +184,7 @@ USAGE
 ```
 
 _See code: [src/commands/version.ts](https://github.com/Luna-Klatzer/Kipper/blob/v0.9.0-beta.0/kipper/cli/src/commands/version.ts)_
+
 <!-- commandsstop -->
 
 ## Copyright and License

--- a/kipper/cli/src/commands/analyse.ts
+++ b/kipper/cli/src/commands/analyse.ts
@@ -5,7 +5,7 @@
  * @since 0.0.5
  */
 import { Command, flags } from "@oclif/command";
-import { KipperCompiler, KipperError, KipperParseStream } from "@kipper/core";
+import { KipperCompiler, KipperError, KipperParseStream, LogLevel } from "@kipper/core";
 import { KipperLogger } from "@kipper/core";
 import { KipperEncoding, KipperEncodings, KipperParseFile, verifyEncoding } from "../file-stream";
 import { defaultCliEmitHandler, defaultCliLogger } from "../logger";
@@ -37,11 +37,17 @@ export default class Analyse extends Command {
 			char: "s",
 			description: "The content of a Kipper file that can be passed as a replacement for the 'file' parameter.",
 		}),
+		warnings: flags.boolean({
+			char: "w",
+			default: true,
+			description: "Show warnings that were emitted during the analysis.",
+			allowNo: true,
+		}),
 	};
 
 	async run() {
 		const { args, flags } = this.parse(Analyse);
-		const logger = new KipperLogger(defaultCliEmitHandler);
+		const logger = new KipperLogger(defaultCliEmitHandler, LogLevel.INFO, flags["warnings"]);
 		const compiler = new KipperCompiler(logger);
 
 		// Fetch the file

--- a/kipper/cli/src/commands/compile.ts
+++ b/kipper/cli/src/commands/compile.ts
@@ -11,6 +11,7 @@ import {
 	KipperCompileResult,
 	KipperError,
 	KipperParseStream,
+	LogLevel,
 } from "@kipper/core";
 import { KipperLogger } from "@kipper/core";
 import { defaultCliEmitHandler, defaultCliLogger } from "../logger";
@@ -66,11 +67,17 @@ export default class Compile extends Command {
 				"reducing the size of the output.",
 			allowNo: true,
 		}),
+		warnings: flags.boolean({
+			char: "w",
+			default: true,
+			description: "Show warnings that were emitted during the compilation.",
+			allowNo: true,
+		}),
 	};
 
 	async run() {
 		const { args, flags } = this.parse(Compile);
-		const logger = new KipperLogger(defaultCliEmitHandler);
+		const logger = new KipperLogger(defaultCliEmitHandler, LogLevel.INFO, flags["warnings"]);
 		const compiler = new KipperCompiler(logger);
 
 		// Fetch the file

--- a/kipper/cli/src/commands/run.ts
+++ b/kipper/cli/src/commands/run.ts
@@ -11,13 +11,13 @@ import {
 	KipperCompileResult,
 	KipperError,
 	KipperParseStream,
+	LogLevel,
 } from "@kipper/core";
 import { KipperLogger } from "@kipper/core";
 import { defaultCliEmitHandler, defaultCliLogger } from "../logger";
 import { KipperEncoding, KipperEncodings, KipperParseFile, verifyEncoding } from "../file-stream";
 import { writeCompilationResult } from "../compile";
 import { spawn } from "child_process";
-import { LogLevel } from "@kipper/core";
 import { KipperInvalidInputError } from "../errors";
 import * as ts from "typescript";
 import { IFlag } from "@oclif/command/lib/flags";
@@ -87,11 +87,17 @@ export default class Run extends Command {
 				"reducing the size of the output.",
 			allowNo: true,
 		}),
+		warnings: flags.boolean({
+			char: "w",
+			default: false, // Log warnings ONLY if the user intends to do so
+			description: "Show warnings that were emitted during the compilation.",
+			allowNo: true,
+		}),
 	};
 
 	async run() {
 		const { args, flags } = this.parse(Run);
-		const logger = new KipperLogger(defaultCliEmitHandler, LogLevel.ERROR);
+		const logger = new KipperLogger(defaultCliEmitHandler, LogLevel.ERROR, flags["warnings"]);
 		const compiler = new KipperCompiler(logger);
 
 		// Fetch the file

--- a/kipper/cli/src/errors.ts
+++ b/kipper/cli/src/errors.ts
@@ -13,8 +13,8 @@ import { ParserRuleContext } from "antlr4ts";
  * @since 0.1.0
  */
 export abstract class KipperCLIError extends KipperError {
-	protected constructor(msg: string, token?: ParserRuleContext) {
-		super(msg, token);
+	protected constructor(msg: string, isWarning?: boolean, token?: ParserRuleContext) {
+		super(msg, isWarning ?? false, token);
 	}
 }
 

--- a/kipper/core/src/compiler/compiler.ts
+++ b/kipper/core/src/compiler/compiler.ts
@@ -25,11 +25,15 @@ export interface CompileConfig {
 	/**
 	 * The built-in functions that will be available in a Kipper program. This option overwrites the default built-ins,
 	 * if you wish to only add new built-in functions write to {@link extendBuiltIns}.
+	 *
+	 * All built-in functions defined here must be implemented by the {@link target.builtInGenerator}.
 	 */
 	builtIns?: Array<BuiltInFunction>;
 	/**
 	 * Extends the {@link builtIns} with the specified items. If {@link builtIns} is undefined, then it will simply extend
 	 * the default array.
+	 *
+	 * All built-in functions defined here must be implemented by the {@link target.builtInGenerator}.
 	 */
 	extendBuiltIns?: Array<BuiltInFunction>;
 	/**
@@ -47,6 +51,12 @@ export interface CompileConfig {
 	 * @since 0.8.0
 	 */
 	optimisationOptions?: OptimisationOptions;
+	/**
+	 * If set to true, the compiler will check for warnings and add them to {@link KipperProgramContext.warnings} and
+	 * {@link KipperCompileResult.warnings}.
+	 * @since 0.9.0
+	 */
+	warnings?: boolean;
 }
 
 /**
@@ -74,25 +84,48 @@ export class EvaluatedCompileOptions implements CompileConfig {
 		fileName: "anonymous-script", // Default name if no name is specified.
 		target: new TypeScriptTarget(), // Default target is TypeScript.
 		optimisationOptions: defaultOptimisationOptions,
+		warnings: true, // Always generate warnings by default.
 	};
 
-	/**, // Include all built-ins to allow the user to modify the functions in the target language.
+	/**
 	 * The built-in functions that will be available in a Kipper program.
 	 *
-	 * This will be extended by {@link extendBuiltIns}.
+	 * This will be extended by {@link extendBuiltIns}. All built-in functions defined here must be implemented by the
+	 * {@link target.builtInGenerator}.
 	 */
 	public readonly builtIns: Array<BuiltInFunction>;
 
 	/**
 	 * Extensions to the global built-in functions that should not replace the primary {@link builtIns}.
+	 *
+	 * All built-in functions defined here must be implemented by the {@link target.builtInGenerator}.
 	 */
 	public readonly extendBuiltIns: Array<BuiltInFunction>;
 
+	/**
+	 * The filename that should be used to represent the program.
+	 * @since 0.2.0
+	 */
 	public readonly fileName: string;
 
+	/**
+	 * The translation languages for the compilation.
+	 * @since 0.5.0
+	 */
 	public readonly target: KipperCompileTarget;
 
+	/**
+	 * Options for the {@link KipperOptimiser}.
+	 * @since 0.8.0
+	 */
 	public readonly optimisationOptions: OptimisationOptions;
+
+	/**
+	 * If set to true, the compiler will check for warnings and add them to {@link KipperProgramContext.warnings} and
+	 * {@link KipperCompileResult.warnings}.
+	 * @since 0.9.0
+	 */
+	public readonly warnings: boolean;
 
 	constructor(options: CompileConfig) {
 		this.userOptions = options;
@@ -103,6 +136,7 @@ export class EvaluatedCompileOptions implements CompileConfig {
 		this.fileName = options.fileName ?? EvaluatedCompileOptions.defaults.fileName;
 		this.target = options.target ?? EvaluatedCompileOptions.defaults.target;
 		this.optimisationOptions = options.optimisationOptions ?? EvaluatedCompileOptions.defaults.optimisationOptions;
+		this.warnings = options.warnings ?? EvaluatedCompileOptions.defaults.warnings;
 	}
 }
 
@@ -246,7 +280,7 @@ export class KipperCompiler {
 		// Parse the input, where `compilationUnit` is whatever entry point you defined
 		return (() => {
 			let result = parser.compilationUnit();
-			this._logger.debug(`Finished generation of parse tree for file '${parseStream.name}'.`);
+			this._logger.debug(`Finished generation of parse tree.`);
 			return new KipperProgramContext(
 				parseStream,
 				result,
@@ -296,11 +330,7 @@ export class KipperCompiler {
 			if (globals.length > 0) {
 				fileCtx.registerBuiltIns(globals);
 			}
-			this.logger.debug(
-				`Registered ${globals.length} global function${globals.length === 1 ? "" : "s"} for the program '${
-					inStream.name
-				}'.`,
-			);
+			this.logger.debug(`Registered ${globals.length} global function${globals.length === 1 ? "" : "s"}.`);
 
 			// Start compilation of the Kipper program
 			const code = await fileCtx.compileProgram(config.optimisationOptions);

--- a/kipper/core/src/compiler/compiler.ts
+++ b/kipper/core/src/compiler/compiler.ts
@@ -14,6 +14,7 @@ import { KipperCompileTarget } from "./compile-target";
 import { TypeScriptTarget } from "../targets/typescript";
 import type { TranslatedCodeLine } from "./semantics";
 import { defaultOptimisationOptions, OptimisationOptions } from "./optimiser";
+import type { KipperError } from "../errors";
 
 /**
  * Compilation Configuration for a Kipper program. This interface will be wrapped using {@link EvaluatedCompileOptions}
@@ -141,6 +142,17 @@ export class KipperCompileResult {
 	 */
 	public get result(): Array<Array<string>> {
 		return this._result;
+	}
+
+	/**
+	 * The list of warnings that were raised during the compilation process.
+	 *
+	 * Warnings are non-fatal errors, which are raised when the compiler encounters a situation that it considers to
+	 * be problematic, but which do not prevent the program from being compiled.
+	 * @since 0.9.0
+	 */
+	public get warnings(): Array<KipperError> {
+		return this.programCtx.warnings;
 	}
 
 	/**

--- a/kipper/core/src/compiler/parser/compilable-ast-node.ts
+++ b/kipper/core/src/compiler/parser/compilable-ast-node.ts
@@ -204,6 +204,11 @@ export abstract class CompilableASTNode<Semantics extends SemanticData> extends 
 		await this.primarySemanticAnalysis();
 		await this.semanticTypeChecking();
 		await this.targetSemanticAnalysis(this);
+
+		// Check for warnings after the semantic analysis has been completed
+		if (this.programCtx.reportWarnings) {
+			await this.checkForWarnings();
+		}
 	}
 
 	/**

--- a/kipper/core/src/compiler/parser/compilable-ast-node.ts
+++ b/kipper/core/src/compiler/parser/compilable-ast-node.ts
@@ -207,8 +207,8 @@ export abstract class CompilableASTNode<Semantics extends SemanticData> extends 
 	}
 
 	/**
-	 * Semantically analyses the code inside this AST node. This will log all warnings using {@link programCtx.logger}
-	 * and throw errors if encountered.
+	 * Semantically analyses the code inside this AST node.
+	 * @throws KipperError if the code is not valid.
 	 * @since 0.8.0
 	 */
 	public abstract primarySemanticAnalysis(): Promise<void>;
@@ -219,6 +219,14 @@ export abstract class CompilableASTNode<Semantics extends SemanticData> extends 
 	 * @since 0.8.0
 	 */
 	public abstract semanticTypeChecking(): Promise<void>;
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public abstract checkForWarnings(): Promise<void>;
 
 	/**
 	 * Semantic analyser function that is specific for the {@link KipperCompileTarget target}.

--- a/kipper/core/src/compiler/program-ctx.ts
+++ b/kipper/core/src/compiler/program-ctx.ts
@@ -27,13 +27,9 @@ export class KipperProgramContext {
 
 	private readonly _antlrParseTree: CompilationUnitContext;
 
-	private _abstractSyntaxTree: RootASTNode | undefined;
+	private _warnings: Array<KipperError>;
 
-	/**
-	 * The global scope of this program, containing all variable and function definitions
-	 * @private
-	 */
-	private readonly _globalScope: GlobalScope;
+	private _abstractSyntaxTree: RootASTNode | undefined;
 
 	/**
 	 * The field compiledCode that will store the cached code, once 'compileProgram' has been called. This is
@@ -41,6 +37,34 @@ export class KipperProgramContext {
 	 * @private
 	 */
 	private _compiledCode: Array<Array<string>> | undefined;
+
+	/**
+	 * A list of all references to built-in functions. This is used to determine which built-in functions are
+	 * used and which aren't.
+	 *
+	 * This is primarily used for optimisations in {@link KipperOptimiser}, by applying tree-shaking to unused built-in
+	 * functions, so they will not be generated.
+	 * @private
+	 * @since 0.8.0
+	 */
+	private readonly _builtInReferences: Array<Reference<BuiltInFunction>>;
+
+	/**
+	 * A list of all references to internal functions. This is used to determine which internal functions are
+	 * used and which aren't.
+	 *
+	 * This is primarily used for optimisations in {@link KipperOptimiser}, by applying tree-shaking to unused internal
+	 * functions, so they will not be generated.
+	 * @private
+	 * @since 0.8.0
+	 */
+	private readonly _internalReferences: Array<Reference<InternalFunction>>;
+
+	/**
+	 * The global scope of this program, containing all variable and function definitions
+	 * @private
+	 */
+	private readonly _globalScope: GlobalScope;
 
 	/**
 	 * Represents the compilation translation target for the program. This contains the:
@@ -107,28 +131,6 @@ export class KipperProgramContext {
 	 */
 	public builtIns: Array<BuiltInFunction>;
 
-	/**
-	 * A list of all references to built-in functions. This is used to determine which built-in functions are
-	 * used and which aren't.
-	 *
-	 * This is primarily used for optimisations in {@link KipperOptimiser}, by applying tree-shaking to unused built-in
-	 * functions, so they will not be generated.
-	 * @private
-	 * @since 0.8.0
-	 */
-	private readonly _builtInReferences: Array<Reference<BuiltInFunction>>;
-
-	/**
-	 * A list of all references to internal functions. This is used to determine which internal functions are
-	 * used and which aren't.
-	 *
-	 * This is primarily used for optimisations in {@link KipperOptimiser}, by applying tree-shaking to unused internal
-	 * functions, so they will not be generated.
-	 * @private
-	 * @since 0.8.0
-	 */
-	private readonly _internalReferences: Array<Reference<InternalFunction>>;
-
 	constructor(
 		stream: KipperParseStream,
 		parseTreeEntry: CompilationUnitContext,
@@ -156,6 +158,7 @@ export class KipperProgramContext {
 		this._abstractSyntaxTree = undefined;
 		this._builtInReferences = [];
 		this._internalReferences = [];
+		this._warnings = [];
 	}
 
 	/**
@@ -278,6 +281,27 @@ export class KipperProgramContext {
 	 */
 	public get abstractSyntaxTree(): RootASTNode | undefined {
 		return this._abstractSyntaxTree;
+	}
+
+	/**
+	 * The list of warnings that were raised during the compilation process.
+	 *
+	 * Warnings are non-fatal errors, which are raised when the compiler encounters a situation that it considers to be
+	 * problematic, but which it cannot fix.
+	 * @since 0.9.0
+	 */
+	public get warnings(): Array<KipperError> {
+		return this._warnings;
+	}
+
+	/**
+	 * Adds a new warning to the list of warnings for this file.
+	 * @param warning The warning to add.
+	 * @private
+	 * @since 0.9.0
+	 */
+	private addWarning(warning: KipperError): void {
+		this.warnings.push(warning);
 	}
 
 	/**

--- a/kipper/core/src/compiler/program-ctx.ts
+++ b/kipper/core/src/compiler/program-ctx.ts
@@ -287,7 +287,7 @@ export class KipperProgramContext {
 	 * The list of warnings that were raised during the compilation process.
 	 *
 	 * Warnings are non-fatal errors, which are raised when the compiler encounters a situation that it considers to be
-	 * problematic, but which it cannot fix.
+	 * problematic, which do not prevent the program from being compiled.
 	 * @since 0.9.0
 	 */
 	public get warnings(): Array<KipperError> {

--- a/kipper/core/src/compiler/program-ctx.ts
+++ b/kipper/core/src/compiler/program-ctx.ts
@@ -151,7 +151,7 @@ export class KipperProgramContext {
 		semanticChecker?: KipperSemanticChecker,
 		typeChecker?: KipperTypeChecker,
 		optimiser?: KipperOptimiser,
-		reportWarnings: boolean = true
+		reportWarnings: boolean = true,
 	) {
 		this.logger = logger;
 		this.target = target;

--- a/kipper/core/src/compiler/semantics/language/definitions.ts
+++ b/kipper/core/src/compiler/semantics/language/definitions.ts
@@ -95,10 +95,15 @@ export abstract class Declaration<Semantics extends DeclarationSemantics> extend
 		return this._antlrRuleCtx;
 	}
 
+	/**
+	 * Generates the typescript code for this item, and all children (if they exist).
+	 * @since 0.8.0
+	 */
 	public async translateCtxAndChildren(): Promise<Array<TranslatedCodeLine>> {
 		return await this.targetCodeGenerator(this);
 	}
 
+	public abstract targetSemanticAnalysis: TargetASTNodeSemanticAnalyser<any>;
 	public abstract targetCodeGenerator: TargetASTNodeCodeGenerator<any, Array<TranslatedCodeLine>>;
 }
 
@@ -134,6 +139,16 @@ export class ParameterDeclaration extends Declaration<ParameterDeclarationSemant
 	constructor(antlrRuleCtx: ParameterDeclarationContext, parent: compilableNodeParent) {
 		super(antlrRuleCtx, parent);
 		this._antlrRuleCtx = antlrRuleCtx;
+	}
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
 	}
 
 	/**
@@ -212,6 +227,16 @@ export class FunctionDeclaration extends Declaration<FunctionDeclarationSemantic
 	constructor(antlrRuleCtx: FunctionDeclarationContext, parent: compilableNodeParent) {
 		super(antlrRuleCtx, parent);
 		this._antlrRuleCtx = antlrRuleCtx;
+	}
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
 	}
 
 	/**
@@ -334,6 +359,16 @@ export class VariableDeclaration extends Declaration<VariableDeclarationSemantic
 		super(antlrRuleCtx, parent);
 		this._antlrRuleCtx = antlrRuleCtx;
 		this._children = [];
+	}
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
 	}
 
 	/**

--- a/kipper/core/src/compiler/semantics/language/expressions.ts
+++ b/kipper/core/src/compiler/semantics/language/expressions.ts
@@ -227,6 +227,16 @@ export abstract class Expression<Semantics extends ExpressionSemantics> extends 
 	}
 
 	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
+	}
+
+	/**
 	 * The antlr context containing the antlr4 metadata for this expression.
 	 */
 	public override get antlrRuleCtx(): antlrExpressionCtxType {
@@ -333,6 +343,16 @@ export class NumberPrimaryExpression extends ConstantExpression<NumberPrimaryExp
 	}
 
 	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
+	}
+
+	/**
 	 * The antlr context containing the antlr4 metadata for this expression.
 	 */
 	public override get antlrRuleCtx(): NumberPrimaryExpressionContext {
@@ -398,6 +418,16 @@ export class CharacterPrimaryExpression extends ConstantExpression<CharacterPrim
 	public async semanticTypeChecking(): Promise<void> {
 		// Constants will never get type checking
 		return Promise.resolve(undefined);
+	}
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
 	}
 
 	/**
@@ -468,6 +498,16 @@ export class ListPrimaryExpression extends ConstantExpression<ListPrimaryExpress
 	}
 
 	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
+	}
+
+	/**
 	 * The antlr context containing the antlr4 metadata for this expression.
 	 */
 	public override get antlrRuleCtx(): ListPrimaryExpressionContext {
@@ -533,6 +573,16 @@ export class StringPrimaryExpression extends ConstantExpression<StringPrimaryExp
 	public async semanticTypeChecking(): Promise<void> {
 		// Constants will never get type checking
 		return Promise.resolve(undefined);
+	}
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
 	}
 
 	/**
@@ -611,6 +661,16 @@ export class BoolPrimaryExpression extends Expression<BoolPrimaryExpressionSeman
 	}
 
 	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
+	}
+
+	/**
 	 * The antlr context containing the antlr4 metadata for this expression.
 	 */
 	public override get antlrRuleCtx(): BoolPrimaryExpressionContext {
@@ -677,6 +737,16 @@ export class FStringPrimaryExpression extends Expression<FStringPrimaryExpressio
 	 * @since 0.7.0
 	 */
 	public async semanticTypeChecking(): Promise<void> {
+		// TODO!
+	}
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
 		// TODO!
 	}
 
@@ -751,6 +821,16 @@ export class IdentifierPrimaryExpression extends Expression<IdentifierPrimaryExp
 	public async semanticTypeChecking(): Promise<void> {
 		// Constants will never get type checking
 		return Promise.resolve(undefined);
+	}
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
 	}
 
 	/**
@@ -840,6 +920,16 @@ export class IdentifierTypeSpecifierExpression extends TypeSpecifierExpression<I
 	}
 
 	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
+	}
+
+	/**
 	 * The antlr context containing the antlr4 metadata for this expression.
 	 */
 	public override get antlrRuleCtx(): IdentifierTypeSpecifierContext {
@@ -910,6 +1000,16 @@ export class GenericTypeSpecifierExpression extends TypeSpecifierExpression<Gene
 	}
 
 	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
+	}
+
+	/**
 	 * The antlr context containing the antlr4 metadata for this expression.
 	 */
 	public override get antlrRuleCtx(): GenericTypeSpecifierContext {
@@ -970,6 +1070,16 @@ export class TypeofTypeSpecifierExpression extends TypeSpecifierExpression<Typeo
 		const semanticData = this.getSemanticData();
 
 		this.programCtx.typeCheck(this).typeExists(semanticData.type);
+	}
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
 	}
 
 	/**
@@ -1040,6 +1150,16 @@ export class TangledPrimaryExpression extends Expression<TangledPrimaryExpressio
 	}
 
 	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
+	}
+
+	/**
 	 * The antlr context containing the antlr4 metadata for this expression.
 	 */
 	public override get antlrRuleCtx(): TangledPrimaryExpressionContext {
@@ -1105,6 +1225,16 @@ export class IncrementOrDecrementExpression extends Expression<IncrementOrDecrem
 	}
 
 	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
+	}
+
+	/**
 	 * The antlr context containing the antlr4 metadata for this expression.
 	 */
 	public override get antlrRuleCtx(): IncrementOrDecrementPostfixExpressionContext {
@@ -1163,6 +1293,16 @@ export class ArraySpecifierExpression extends Expression<ArraySpecifierExpressio
 	 * @since 0.7.0
 	 */
 	public async semanticTypeChecking(): Promise<void> {
+		// TODO!
+	}
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
 		// TODO!
 	}
 
@@ -1265,6 +1405,16 @@ export class FunctionCallPostfixExpression extends Expression<FunctionCallPostfi
 	}
 
 	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
+	}
+
+	/**
 	 * The antlr context containing the antlr4 metadata for this expression.
 	 */
 	public override get antlrRuleCtx(): FunctionCallPostfixExpressionContext {
@@ -1358,6 +1508,16 @@ export class IncrementOrDecrementUnaryExpression extends UnaryExpression<Increme
 	 * @since 0.7.0
 	 */
 	public async semanticTypeChecking(): Promise<void> {
+		// TODO!
+	}
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
 		// TODO!
 	}
 
@@ -1456,6 +1616,16 @@ export class OperatorModifiedUnaryExpression extends UnaryExpression<OperatorMod
 	}
 
 	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
+	}
+
+	/**
 	 * The antlr context containing the antlr4 metadata for this expression.
 	 */
 	public override get antlrRuleCtx(): OperatorModifiedUnaryExpressionContext {
@@ -1544,6 +1714,16 @@ export class CastOrConvertExpression extends Expression<CastOrConvertExpressionS
 		const semanticData = this.getSemanticData();
 
 		this.programCtx.semanticCheck(this).validConversion(semanticData.exp, semanticData.type);
+	}
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
 	}
 
 	/**
@@ -1676,6 +1856,16 @@ export class MultiplicativeExpression extends Expression<MultiplicativeExpressio
 	}
 
 	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
+	}
+
+	/**
 	 * The antlr context containing the antlr4 metadata for this expression.
 	 */
 	public override get antlrRuleCtx(): MultiplicativeExpressionContext {
@@ -1791,6 +1981,16 @@ export class AdditiveExpression extends Expression<AdditiveExpressionSemantics> 
 		this.programCtx
 			.typeCheck(this)
 			.validArithmeticExpression(semanticData.exp1, semanticData.exp2, semanticData.operator);
+	}
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
 	}
 
 	/**
@@ -1926,6 +2126,16 @@ export class RelationalExpression extends ComparativeExpression<RelationalExpres
 	}
 
 	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
+	}
+
+	/**
 	 * The antlr context containing the antlr4 metadata for this expression.
 	 */
 	public override get antlrRuleCtx(): RelationalExpressionContext {
@@ -2020,6 +2230,16 @@ export class EqualityExpression extends ComparativeExpression<EqualityExpression
 	public async semanticTypeChecking(): Promise<void> {
 		// No type checking needed, since every type can be compared against every other type
 		return Promise.resolve(undefined);
+	}
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
 	}
 
 	/**
@@ -2143,6 +2363,16 @@ export class LogicalAndExpression extends LogicalExpression<LogicalAndExpression
 	}
 
 	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
+	}
+
+	/**
 	 * The antlr context containing the antlr4 metadata for this expression.
 	 */
 	public override get antlrRuleCtx(): LogicalAndExpressionContext {
@@ -2233,6 +2463,16 @@ export class LogicalOrExpression extends LogicalExpression<LogicalOrExpressionSe
 	}
 
 	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
+	}
+
+	/**
 	 * The antlr context containing the antlr4 metadata for this expression.
 	 */
 	public override get antlrRuleCtx(): LogicalOrExpressionContext {
@@ -2293,6 +2533,16 @@ export class ConditionalExpression extends Expression<ConditionalExpressionSeman
 	 * @since 0.7.0
 	 */
 	public async semanticTypeChecking(): Promise<void> {
+		// TODO!
+	}
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
 		// TODO!
 	}
 
@@ -2385,6 +2635,16 @@ export class AssignmentExpression extends Expression<AssignmentExpressionSemanti
 		const semanticData = this.getSemanticData();
 
 		this.programCtx.typeCheck(this).validAssignment(semanticData.identifier, semanticData.value);
+	}
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
 	}
 
 	/**

--- a/kipper/core/src/compiler/semantics/language/statements.ts
+++ b/kipper/core/src/compiler/semantics/language/statements.ts
@@ -170,6 +170,16 @@ export class CompoundStatement extends Statement<NoSemantics> {
 		return Promise.resolve(undefined);
 	}
 
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
+	}
+
 	targetSemanticAnalysis: TargetASTNodeSemanticAnalyser<CompoundStatement> = this.semanticAnalyser.compoundStatement;
 	targetCodeGenerator: TargetASTNodeCodeGenerator<CompoundStatement, Array<TranslatedCodeLine>> =
 		this.codeGenerator.compoundStatement;
@@ -269,6 +279,16 @@ export class IfStatement extends Statement<IfStatementSemantics> {
 		// TODO!
 	}
 
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
+	}
+
 	targetSemanticAnalysis: TargetASTNodeSemanticAnalyser<IfStatement> = this.semanticAnalyser.ifStatement;
 	targetCodeGenerator: TargetASTNodeCodeGenerator<IfStatement, Array<TranslatedCodeLine>> =
 		this.codeGenerator.ifStatement;
@@ -323,6 +343,16 @@ export class SwitchStatement extends Statement<NoSemantics> {
 	 * @since 0.7.0
 	 */
 	public async semanticTypeChecking(): Promise<void> {
+		// TODO!
+	}
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
 		// TODO!
 	}
 
@@ -381,6 +411,16 @@ export class ExpressionStatement extends Statement<NoSemantics> {
 	public semanticTypeChecking(): Promise<void> {
 		// Expression statements will never have type checking
 		return Promise.resolve(undefined);
+	}
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
 	}
 
 	targetSemanticAnalysis: TargetASTNodeSemanticAnalyser<ExpressionStatement> =
@@ -442,6 +482,16 @@ export class IterationStatement extends Statement<NoSemantics> {
 		// TODO!
 	}
 
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
+		// TODO!
+	}
+
 	targetSemanticAnalysis: TargetASTNodeSemanticAnalyser<IterationStatement> = this.semanticAnalyser.iterationStatement;
 	targetCodeGenerator: TargetASTNodeCodeGenerator<IterationStatement, Array<TranslatedCodeLine>> =
 		this.codeGenerator.iterationStatement;
@@ -497,6 +547,16 @@ export class JumpStatement extends Statement<NoSemantics> {
 	 * @since 0.7.0
 	 */
 	public async semanticTypeChecking(): Promise<void> {
+		// TODO!
+	}
+
+	/**
+	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
+	 *
+	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * @since 0.9.0
+	 */
+	public async checkForWarnings(): Promise<void> {
 		// TODO!
 	}
 

--- a/kipper/core/src/logger.ts
+++ b/kipper/core/src/logger.ts
@@ -55,6 +55,13 @@ export function getLogLevelString(level: LogLevel): string {
  */
 export class KipperLogger {
 	/**
+	 * The private field '_emitHandler' that actually stores the variable data,
+	 * which is returned inside the {@link this.emitHandler}.
+	 * @private
+	 */
+	private readonly _emitHandler: (level: LogLevel, msg: string) => void;
+
+	/**
 	 * Available log levels for the {@link KipperLogger}.
 	 * @static
 	 * @public
@@ -69,26 +76,30 @@ export class KipperLogger {
 	public static numLevels: typeof LogLevel = LogLevel;
 
 	/**
-	 * The private field '_emitHandler' that actually stores the variable data,
-	 * which is returned inside the {@link this.emitHandler}.
-	 * @private
+	 * The current log level of the {@link KipperLogger}. Everything with a lower level will be ignored and not logged.
 	 */
-	// eslint-disable-next-line no-unused-vars
-	private readonly _emitHandler: (level: LogLevel, msg: string) => void;
+	public logLevel: LogLevel;
+
+	/**
+	 * If set to true, warnings will be reported. Otherwise, they will be ignored even if the log level is set to
+	 * 'WARN' or lower.
+	 * @since 0.9.0
+	 */
+	public readonly reportWarnings: boolean;
 
 	constructor(
-		// eslint-disable-next-line no-unused-vars
 		emitHandler: (level: LogLevel, msg: string) => void,
-		// eslint-disable-next-line no-unused-vars
-		public logLevel: LogLevel = LogLevel.INFO,
+		logLevel: LogLevel = LogLevel.INFO,
+		reportWarnings: boolean = true,
 	) {
 		this._emitHandler = emitHandler;
+		this.reportWarnings = reportWarnings;
+		this.logLevel = logLevel;
 	}
 
 	/**
 	 * The specific handler that should handle emitted log messages
 	 */
-	// eslint-disable-next-line no-unused-vars
 	public get emitHandler(): (level: LogLevel, msg: string) => void {
 		return this._emitHandler;
 	}
@@ -139,7 +150,9 @@ export class KipperLogger {
 	 * @param msg The content of the logging message.
 	 */
 	public log(level: LogLevel, msg: string): void {
-		if (level < this.logLevel) {
+		// If the level is lower than the current log level or the level is 'WARN' and the warnings are disabled, then
+		// ignore the message.
+		if (level < this.logLevel || (level === LogLevel.WARN && !this.reportWarnings)) {
 			return;
 		}
 
@@ -154,5 +167,14 @@ export class KipperLogger {
 	 */
 	public reportError(level: LogLevel.WARN | LogLevel.ERROR | LogLevel.FATAL, err: KipperError | string) {
 		this.log(level, err instanceof KipperError ? err.getTraceback() : err);
+	}
+
+	/**
+	 * Reports a warning with the passed level.
+	 * @param warn The warning to log.
+	 * @since 0.9.0
+	 */
+	public reportWarning(warn: KipperError | string) {
+		this.reportError(LogLevel.WARN, warn);
 	}
 }

--- a/kipper/core/src/logger.ts
+++ b/kipper/core/src/logger.ts
@@ -1,7 +1,5 @@
 /**
- * The global logger that will handle the output for either the browser or
- * the local command line
- *
+ * The global logger that will handle the log output of the {@link KipperCompiler}.
  * @author Luna Klatzer
  * @copyright 2021-2022 Luna Klatzer
  * @since 0.0.3

--- a/kipper/core/src/utils.ts
+++ b/kipper/core/src/utils.ts
@@ -1,3 +1,9 @@
+/**
+ * Utility functions for the Kipper core package.
+ * @author Luna Klatzer
+ * @copyright 2021-2022 Luna Klatzer
+ * @since 0.9.0
+ */
 import { Interval } from "antlr4ts/misc/Interval";
 import { ParserRuleContext, Token } from "antlr4ts";
 import { ParseTree } from "antlr4ts/tree";

--- a/test/module/core/ast-node.test.ts
+++ b/test/module/core/ast-node.test.ts
@@ -36,6 +36,10 @@ describe("Parse-Tokens", () => {
 			semanticTypeChecking(): Promise<void> {
 				return Promise.resolve(undefined);
 			}
+
+			checkForWarnings(): Promise<void> {
+				return Promise.resolve(undefined);
+			}
 		}
 
 		describe("sourceCode", () => {


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it. Remove any non-checked option -->

- [x] New feature (Non-breaking change which adds functionality)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

<!-- Explain the reason for this pr, changes and solution briefly. -->

Adds partial support for semantic analysis warnings, by implementing the base structure for warnings.

Partially implements #199

## Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

- Added new flag `-w/--warnings/--no-warnings` to the Kipper CLI commands `run`, `compile` and `analyse`.
- Implemented abstract function `CompilableASTNode.checkForWarnings()`, which is implemented by every AST node.
- Added new fields `KipperCompileResult.warnings` and `KipperProgramContext.warnings`, which will store all the warnings
  generated for the file.
- Added new field `KipperLogger.reportWarnings`, which if set to true logs warnings.
- Added new fields `CompileConfig.warnings` and `KipperProgramContext.reportWarnings`, which if set to true enables warning checks using `CompilableASTNode.checkForWarnings()`. (Users should avoid though setting `KipperProgramContext.reportWarnings`).

<!-- Remove example text! -->

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Changelog

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added). -->

### Added

- Partial support for compiler warnings by allowing `KipperError` instances to be warnings if `isWarning` is set to
  true and implementing AST-based checks for warnings using the new function `CompilableASTNode.checkForWarnings()` ([#199](https://github.com/Luna-Klatzer/Kipper/issues/199))
- New flag `-w/--warnings` in the commands `compile`, `run` and `analyse`, which enables logger warnings. ([#199](https://github.com/Luna-Klatzer/Kipper/issues/199))
- New functions:
  - `CompilableASTNode.checkForWarnings()`, which checks for warnings in an AST Node.
  - `KipperProgramContext.addWarning()`, which adds a warning to the program context.
  - `KipperLogger.reportWarning()`, which reports a warning with its traceback to the consoles.
- New fields/properties:
  - `CompileConfig.warnings`, which if set to true enables warnings and stores them in `KipperCompileResult.warnings`.
  - `EvaluatedCompileOptions.warnings`, which if set to true enables warnings and stores them in
    `KipperCompileResult.warnings`.
  - `KipperCompileResult.warnings`, which contains a list of all warnings that were found during the compilation of a
    program.
  - `KipperError.isWarning`, which if true defines the error as non-fatal warning that does not prevent the
    compilation from continuing.
  - `KipperProgramContext.warnings`, which contains all warnings that have been found in the program.
  - `KipperLogger.reportWarnings`, which if set to true will report warnings to the console.
  - `KipperProgramContext.reportWarnings`, which if set to true will run warning checks on the AST nodes of the program.

### Changed

- Updated logging messages and shortened them to be more concise.

<!-- Remove any header with no item. -->

## Linked other issues or PRs

<!-- Include other issues and PRs related to this if any exist. -->

<!-- Use this format: - [ ] #ISSUE_OR_PR -->
- [ ] #199 