### PR TITLE
Fixed error recovery bug for references of variables that had a semantic error in their definition causing an internal error

### DIFF
--- a/.run/kipper run.run.xml
+++ b/.run/kipper run.run.xml
@@ -1,8 +1,5 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="kipper run" type="NodeJSConfigurationType" application-parameters="run -s &quot;&quot;" path-to-js-file="./kipper/cli/bin/run" working-dir="$PROJECT_DIR$/">
-    <envs>
-      <env name="DEBUG" value="*" />
-    </envs>
     <method v="2" />
   </configuration>
 </component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,10 +124,10 @@ To use development versions of Kipper download the
 		node.
   - `AnalysableASTNode.targetSemanticallyAnalyseChildren()`, which semantically analyses all children nodes of the AST
 		node for the target.
-  - `AnalysableASTNode.ensureSemanticallyValid()`, which throws an `MissingRequiredSemanticDataError` in case that the
+  - `AnalysableASTNode.ensureSemanticallyValid()`, which throws a `MissingRequiredSemanticDataError` in case that the
   	specified node failed during semantic analysis. This is used by other nodes to ensure that the node is valid and
     its data can be safely accessed.
-  - `AnalysableASTNode.ensureTypeSemanticallyValid()`, which throws an `MissingRequiredSemanticDataError` in case that
+  - `AnalysableASTNode.ensureTypeSemanticallyValid()`, which throws a `MissingRequiredSemanticDataError` in case that
 		the specified node failed during type checking. This is used by other nodes to ensure that the node is valid and
 		its data can be safely accessed.
 - New types:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ To use development versions of Kipper download the
     an object-like or array-like.
   - `ValueNotIndexableTypeError`, which is thrown when a value is not indexable (not object-like), despite it being used
     in a member access expression.
+  - `MissingRequiredSemanticDataError`, which is a specific internal error used to indicate that a specified node is
+		missing required semantic data from another node and as a result failed to process itself.
 - New classes:
   - `KipperWarning`, which is a subclass of `KipperError` that is used to indicate a warning.
     This replaces the use of `KipperError` for warnings.
@@ -116,6 +118,18 @@ To use development versions of Kipper download the
   - `removeBraces()` for removing braces due to formatting reasons.
   - `CompilableASTNode.recursivelyCheckForWarnings()`, which recursively calls all children's `checkforWarnings()`
     functions as well as the function of the parent instance.
+  - `shouldRecoverFromError()` and `handleSemanticError()` in `handle-error.ts`.
+  - `AnalysableASTNode.semanticallyAnalyseChildren()`, which semantically analyses all children nodes of the AST node.
+  - `AnalysableASTNode.semanticallyTypeCheckChildren()`, which semantically type checks all children nodes of the AST
+		node.
+  - `AnalysableASTNode.targetSemanticallyAnalyseChildren()`, which semantically analyses all children nodes of the AST
+		node for the target.
+  - `AnalysableASTNode.ensureSemanticallyValid()`, which throws an `MissingRequiredSemanticDataError` in case that the
+  	specified node failed during semantic analysis. This is used by other nodes to ensure that the node is valid and
+    its data can be safely accessed.
+  - `AnalysableASTNode.ensureTypeSemanticallyValid()`, which throws an `MissingRequiredSemanticDataError` in case that
+		the specified node failed during type checking. This is used by other nodes to ensure that the node is valid and
+		its data can be safely accessed.
 - New types:
   - `TypeData`, which represents the type data of an `ASTNode`.
   - `NoTypeSemantics`, which hints that an `ASTNode` has no type semantic data.
