### PR TITLE
Fixed bug allowing duplicate parameter name usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - `KipperTypeChecker.referenceCallable()`, which asserts that the specified reference is a callable function.
   - `KipperTypeChecker.validReturnCodePathsInFunctionBody()`, which ensures that all code paths of a non-void
     function return a proper value.
-  - `KipperSemanticChecker.identifierUnused()`, which asserts that the specified identifier is unused.
+  - `KipperSemanticChecker.identifierNotUsed()`, which asserts that the specified identifier is unused in the
+    specified scope and can be used for a new declaration.
   - `KipperSemanticChecker.getReturnStatementParent()`, which evaluates the parent function for a return statement.
   - `KipperSemanticChecker.referenceDefined()`, which asserts that the specified reference is defined and can be used.
   - `KipperSemanticChecker.validFunctionBody()`, which ensures the body of a function is a compound statement.

--- a/kipper/core/src/compiler/analysis/analyser/semantic-checker.ts
+++ b/kipper/core/src/compiler/analysis/analyser/semantic-checker.ts
@@ -12,7 +12,6 @@ import {
 	Scope,
 	ScopeDeclaration,
 	ScopeFunctionDeclaration,
-	ScopeParameterDeclaration,
 	ScopeVariableDeclaration,
 } from "../symbol-table";
 import {
@@ -90,34 +89,13 @@ export class KipperSemanticChecker extends KipperSemanticsAsserter {
 	}
 
 	/**
-	 * Asserts that the passed parameter identifier has not been used yet (both declarations or definitions).
-	 * @param identifier The identifier to check.
-	 * @param scopeCtx The ctx of the local scope, which will be also used for the reference check.
+	 * Recursively ensures that the identifier does not overwrite any declarations in this scope or parent scopes.
+	 * @param identifier The identifier to search for in this scope and its parent scopes.
+	 * @param scopeCtx The context instance of the scope.
 	 * @throws {IdentifierAlreadyUsedByVariableError} If the identifier is already used by a variable.
 	 * @throws {IdentifierAlreadyUsedByFunctionError} If the identifier is already used by a function.
 	 * @throws {IdentifierAlreadyUsedByParameterError} If the identifier is already used by a parameter.
 	 * @throws {BuiltInOverwriteError} If the identifier is already in use by a built-in function.
-	 */
-	public identifierUnused(identifier: string, scopeCtx?: CompoundStatement): void {
-		// Check if the identifier is available and throw an appropriate error if it is not
-		const ref = this.getReference(identifier, scopeCtx);
-		if (ref) {
-			if (ref instanceof ScopeVariableDeclaration) {
-				throw this.assertError(new IdentifierAlreadyUsedByVariableError(identifier));
-			} else if (ref instanceof ScopeFunctionDeclaration) {
-				throw this.assertError(new IdentifierAlreadyUsedByFunctionError(identifier));
-			} else if (ref instanceof ScopeParameterDeclaration) {
-				throw this.assertError(new IdentifierAlreadyUsedByParameterError(identifier));
-			} else {
-				throw this.assertError(new BuiltInOverwriteError(identifier));
-			}
-		}
-	}
-
-	/**
-	 * Recursively ensures that the identifier does not overwrite any declarations in this scope or parent scopes.
-	 * @param identifier The identifier to search for in this scope and its parent scopes.
-	 * @param scopeCtx The context instance of the scope.
 	 * @since 0.10.0
 	 */
 	public identifierNotUsed(identifier: string, scopeCtx: Scope): void {

--- a/kipper/core/src/compiler/analysis/analyser/semantic-checker.ts
+++ b/kipper/core/src/compiler/analysis/analyser/semantic-checker.ts
@@ -99,6 +99,9 @@ export class KipperSemanticChecker extends KipperSemanticsAsserter {
 	 * @since 0.10.0
 	 */
 	public identifierNotUsed(identifier: string, scopeCtx: Scope): void {
+		// Ensure beforehand that also no built-in has the same identifier
+		this.builtInNotDefined(identifier);
+
 		const ref = scopeCtx.getEntryRecursively(identifier);
 		if (ref) {
 			if (ref instanceof ScopeVariableDeclaration) {

--- a/kipper/core/src/compiler/analysis/symbol-table/function-scope.ts
+++ b/kipper/core/src/compiler/analysis/symbol-table/function-scope.ts
@@ -39,7 +39,6 @@ export class FunctionScope extends LocalScope {
 		const identifier = declaration.getSemanticData().identifier;
 
 		// Ensuring that the declaration does not overwrite other definitions
-		this.ctx.programCtx.semanticCheck(declaration).builtInNotDefined(identifier);
 		this.ctx.programCtx.semanticCheck(declaration).identifierNotUsed(identifier, this);
 
 		const scopeDeclaration = new ScopeParameterDeclaration(declaration);

--- a/kipper/core/src/compiler/analysis/symbol-table/function-scope.ts
+++ b/kipper/core/src/compiler/analysis/symbol-table/function-scope.ts
@@ -36,6 +36,12 @@ export class FunctionScope extends LocalScope {
 	 * @since 0.10.0
 	 */
 	public addArgument(declaration: ParameterDeclaration): ScopeParameterDeclaration {
+		const identifier = declaration.getSemanticData().identifier;
+
+		// Ensuring that the declaration does not overwrite other definitions
+		this.ctx.programCtx.semanticCheck(declaration).builtInNotDefined(identifier);
+		this.ctx.programCtx.semanticCheck(declaration).identifierNotUsed(identifier, this);
+
 		const scopeDeclaration = new ScopeParameterDeclaration(declaration);
 		this.arguments.set(scopeDeclaration.identifier, scopeDeclaration);
 		return scopeDeclaration;

--- a/kipper/core/src/compiler/analysis/symbol-table/global-scope.ts
+++ b/kipper/core/src/compiler/analysis/symbol-table/global-scope.ts
@@ -28,7 +28,6 @@ export class GlobalScope extends Scope {
 		const identifier = declaration.getSemanticData().identifier;
 
 		// Ensuring that the declaration does not overwrite other definitions
-		this.programCtx.semanticCheck(declaration).builtInNotDefined(identifier);
 		this.programCtx.semanticCheck(declaration).identifierNotUsed(identifier, this.programCtx.globalScope);
 
 		const scopeDeclaration = new ScopeFunctionDeclaration(declaration);
@@ -40,7 +39,6 @@ export class GlobalScope extends Scope {
 		const identifier = declaration.getSemanticData().identifier;
 
 		// Ensuring that the declaration does not overwrite other definitions
-		this.programCtx.semanticCheck(declaration).builtInNotDefined(identifier);
 		this.programCtx.semanticCheck(declaration).identifierNotUsed(identifier, this.programCtx.globalScope);
 
 		const scopeDeclaration = new ScopeVariableDeclaration(declaration);

--- a/kipper/core/src/compiler/analysis/symbol-table/local-scope.ts
+++ b/kipper/core/src/compiler/analysis/symbol-table/local-scope.ts
@@ -37,7 +37,7 @@ export class LocalScope extends Scope {
 		const identifier = declaration.getSemanticData().identifier;
 
 		// Ensuring that the declaration does not overwrite other definitions
-		// Using 'declaration' as a context since it stores the context info of the scope
+		this.ctx.programCtx.semanticCheck(declaration).builtInNotDefined(identifier);
 		this.ctx.programCtx.semanticCheck(declaration).identifierNotUsed(identifier, this);
 
 		const scopeDeclaration = new ScopeVariableDeclaration(declaration);

--- a/kipper/core/src/compiler/analysis/symbol-table/local-scope.ts
+++ b/kipper/core/src/compiler/analysis/symbol-table/local-scope.ts
@@ -37,7 +37,6 @@ export class LocalScope extends Scope {
 		const identifier = declaration.getSemanticData().identifier;
 
 		// Ensuring that the declaration does not overwrite other definitions
-		this.ctx.programCtx.semanticCheck(declaration).builtInNotDefined(identifier);
 		this.ctx.programCtx.semanticCheck(declaration).identifierNotUsed(identifier, this);
 
 		const scopeDeclaration = new ScopeVariableDeclaration(declaration);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -476,7 +476,6 @@ packages:
       treeverse: 1.0.4
       walk-up-path: 1.0.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -506,8 +505,6 @@ packages:
       promise-retry: 2.0.1
       semver: 7.3.8
       which: 2.0.2
-    transitivePeerDependencies:
-      - bluebird
     dev: true
 
   /@npmcli/installed-package-contents/1.0.7:
@@ -538,7 +535,6 @@ packages:
       pacote: 12.0.3
       semver: 7.3.8
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -588,7 +584,6 @@ packages:
       node-gyp: 8.4.1
       read-package-json-fast: 2.0.3
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -1859,8 +1854,6 @@ packages:
       ssri: 8.0.1
       tar: 6.1.12
       unique-filename: 1.1.1
-    transitivePeerDependencies:
-      - bluebird
     dev: true
 
   /cacache/16.1.3:
@@ -1885,8 +1878,6 @@ packages:
       ssri: 9.0.1
       tar: 6.1.12
       unique-filename: 2.0.1
-    transitivePeerDependencies:
-      - bluebird
     dev: true
 
   /cached-path-relative/1.1.0:
@@ -2884,7 +2875,7 @@ packages:
     dev: true
 
   /fast-levenshtein/2.0.6:
-    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==, tarball: fast-levenshtein/-/fast-levenshtein-2.0.6.tgz}
     dependencies:
       fastest-levenshtein: 1.0.16
     dev: true
@@ -4084,7 +4075,6 @@ packages:
       socks-proxy-agent: 7.0.0
       ssri: 9.0.1
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -4109,7 +4099,6 @@ packages:
       socks-proxy-agent: 6.2.1
       ssri: 8.0.1
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -4485,7 +4474,6 @@ packages:
       tar: 6.1.12
       which: 2.0.2
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -4594,7 +4582,6 @@ packages:
       minizlib: 2.1.2
       npm-package-arg: 8.1.5
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -4706,7 +4693,6 @@ packages:
       yeoman-generator: 5.7.0_yeoman-environment@3.12.1
       yosay: 2.0.2
     transitivePeerDependencies:
-      - bluebird
       - encoding
       - supports-color
     dev: true
@@ -4878,7 +4864,6 @@ packages:
       ssri: 8.0.1
       tar: 6.1.12
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -5098,11 +5083,6 @@ packages:
 
   /promise-inflight/1.0.1:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
     dev: true
 
   /promise-retry/2.0.1:
@@ -5815,8 +5795,8 @@ packages:
     dev: true
 
   /strip-bom/3.0.0:
-    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
-    engines: {node: '>=4'}
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==, tarball: strip-bom/-/strip-bom-3.0.0.tgz}
+    engines: {node: '>=0.10.0'}
     dependencies:
       is-utf8: 0.2.1
     dev: true
@@ -6784,7 +6764,6 @@ packages:
       textextensions: 5.15.0
       untildify: 4.0.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 

--- a/test/module/core/errors.test.ts
+++ b/test/module/core/errors.test.ts
@@ -393,16 +393,8 @@ describe("Kipper errors", () => {
 			].forEach((test) => {
 				const config: CompileConfig = {
 					...defaultConfig,
-					extendBuiltIns:
-						test.i !== "print"
-							? [
-									{
-										identifier: test.i,
-										params: [],
-										returnType: "void",
-									},
-							  ]
-							: [],
+					// prettier-ignore
+					extendBuiltIns: test.i !== "print" ? [{ identifier: test.i, params: [], returnType: "void", }, ] : [],
 				};
 
 				describe(`Global Scope - ${test.t} Overwrite`, () => {

--- a/test/module/core/errors.test.ts
+++ b/test/module/core/errors.test.ts
@@ -330,6 +330,22 @@ describe("Kipper errors", () => {
 		});
 
 		describe("IdentifierAlreadyUsedByParameterError", () => {
+			it("Overwrite by other parameter", async () => {
+				let result: KipperCompileResult | undefined = undefined;
+				try {
+					result = await new KipperCompiler().compile("def f(x: num, x: num) -> void {};", defaultConfig);
+				} catch (e) {
+					assert(
+						(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByParameterError",
+						"Expected proper error",
+					);
+					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
+					ensureTracebackDataExists(<KipperError>e);
+					return;
+				}
+				assert.fail("Expected 'IdentifierAlreadyUsedByParameterError'");
+			});
+
 			describe("Override from Root Function Scope", () => {
 				it("Redeclaration by variable", async () => {
 					let result: KipperCompileResult | undefined = undefined;
@@ -385,7 +401,7 @@ describe("Kipper errors", () => {
 										params: [],
 										returnType: "void",
 									},
-							  ]
+								]
 							: [],
 				};
 

--- a/test/module/core/errors.test.ts
+++ b/test/module/core/errors.test.ts
@@ -401,7 +401,7 @@ describe("Kipper errors", () => {
 										params: [],
 										returnType: "void",
 									},
-								]
+							  ]
 							: [],
 				};
 


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it -->

- [x] Bug fix (Non-breaking change which fixes an issue)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

<!-- Explain the reason for this pr, changes and solution briefly. -->

Fixed bug allowing duplicate parameter name usage, which was caused by insufficient checking during the registration of the parameter in the symbol table.

Closes #363

## Summary of Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

- Fixed symbol table registration bugs for parameters and other declarations, where some checks were not done properly.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Detailed Changelog

_Not present for website/docs changes_

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added and remove any header with no item.). -->

None.

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [x] #363 