@@ -265,20 +279,24 @@ context to an AST node. This is the type representing all values from`ParserASTM
   - `ParserStatementCtx` to `ParserStatementContext`.
   - `ParserDeclarationCtx` to `ParserDeclarationContext`.
   - `KipperFileListener` to `KipperFileASTGenerator`.
+  - `KipperProgramContext.addError` to `reportError`.
 - Moved:
   - Function `KipperSemanticsAsserter.getReference` to class `KipperSemanticChecker`.
   - Function `KipperSemanticsAsserter.getExistingReference` to class `KipperSemanticChecker`.
   - Function `indentLines` to file `tools.ts` of `@kipper/target-js`.
-  - Function `CompilableASTNode.semanticAnalysis` to `AnalysableASTNode.semanticAnalysis`.
-  - Function `CompilableASTNode.semanticTypeChecking` to `AnalysableASTNode.semanticTypeChecking`.
-  - Function `CompilableASTNode.wrapUpSemanticAnalysis` to `AnalysableASTNode.wrapUpSemanticAnalysis`.
-  - Function `CompilableASTNode.recursivelyCheckForWarnings` to `AnalysableASTNode.recursivelyCheckForWarnings`.
-  - Function `CompilableASTNode.recursivelyCheckForWarnings` to `AnalysableASTNode.recursivelyCheckForWarnings`.
-  - Abstract Function `CompilableASTNode.primarySemanticAnalysis` to `AnalysableASTNode.primarySemanticAnalysis`.
-  - Abstract Function `CompilableASTNode.primarySemanticTypeChecking` to `AnalysableASTNode.primarySemanticTypeChecking`.
-  - Abstract Function `CompilableASTNode.checkForWarnings` to `AnalysableASTNode.checkForWarnings`.
-  - Field `CompilableASTNode.programCtx` to `AnalysableASTNode.programCtx`
-  - Field `CompilableASTNode.compileConfig` to `AnalysableASTNode.compileConfig`
+  - Function `CompilableASTNode.semanticAnalysis` to `AnalysableASTNode`.
+  - Function `CompilableASTNode.semanticTypeChecking` to `AnalysableASTNode`.
+  - Function `CompilableASTNode.wrapUpSemanticAnalysis` to `AnalysableASTNode`.
+  - Function `CompilableASTNode.recursivelyCheckForWarnings` to `AnalysableASTNode`.
+  - Function `CompilableASTNode.recursivelyCheckForWarnings` to `AnalysableASTNode`.
+  - Abstract Function `CompilableASTNode.primarySemanticAnalysis` to `AnalysableASTNode`.
+  - Abstract Function `CompilableASTNode.primarySemanticTypeChecking` to `AnalysableASTNode`.
+  - Abstract Function `CompilableASTNode.checkForWarnings` to `AnalysableASTNode`.
+  - Field `CompilableASTNode.programCtx` to `AnalysableASTNode`.
+  - Field `CompilableASTNode.compileConfig` to `AnalysableASTNode`. 
+  - Field `CompilableASTNode.errors` to `AnalysableASTNode`.
+	- Field `CompilableASTNode.addError` to `AnalysableASTNode`.
+  - Field `CompilableASTNode.hasFailed` to `AnalysableASTNode`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ To use development versions of Kipper download the
 - Implemented member-access expressions using bracket and slice notation (`[]`, `[:]`), which can be used to access
   specific elements of a string (In the future, this will also be used to access elements of arrays and objects).
   ([#372](https://github.com/Luna-Klatzer/Kipper/issues/372)).
-- Support for single-line comments separated by a newline char. 
+- Support for single-line comments separated by a newline char.
   ([#400](https://github.com/Luna-Klatzer/Kipper/issues/400)).
 - New built-in Kipper type `null` and `undefined`, and support for the constant identifier `void`, `null` and
   `undefined`.

--- a/kipper/core/src/compiler/analysis/handle-error.ts
+++ b/kipper/core/src/compiler/analysis/handle-error.ts
@@ -1,0 +1,37 @@
+/**
+ * Functions for handling errors that occur during the semantic analysis of a node.
+ * @since 0.10.0
+ */
+import type { AnalysableASTNode, RootASTNode } from "../ast";
+import { KipperError, MissingRequiredSemanticDataError } from "../../errors";
+
+/**
+ * Checks whether the given error should be recovered from or not.
+ * @param node The node that is currently being processed.
+ * @param error The error to check.
+ * @since 0.10.0
+ */
+export function shouldRecoverFromError(node: RootASTNode | AnalysableASTNode, error: Error | KipperError): boolean {
+	// Note: Option 'abortOnFirstError' overwrites 'recover' per default
+	return error instanceof KipperError && node.compileConfig.recover && !node.compileConfig.abortOnFirstError;
+}
+
+/**
+ * Handles the specified error that occurred during the semantic analysis of a node in a standardised way.
+ * @param node The node that is currently being processed.
+ * @param error The error to handle.
+ * @since 0.10.0
+ */
+export function handleSemanticError(node: RootASTNode | AnalysableASTNode, error: Error | KipperError): void {
+	if (shouldRecoverFromError(node, <Error>error)) {
+		node.programCtx.reportError(<KipperError>error);
+	} else if (!(error instanceof MissingRequiredSemanticDataError)) {
+		// If the error is not a MissingRequiredSemanticDataError, then re-throw it. This is due to the fact that
+		// the error is an intended error and used as prevention for nodes to continue processing despite required data
+		// not being available.
+		//
+		// -> The required node will already have reported the error, so we shouldn't try to access data that does
+		// not exist or is not valid. Also see 'this.ensureSemanticallyValid()'/'this.ensureTypeSemanticallyValid()'.
+		throw error;
+	}
+}

--- a/kipper/core/src/compiler/analysis/index.ts
+++ b/kipper/core/src/compiler/analysis/index.ts
@@ -2,6 +2,7 @@
  * Analysis submodule in the Kipper compiler which is responsible for defining and processing semantic data.
  * @since 0.7.0
  */
+export * from "./handle-error";
 export * from "./analyser/";
 export * from "./symbol-table/";
 export * from "./type";

--- a/kipper/core/src/compiler/ast/compilable-ast-node.ts
+++ b/kipper/core/src/compiler/ast/compilable-ast-node.ts
@@ -11,10 +11,9 @@ import type { TokenStream } from "antlr4ts/TokenStream";
 import type { RootASTNode, SemanticData } from "./index";
 import type { FunctionScope, GlobalScope, LocalScope } from "../analysis";
 import type { ScopeNode } from "./scope-node";
-import { KipperError } from "../../errors";
+import type { TargetCompilableNode } from "./target-node";
+import type { TargetASTNodeCodeGenerator } from "../target-presets";
 import { AnalysableASTNode } from "./analysable-ast-node";
-import { TargetCompilableNode } from "./target-node";
-import { TargetASTNodeCodeGenerator } from "../target-presets";
 
 /**
  * An eligible parent for a compilable AST node.
@@ -40,7 +39,6 @@ export abstract class CompilableASTNode<
 	implements TargetCompilableNode
 {
 	protected _scopeCtx: ScopeNode<LocalScope | FunctionScope> | KipperProgramContext | undefined;
-	protected _errors: Array<KipperError>;
 	protected override _parent: CompilableNodeParent;
 	protected override _children: Array<CompilableNodeChild>;
 
@@ -48,7 +46,6 @@ export abstract class CompilableASTNode<
 		super(antlrCtx, parent);
 		this._parent = parent;
 		this._children = [];
-		this._errors = [];
 	}
 
 	/**
@@ -76,37 +73,6 @@ export abstract class CompilableASTNode<
 	 */
 	public addNewChild(newChild: CompilableNodeChild): void {
 		this._children.push(newChild);
-	}
-
-	/**
-	 * The errors that were caused by this node. Includes all errors from children.
-	 * @since 0.10.0
-	 */
-	public get errors(): Array<KipperError> {
-		return [...this._errors, ...this._children.flatMap((child) => child.errors)];
-	}
-
-	/**
-	 * Adds the specified {@link error} to the list of errors caused by this node.
-	 *
-	 * This is not the same as {@link KipperProgramContext.reportError}, since that function automatically logs the error
-	 * as well and this function does not! This is only intended to keep track if a node has failed.
-	 * @param error The error to add.
-	 */
-	public addError(error: KipperError) {
-		this._errors.push(error);
-	}
-
-	/**
-	 * Returns true if the {@link this.primarySemanticAnalysis semantic analysis} or
-	 * {@link this.primarySemanticTypeChecking type checking} of {@link CompilableASTNode this node} or any
-	 * {@link children children nodes} failed.
-	 *
-	 * This indicates that the node is not valid and can not be translated.
-	 * @since 0.10.0
-	 */
-	public get hasFailed(): boolean {
-		return this.errors.length > 0;
 	}
 
 	/**

--- a/kipper/core/src/compiler/ast/compilable-ast-node.ts
+++ b/kipper/core/src/compiler/ast/compilable-ast-node.ts
@@ -83,18 +83,13 @@ export abstract class CompilableASTNode<
 	 * @since 0.10.0
 	 */
 	public get errors(): Array<KipperError> {
-		// TODO! Finish implementation of this
-		let errors = this._errors;
-		for (const child of this._children) {
-			errors = errors.concat(child.errors);
-		}
-		return errors;
+		return [...this._errors, ...this._children.flatMap((child) => child.errors)];
 	}
 
 	/**
 	 * Adds the specified {@link error} to the list of errors caused by this node.
 	 *
-	 * This is not the same as {@link KipperProgramContext.addError}, since that function automatically logs the error
+	 * This is not the same as {@link KipperProgramContext.reportError}, since that function automatically logs the error
 	 * as well and this function does not! This is only intended to keep track if a node has failed.
 	 * @param error The error to add.
 	 */

--- a/kipper/core/src/compiler/ast/nodes/definitions.ts
+++ b/kipper/core/src/compiler/ast/nodes/definitions.ts
@@ -253,6 +253,7 @@ export class ParameterDeclaration extends Declaration<
 	 */
 	public async primarySemanticTypeChecking(): Promise<void> {
 		const semanticData = this.getSemanticData();
+		this.ensureChildTypeSemanticallyValid(semanticData.valueTypeSpecifier); // Required type data
 
 		// Get the type that will be returned using the value type specifier
 		const valueType = semanticData.valueTypeSpecifier.getTypeSemanticData().storedType;
@@ -405,6 +406,7 @@ export class FunctionDeclaration
 	 */
 	public async primarySemanticTypeChecking(): Promise<void> {
 		const semanticData = this.getSemanticData();
+		this.ensureChildTypeSemanticallyValid(semanticData.returnTypeSpecifier); // Required type data
 
 		// Get the type that will be returned using the return type specifier
 		const returnType = semanticData.returnTypeSpecifier.getTypeSemanticData().storedType;
@@ -532,6 +534,7 @@ export class VariableDeclaration extends Declaration<VariableDeclarationSemantic
 		// The type of this declaration, which should always be present, since the parser requires it during the parsing
 		// step.
 		const typeSpecifier: IdentifierTypeSpecifierExpression = <IdentifierTypeSpecifierExpression>this.children[0];
+		this.ensureChildSemanticallyValid(typeSpecifier); // Required semantic data
 
 		// There will always be only one child, which is the expression assigned.
 		// If this child is missing, then this declaration does not contain a definition.
@@ -558,11 +561,11 @@ export class VariableDeclaration extends Declaration<VariableDeclarationSemantic
 			value: assignValue,
 		};
 
-		// If the storage type is 'const' ensure that the variable has a value set.
-		this.programCtx.semanticCheck(this).validVariableDeclaration(this);
-
 		// Add scope variable entry
 		this.scopeDeclaration = this.scope.addVariable(this);
+
+		// If the storage type is 'const' ensure that the variable has a value set.
+		this.programCtx.semanticCheck(this).validVariableDeclaration(this);
 	}
 
 	/**
@@ -572,6 +575,7 @@ export class VariableDeclaration extends Declaration<VariableDeclarationSemantic
 	 */
 	public async primarySemanticTypeChecking(): Promise<void> {
 		const semanticData = this.getSemanticData();
+		this.ensureChildTypeSemanticallyValid(semanticData.valueTypeSpecifier); // Required type data
 
 		// Get the type that will be returned using the value type specifier
 		const valueType = semanticData.valueTypeSpecifier.getTypeSemanticData().storedType;
@@ -581,6 +585,7 @@ export class VariableDeclaration extends Declaration<VariableDeclarationSemantic
 
 		// If the variable is defined, check whether the assignment is valid
 		if (semanticData.value) {
+			this.ensureChildTypeSemanticallyValid(semanticData.value); // Required type data
 			this.programCtx.typeCheck(this).validVariableDefinition(this.getScopeDeclaration(), semanticData.value);
 		}
 	}

--- a/kipper/core/src/compiler/ast/nodes/definitions.ts
+++ b/kipper/core/src/compiler/ast/nodes/definitions.ts
@@ -223,6 +223,9 @@ export class ParameterDeclaration extends Declaration<
 	/**
 	 * Performs the semantic analysis for this Kipper token. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the semantic analysis of
+	 * the children has already failed and as such no parent node should run type checking.
 	 */
 	public async primarySemanticAnalysis(): Promise<void> {
 		const parseTreeChildren = this.getAntlrRuleChildren();
@@ -249,11 +252,13 @@ export class ParameterDeclaration extends Declaration<
 	/**
 	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
+	 * the children has already failed and as such no parent node should run type checking.
 	 * @since 0.7.0
 	 */
 	public async primarySemanticTypeChecking(): Promise<void> {
 		const semanticData = this.getSemanticData();
-		this.ensureChildTypeSemanticallyValid(semanticData.valueTypeSpecifier); // Required type data
 
 		// Get the type that will be returned using the value type specifier
 		const valueType = semanticData.valueTypeSpecifier.getTypeSemanticData().storedType;
@@ -344,6 +349,9 @@ export class FunctionDeclaration
 	/**
 	 * Performs the semantic analysis for this Kipper token. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the semantic analysis of
+	 * the children has already failed and as such no parent node should run type checking.
 	 */
 	public async primarySemanticAnalysis(): Promise<void> {
 		const parseTreeChildren = this.getAntlrRuleChildren();
@@ -402,11 +410,13 @@ export class FunctionDeclaration
 	/**
 	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
+	 * the children has already failed and as such no parent node should run type checking.
 	 * @since 0.7.0
 	 */
 	public async primarySemanticTypeChecking(): Promise<void> {
 		const semanticData = this.getSemanticData();
-		this.ensureChildTypeSemanticallyValid(semanticData.returnTypeSpecifier); // Required type data
 
 		// Get the type that will be returned using the return type specifier
 		const returnType = semanticData.returnTypeSpecifier.getTypeSemanticData().storedType;
@@ -516,6 +526,9 @@ export class VariableDeclaration extends Declaration<VariableDeclarationSemantic
 	/**
 	 * Performs the semantic analysis for this Kipper token. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the semantic analysis of
+	 * the children has already failed and as such no parent node should run type checking.
 	 */
 	public async primarySemanticAnalysis(): Promise<void> {
 		const children: Array<ParseTree> = this.getAntlrRuleChildren();
@@ -534,7 +547,6 @@ export class VariableDeclaration extends Declaration<VariableDeclarationSemantic
 		// The type of this declaration, which should always be present, since the parser requires it during the parsing
 		// step.
 		const typeSpecifier: IdentifierTypeSpecifierExpression = <IdentifierTypeSpecifierExpression>this.children[0];
-		this.ensureChildSemanticallyValid(typeSpecifier); // Required semantic data
 
 		// There will always be only one child, which is the expression assigned.
 		// If this child is missing, then this declaration does not contain a definition.
@@ -571,13 +583,16 @@ export class VariableDeclaration extends Declaration<VariableDeclarationSemantic
 	/**
 	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
+	 * the children has already failed and as such no parent node should run type checking.
 	 * @since 0.7.0
 	 */
 	public async primarySemanticTypeChecking(): Promise<void> {
 		const semanticData = this.getSemanticData();
-		this.ensureChildTypeSemanticallyValid(semanticData.valueTypeSpecifier); // Required type data
 
 		// Get the type that will be returned using the value type specifier
+		semanticData.valueTypeSpecifier.ensureTypeSemanticallyValid(); // Ensure the type specifier didn't fail
 		const valueType = semanticData.valueTypeSpecifier.getTypeSemanticData().storedType;
 		this.typeSemantics = {
 			valueType: valueType,
@@ -585,7 +600,7 @@ export class VariableDeclaration extends Declaration<VariableDeclarationSemantic
 
 		// If the variable is defined, check whether the assignment is valid
 		if (semanticData.value) {
-			this.ensureChildTypeSemanticallyValid(semanticData.value); // Required type data
+			semanticData.value.ensureTypeSemanticallyValid(); // Ensure the assignment didn't fail
 			this.programCtx.typeCheck(this).validVariableDefinition(this.getScopeDeclaration(), semanticData.value);
 		}
 	}

--- a/kipper/core/src/compiler/ast/nodes/statements.ts
+++ b/kipper/core/src/compiler/ast/nodes/statements.ts
@@ -155,12 +155,18 @@ export class CompoundStatement extends Statement<NoSemantics, NoTypeSemantics> i
 	/**
 	 * Performs the semantic analysis for this Kipper token. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the semantic analysis of
+	 * the children has already failed and as such no parent node should run type checking.
 	 */
 	public primarySemanticAnalysis = undefined; // Compound statements will never have semantic data
 
 	/**
 	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
+	 * the children has already failed and as such no parent node should run type checking.
 	 * @since 0.7.0
 	 */
 	public primarySemanticTypeChecking = undefined; // Compound statements will never have type checking
@@ -227,6 +233,9 @@ export class IfStatement extends Statement<IfStatementSemantics, NoTypeSemantics
 	/**
 	 * Performs the semantic analysis for this Kipper token. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the semantic analysis of
+	 * the children has already failed and as such no parent node should run type checking.
 	 */
 	public async primarySemanticAnalysis(): Promise<void> {
 		// There will be always at least two children
@@ -250,6 +259,9 @@ export class IfStatement extends Statement<IfStatementSemantics, NoTypeSemantics
 	/**
 	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
+	 * the children has already failed and as such no parent node should run type checking.
 	 * @since 0.7.0
 	 */
 	public primarySemanticTypeChecking = undefined; // If-statements will never have type checking
@@ -311,6 +323,9 @@ export class SwitchStatement extends Statement<NoSemantics, NoTypeSemantics> {
 	/**
 	 * Performs the semantic analysis for this Kipper token. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the semantic analysis of
+	 * the children has already failed and as such no parent node should run type checking.
 	 */
 	public async primarySemanticAnalysis(): Promise<void> {
 		throw this.programCtx
@@ -321,6 +336,9 @@ export class SwitchStatement extends Statement<NoSemantics, NoTypeSemantics> {
 	/**
 	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
+	 * the children has already failed and as such no parent node should run type checking.
 	 * @since 0.7.0
 	 */
 	public async primarySemanticTypeChecking(): Promise<void> {
@@ -388,12 +406,18 @@ export class ExpressionStatement extends Statement<NoSemantics, NoTypeSemantics>
 	/**
 	 * Performs the semantic analysis for this Kipper token. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the semantic analysis of
+	 * the children has already failed and as such no parent node should run type checking.
 	 */
 	public primarySemanticAnalysis = undefined; // Expression statements will never have semantic data
 
 	/**
 	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
+	 * the children has already failed and as such no parent node should run type checking.
 	 * @since 0.7.0
 	 */
 	public primarySemanticTypeChecking = undefined; // Expression statements will never have type checking
@@ -486,6 +510,9 @@ export class DoWhileLoopStatement extends IterationStatement<DoWhileLoopStatemen
 	/**
 	 * Performs the semantic analysis for this Kipper token. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the semantic analysis of
+	 * the children has already failed and as such no parent node should run type checking.
 	 */
 	public async primarySemanticAnalysis(): Promise<void> {
 		throw this.programCtx
@@ -496,6 +523,9 @@ export class DoWhileLoopStatement extends IterationStatement<DoWhileLoopStatemen
 	/**
 	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
+	 * the children has already failed and as such no parent node should run type checking.
 	 * @since 0.7.0
 	 */
 	public async primarySemanticTypeChecking(): Promise<void> {
@@ -563,6 +593,9 @@ export class WhileLoopStatement extends IterationStatement<WhileLoopStatementSem
 	/**
 	 * Performs the semantic analysis for this Kipper token. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the semantic analysis of
+	 * the children has already failed and as such no parent node should run type checking.
 	 */
 	public async primarySemanticAnalysis(): Promise<void> {
 		const loopCondition = <Expression>this.children[0];
@@ -577,6 +610,9 @@ export class WhileLoopStatement extends IterationStatement<WhileLoopStatementSem
 	/**
 	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
+	 * the children has already failed and as such no parent node should run type checking.
 	 * @since 0.7.0
 	 */
 	public primarySemanticTypeChecking = undefined; // While-loop statements will never have type checking
@@ -639,6 +675,9 @@ export class ForLoopStatement extends IterationStatement<ForLoopStatementSemanti
 	/**
 	 * Performs the semantic analysis for this Kipper token. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the semantic analysis of
+	 * the children has already failed and as such no parent node should run type checking.
 	 */
 	public async primarySemanticAnalysis(): Promise<void> {
 		throw this.programCtx
@@ -649,6 +688,9 @@ export class ForLoopStatement extends IterationStatement<ForLoopStatementSemanti
 	/**
 	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
+	 * the children has already failed and as such no parent node should run type checking.
 	 * @since 0.7.0
 	 */
 	public async primarySemanticTypeChecking(): Promise<void> {
@@ -715,6 +757,9 @@ export class JumpStatement extends Statement<JumpStatementSemantics, NoTypeSeman
 	/**
 	 * Performs the semantic analysis for this Kipper token. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the semantic analysis of
+	 * the children has already failed and as such no parent node should run type checking.
 	 */
 	public async primarySemanticAnalysis(): Promise<void> {
 		const jmpType = this.sourceCode.startsWith("break") ? "break" : "continue";
@@ -733,6 +778,9 @@ export class JumpStatement extends Statement<JumpStatementSemantics, NoTypeSeman
 	/**
 	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
+	 * the children has already failed and as such no parent node should run type checking.
 	 * @since 0.7.0
 	 */
 	public async primarySemanticTypeChecking(): Promise<void> {
@@ -801,6 +849,9 @@ export class ReturnStatement extends Statement<ReturnStatementSemantics, ReturnS
 	/**
 	 * Performs the semantic analysis for this Kipper token. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the semantic analysis of
+	 * the children has already failed and as such no parent node should run type checking.
 	 */
 	public async primarySemanticAnalysis(): Promise<void> {
 		const returnValue = <Expression | undefined>this.children[0];
@@ -817,6 +868,9 @@ export class ReturnStatement extends Statement<ReturnStatementSemantics, ReturnS
 	/**
 	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
 	 * and throw errors if encountered.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
+	 * the children has already failed and as such no parent node should run type checking.
 	 * @since 0.7.0
 	 */
 	public async primarySemanticTypeChecking(): Promise<void> {

--- a/kipper/core/src/compiler/ast/root-ast-node.ts
+++ b/kipper/core/src/compiler/ast/root-ast-node.ts
@@ -143,7 +143,7 @@ export class RootASTNode extends ParserASTNode<NoSemantics, NoTypeSemantics> {
 	async handleSemanticError(e: Error | UndefinedSemanticsError | KipperError): Promise<void> {
 		// If it's a compile error, add it to the list of errors
 		if (e instanceof KipperError && this.compileConfig.recover && !this.compileConfig.abortOnFirstError) {
-			this.programCtx.addError(e);
+			this.programCtx.reportError(e);
 		} else {
 			// If we can't handle the error or the user wants to abort/avoid recovering, then re-throw the error
 			throw e;

--- a/kipper/core/src/compiler/ast/root-ast-node.ts
+++ b/kipper/core/src/compiler/ast/root-ast-node.ts
@@ -15,8 +15,9 @@ import type { EvaluatedCompileConfig } from "../compiler";
 import type { KipperProgramContext } from "../program-ctx";
 import type { Declaration, Statement } from "./nodes";
 import type { TranslatedCodeLine } from "../const";
-import { KipperError, UndefinedSemanticsError } from "../../errors";
+import { KipperError } from "../../errors";
 import { CompilationUnitContext, KipperParser } from "../parser";
+import { handleSemanticError } from "../analysis";
 
 /**
  * The root node of an abstract syntax tree, which contains all AST nodes of a file.
@@ -136,18 +137,12 @@ export class RootASTNode extends ParserASTNode<NoSemantics, NoTypeSemantics> {
 	}
 
 	/**
-	 * Handles a semantic error that was thrown in the function {@link this.semanticAnalysis}.
-	 * @param e The error that was thrown.
+	 * Handles the specified error that occurred during the semantic analysis of this node in a standardised way.
+	 * @param error The error to handle.
 	 * @since 0.10.0
 	 */
-	async handleSemanticError(e: Error | UndefinedSemanticsError | KipperError): Promise<void> {
-		// If it's a compile error, add it to the list of errors
-		if (e instanceof KipperError && this.compileConfig.recover && !this.compileConfig.abortOnFirstError) {
-			this.programCtx.reportError(e);
-		} else {
-			// If we can't handle the error or the user wants to abort/avoid recovering, then re-throw the error
-			throw e;
-		}
+	protected handleSemanticError(error: Error | KipperError): void {
+		handleSemanticError(this, error);
 	}
 
 	/**
@@ -169,11 +164,6 @@ export class RootASTNode extends ParserASTNode<NoSemantics, NoTypeSemantics> {
 		// Perform type-checking based on the existing AST nodes and evaluated semantics
 		for (let child of this.children) {
 			try {
-				// If the child has failed to process, avoid type checking
-				if (!child.semanticData) {
-					continue;
-				}
-
 				await child.semanticTypeChecking();
 			} catch (e) {
 				await this.handleSemanticError(<Error>e);
@@ -183,11 +173,6 @@ export class RootASTNode extends ParserASTNode<NoSemantics, NoTypeSemantics> {
 		// Perform wrap-up semantic analysis for the specified target
 		for (let child of this.children) {
 			try {
-				// If the child has failed to process, avoid wrap-up semantic analysis
-				if (!child.semanticData || !child.typeSemantics) {
-					continue;
-				}
-
 				await child.wrapUpSemanticAnalysis();
 			} catch (e) {
 				await this.handleSemanticError(<Error>e);

--- a/kipper/core/src/compiler/compiler.ts
+++ b/kipper/core/src/compiler/compiler.ts
@@ -428,7 +428,7 @@ export class KipperCompiler {
 			if (e instanceof KipperError) {
 				// Add the error to the programCtx, as that should not have been done yet by the semantic analysis in the
 				// RootASTNode class and CompilableASTNode classes.
-				programCtx.addError(e);
+				programCtx.reportError(e);
 
 				if (compilerOptions.recover === false) {
 					// If an error was thrown and the user does not want to recover from it, simply abort the compilation

--- a/kipper/core/src/compiler/const.ts
+++ b/kipper/core/src/compiler/const.ts
@@ -574,7 +574,6 @@ export type KipperReferenceable =
 	| KipperReferenceableFunction
 	| KipperVariable
 	| KipperParam
-	| KipperArg
 	| ScopeDeclaration;
 
 /**

--- a/kipper/core/src/compiler/const.ts
+++ b/kipper/core/src/compiler/const.ts
@@ -570,11 +570,7 @@ export type KipperArg = KipperParam;
  * Represents a runtime variable or function that can be referenced.
  * @since 0.6.0
  */
-export type KipperReferenceable =
-	| KipperReferenceableFunction
-	| KipperVariable
-	| KipperParam
-	| ScopeDeclaration;
+export type KipperReferenceable = KipperReferenceableFunction | KipperVariable | KipperParam | ScopeDeclaration;
 
 /**
  * Represents all possible jump statements inside Kipper.

--- a/kipper/core/src/compiler/program-ctx.ts
+++ b/kipper/core/src/compiler/program-ctx.ts
@@ -341,7 +341,7 @@ export class KipperProgramContext {
 	 * @param error The error to add to the list of reported errors of this program.
 	 * @since 0.10.0
 	 */
-	public addError(error: KipperError): void {
+	public reportError(error: KipperError): void {
 		this.errors.push(error);
 		this.logger.reportError(LogLevel.ERROR, error);
 

--- a/kipper/core/src/errors.ts
+++ b/kipper/core/src/errors.ts
@@ -282,6 +282,22 @@ export class TypeNotCompilableError extends KipperInternalError {
 }
 
 /**
+ * Error that is thrown whenever a parent node attempts to access the {@link CompilableASTNode.semanticData} of a child,
+ * but the child had an error during semantic analysis. This is to prevent the parent from using the child's data
+ * despite the child having an error.
+ *
+ * This will unlike {@link UndefinedSemanticsError} not be thrown to indicate a fatal error/bug in the compiler, but
+ * is used to early abort the semantic analysis of a parent node. This therefore only affects the control flow of the
+ * compiler and not the correctness of the compiler.
+ * @since 0.10.0
+ */
+export class MissingRequiredSemanticDataError extends KipperInternalError {
+	constructor(msg: string = "") {
+		super(msg || "Can not analyse AST node due to missing semantic data in children.");
+	}
+}
+
+/**
  * An error that is raised whenever a feature is used that has not been implemented yet.
  * @since 0.6.0
  */

--- a/test/module/core/core-functionality.test.ts
+++ b/test/module/core/core-functionality.test.ts
@@ -23,23 +23,23 @@ describe("Core functionality", () => {
 
 	describe("Comment", () => {
 		it("Single line", async () => {
-			const fileContent = "var x: num = 5;\n// A comment\n print(\"\");";
+			const fileContent = 'var x: num = 5;\n// A comment\n print("");';
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
 			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
 			assert.include(instance.write(), "let x: number = 5;", "Expected variable declaration to be present in output");
-			assert.include(instance.write(), "__kipper.print(\"\");", "Expected print call to be present in output");
+			assert.include(instance.write(), '__kipper.print("");', "Expected print call to be present in output");
 		});
 
 		it("Multi line", async () => {
-			const fileContent = "var x: num = 5;\n/* A comment\n ... \n end of comment */\n print(\"\");";
+			const fileContent = 'var x: num = 5;\n/* A comment\n ... \n end of comment */\n print("");';
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
 			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
 			assert.include(instance.write(), "let x: number = 5;", "Expected variable declaration to be present in output");
-			assert.include(instance.write(), "__kipper.print(\"\");", "Expected print call to be present in output");
+			assert.include(instance.write(), '__kipper.print("");', "Expected print call to be present in output");
 		});
 	});
 

--- a/test/module/core/error-recovery.test.ts
+++ b/test/module/core/error-recovery.test.ts
@@ -108,5 +108,41 @@ describe("Error recovery", () => {
 				assert(result.errors.length === 3, "Expected only one error");
 			});
 		});
+
+		describe("Scope node handling", () => {
+			it("Semantic data present after error", async () => {
+				const result = await new KipperCompiler().compile(
+					"const x: str; x + 5;",
+					activeErrorRecovery,
+				);
+
+				assert.equal(result.errors.length, 2);
+				assert.include(
+					result.errors.map((error) => error.constructor.name),
+					"UndefinedConstantError",
+				);
+				assert.include(
+					result.errors.map((error) => error.constructor.name),
+					"UndefinedReferenceError",
+				);
+			});
+
+			it("Type data present after error", async () => {
+				const result = await new KipperCompiler().compile(
+					"const x: str = '5'['5']; x + 5;",
+					activeErrorRecovery,
+				);
+
+				assert.equal(result.errors.length, 2);
+				assert.include(
+					result.errors.map((error) => error.constructor.name),
+					"InvalidKeyTypeError",
+				);
+				assert.include(
+					result.errors.map((error) => error.constructor.name),
+					"ArithmeticOperationTypeError",
+				);
+			});
+		});
 	});
 });


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it -->

- [x] Bug fix (Non-breaking change which fixes an issue)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

<!-- Explain the reason for this pr, changes and solution briefly. -->

Fixed a bug in the error recovery system, where internal errors were caused due to references to definitions that had a semantic error in their assignment, which led to their analysis failing and references attempting to access invalid data.

Closes #405 

## Summary of Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

- Updated and restructured the error recovery system. View detailed explanation in commit description: a49dfe74ff79b8eb94938fc6ca1312670a00e8d7

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

No. 

<!-- Remove example text! -->

## Detailed Changelog

_Not present for website/docs changes_

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added and remove any header with no item.). -->

### Added

- New errors:
  - `MissingRequiredSemanticDataError`, which is a specific internal error used to indicate that a specified node is missing required semantic data from another node and as a result failed to process itself.
- New classes:
  - `shouldRecoverFromError()` and `handleSemanticError()` in `handle-error.ts`.
  - `AnalysableASTNode.semanticallyAnalyseChildren()`, which semantically analyses all children nodes of the AST node.
  - `AnalysableASTNode.semanticallyTypeCheckChildren()`, which semantically type checks all children nodes of the AST node.
  - `AnalysableASTNode.targetSemanticallyAnalyseChildren()`, which semantically analyses all children nodes of the AST node for the target.
  - `AnalysableASTNode.ensureSemanticallyValid()`, which throws a `MissingRequiredSemanticDataError` in case that the specified node failed during semantic analysis. This is used by other nodes to ensure that the node is valid and its data can be safely accessed.
  - `AnalysableASTNode.ensureTypeSemanticallyValid()`, which throws a `MissingRequiredSemanticDataError` in case that the specified node failed during type checking. This is used by other nodes to ensure that the node is valid and its data can be safely accessed.
 
### Changed

- Renamed `KipperProgramContext.addError` to `reportError`.
- Moved:
  - Function `CompilableASTNode.semanticAnalysis` to `AnalysableASTNode`.
  - Function `CompilableASTNode.semanticTypeChecking` to `AnalysableASTNode`.
  - Function `CompilableASTNode.wrapUpSemanticAnalysis` to `AnalysableASTNode`.
  - Function `CompilableASTNode.recursivelyCheckForWarnings` to `AnalysableASTNode`.
  - Function `CompilableASTNode.recursivelyCheckForWarnings` to `AnalysableASTNode`.
  - Abstract Function `CompilableASTNode.primarySemanticAnalysis` to `AnalysableASTNode`.
  - Abstract Function `CompilableASTNode.primarySemanticTypeChecking` to `AnalysableASTNode`.
  - Abstract Function `CompilableASTNode.checkForWarnings` to `AnalysableASTNode`.
  - Field `CompilableASTNode.programCtx` to `AnalysableASTNode`.
  - Field `CompilableASTNode.compileConfig` to `AnalysableASTNode`. 
  - Field `CompilableASTNode.errors` to `AnalysableASTNode`.
	- Field `CompilableASTNode.addError` to `AnalysableASTNode`.
  - Field `CompilableASTNode.hasFailed` to `AnalysableASTNode`.

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [x] #405 
