### PR TITLE
Implemented built-in function `len()` to get the length of a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ To use development versions of Kipper download the
   ([#372](https://github.com/Luna-Klatzer/Kipper/issues/372)).
 - Support for single-line comments separated by a newline char.
   ([#400](https://github.com/Luna-Klatzer/Kipper/issues/400)).
+- Implemented new built-in function `len()`, which returns the length of a string (In the future also arrays).
+	([#411](https://github.com/Luna-Klatzer/Kipper/issues/411)).
 - New built-in Kipper type `null` and `undefined`, and support for the constant identifier `void`, `null` and
   `undefined`.
 - New Kipper CLI flag `-t/--target` to specify the target to use for a compilation or execution.

--- a/kipper/core/src/compiler/ast/nodes/statements.ts
+++ b/kipper/core/src/compiler/ast/nodes/statements.ts
@@ -39,7 +39,7 @@ import {
 	WhileLoopIterationStatementContext,
 } from "../../parser";
 import { CompilableASTNode } from "../compilable-ast-node";
-import {CheckedType, FunctionScope, LocalScope} from "../../analysis";
+import { CheckedType, LocalScope } from "../../analysis";
 import { KipperNotImplementedError, UnableToDetermineSemanticDataError } from "../../../errors";
 
 /**

--- a/kipper/core/src/compiler/ast/semantic-data/statements.ts
+++ b/kipper/core/src/compiler/ast/semantic-data/statements.ts
@@ -2,7 +2,7 @@
  * Semantic data definitions for all statement AST nodes.
  * @since 0.10.0
  */
-import type { SemanticData, TypeData } from "../ast-node";
+import type { SemanticData } from "../ast-node";
 import type { Expression, FunctionDeclaration, IfStatement, Statement, VariableDeclaration } from "../nodes";
 import type { JmpStatementType } from "../../const";
 

--- a/kipper/core/src/compiler/runtime-built-ins.ts
+++ b/kipper/core/src/compiler/runtime-built-ins.ts
@@ -140,10 +140,10 @@ export const kipperRuntimeBuiltIns: Record<string, BuiltInFunction> = {
 			{
 				identifier: "arrayLike",
 				valueType: "str", // TODO: Implement this for all arrayLike types (At the moment only strings are supported)
-			}
+			},
 		],
 		returnType: "num",
-	}
+	},
 };
 
 /**
@@ -225,5 +225,5 @@ export const kipperInternalBuiltIns: Record<string, InternalFunction> = {
 			},
 		],
 		returnType: "str", // TODO: Implement this for all arrayLike types (At the moment only strings are supported)
-	}
+	},
 };

--- a/kipper/core/src/compiler/runtime-built-ins.ts
+++ b/kipper/core/src/compiler/runtime-built-ins.ts
@@ -134,6 +134,16 @@ export const kipperRuntimeBuiltIns: Record<string, BuiltInFunction> = {
 		],
 		returnType: "void",
 	},
+	len: {
+		identifier: "len",
+		params: [
+			{
+				identifier: "arrayLike",
+				valueType: "str", // TODO: Implement this for all arrayLike types (At the moment only strings are supported)
+			}
+		],
+		returnType: "num",
+	}
 };
 
 /**
@@ -215,5 +225,5 @@ export const kipperInternalBuiltIns: Record<string, InternalFunction> = {
 			},
 		],
 		returnType: "str", // TODO: Implement this for all arrayLike types (At the moment only strings are supported)
-	},
+	}
 };

--- a/kipper/core/src/compiler/target-presets/translation/built-ins-generator.ts
+++ b/kipper/core/src/compiler/target-presets/translation/built-ins-generator.ts
@@ -77,4 +77,12 @@ export abstract class KipperTargetBuiltInGenerator {
 	 * @since 0.10.0
 	 */
 	public abstract print(funcSpec: BuiltInFunction): Promise<Array<TranslatedCodeLine>>;
+
+	/**
+	 * Len function which provides the ability to get the length of an iterable array-like type.
+	 * @param funcSpec The specification for the function. This contains the overall metadata for the function that
+	 * should be followed. This is auto-inserted by the code-generator in {@link KipperProgramContext}.
+	 * @since 0.10.0
+	 */
+	public abstract len(funcSpec: BuiltInFunction): Promise<Array<TranslatedCodeLine>>;
 }

--- a/kipper/target-js/src/built-in-generator.ts
+++ b/kipper/target-js/src/built-in-generator.ts
@@ -62,7 +62,6 @@ export class JavaScriptTargetBuiltInGenerator extends KipperTargetBuiltInGenerat
 		const signature = getJSFunctionSignature(funcSpec);
 		const convArgIdentifier = signature.params[0];
 
-		// Define the function signature and its body. We will simply use 'console.log(msg)' for printing out IO.
 		return genJSFunction(signature, `{ return ${convArgIdentifier} ? 1 : 0; }`);
 	}
 
@@ -72,7 +71,6 @@ export class JavaScriptTargetBuiltInGenerator extends KipperTargetBuiltInGenerat
 		const startIdentifier = signature.params[1];
 		const endIdentifier = signature.params[2];
 
-		// Define the function signature and its body. We will simply use 'console.log(msg)' for printing out IO.
 		return genJSFunction(
 			signature,
 			`{ return ${objLikeIdentifier} ? ${objLikeIdentifier}.slice(${startIdentifier}, ${endIdentifier}) : ${objLikeIdentifier}; }`,
@@ -84,7 +82,6 @@ export class JavaScriptTargetBuiltInGenerator extends KipperTargetBuiltInGenerat
 		const arrayLikeIdentifier = signature.params[0];
 		const indexIdentifier = signature.params[1];
 
-		// Define the function signature and its body. We will simply use 'console.log(msg)' for printing out IO.
 		return genJSFunction(
 			signature,
 			`{ if (${indexIdentifier} >= ${arrayLikeIdentifier}.length) ` +
@@ -99,5 +96,12 @@ export class JavaScriptTargetBuiltInGenerator extends KipperTargetBuiltInGenerat
 
 		// Define the function signature and its body. We will simply use 'console.log(msg)' for printing out IO.
 		return genJSFunction(signature, `{ console.log(${printArgIdentifier}); }`);
+	}
+
+	async len(funcSpec: BuiltInFunction): Promise<Array<TranslatedCodeLine>> {
+		const signature = getJSFunctionSignature(funcSpec);
+		const lenArgIdentifier = signature.params[0];
+
+		return genJSFunction(signature, `{ return ${lenArgIdentifier}.length; }`);
 	}
 }

--- a/kipper/target-js/src/code-generator.ts
+++ b/kipper/target-js/src/code-generator.ts
@@ -269,15 +269,15 @@ export class JavaScriptTargetCodeGenerator extends KipperTargetCodeGenerator {
 		const semanticData = node.getSemanticData();
 
 		// Translate the parts of the for loop statement - Everything except the loop body is optional
-		let forDeclaration: TranslatedExpression | Array<TranslatedCodeLine> = semanticData.forDeclaration ?
-			await semanticData.forDeclaration.translateCtxAndChildren() :
-			[];
-		const condition: TranslatedExpression = semanticData.loopCondition ?
-			await semanticData.loopCondition.translateCtxAndChildren() :
-			[];
-		const forIterationExp: TranslatedExpression = semanticData.forIterationExp ?
-			await semanticData.forIterationExp.translateCtxAndChildren() :
-			[];
+		let forDeclaration: TranslatedExpression | Array<TranslatedCodeLine> = semanticData.forDeclaration
+			? await semanticData.forDeclaration.translateCtxAndChildren()
+			: [];
+		const condition: TranslatedExpression = semanticData.loopCondition
+			? await semanticData.loopCondition.translateCtxAndChildren()
+			: [];
+		const forIterationExp: TranslatedExpression = semanticData.forIterationExp
+			? await semanticData.forIterationExp.translateCtxAndChildren()
+			: [];
 
 		// Apply formatting for the loop body (compound statements are formatted differently)
 		let isCompound = semanticData.loopBody instanceof CompoundStatement;
@@ -292,11 +292,24 @@ export class JavaScriptTargetCodeGenerator extends KipperTargetCodeGenerator {
 		forDeclaration = <TranslatedExpression>(
 			// Variable declarations are already translated as a single line of code and have a semicolon at the end ->
 			// We need to ensure that the semicolon is not added twice
-			semanticData.forDeclaration instanceof VariableDeclaration ? forDeclaration[0] : [...forDeclaration, ";"]
+			(semanticData.forDeclaration instanceof VariableDeclaration ? forDeclaration[0] : [...forDeclaration, ";"])
 		);
 
 		return [
-			["for", " ", "(", ...forDeclaration, " ", ...condition, ";", " ", ...forIterationExp, ")", " ", ...(isCompound ? ["{"] : [])],
+			[
+				"for",
+				" ",
+				"(",
+				...forDeclaration,
+				" ",
+				...condition,
+				";",
+				" ",
+				...forIterationExp,
+				")",
+				" ",
+				...(isCompound ? ["{"] : []),
+			],
 			...loopBody,
 			isCompound ? ["}"] : [],
 		];

--- a/kipper/target-ts/src/built-in-generator.ts
+++ b/kipper/target-ts/src/built-in-generator.ts
@@ -4,7 +4,7 @@
  * @since 0.8.0
  */
 import type { BuiltInFunction, InternalFunction, TranslatedCodeLine } from "@kipper/core";
-import { JavaScriptTargetBuiltInGenerator } from "@kipper/target-js";
+import {genJSFunction, getJSFunctionSignature, JavaScriptTargetBuiltInGenerator} from "@kipper/target-js";
 import { getTSFunctionSignature, createTSFunctionSignature, getTypeScriptBuiltInIdentifier } from "./tools";
 import { KipperCompilableType } from "@kipper/core";
 
@@ -102,5 +102,12 @@ export class TypeScriptTargetBuiltInGenerator extends JavaScriptTargetBuiltInGen
 
 		// Define the function signature and its body. We will simply use 'console.log(msg)' for printing out IO.
 		return getTSFunction(signature, `{ console.log(${printArgIdentifier}); }`);
+	}
+
+	async len(funcSpec: BuiltInFunction): Promise<Array<TranslatedCodeLine>> {
+		const signature = getTSFunctionSignature(funcSpec);
+		const lenArgIdentifier = signature.params[0].identifier;
+
+		return getTSFunction(signature, `{ return ${lenArgIdentifier}.length; }`);
 	}
 }

--- a/kipper/target-ts/src/built-in-generator.ts
+++ b/kipper/target-ts/src/built-in-generator.ts
@@ -4,7 +4,7 @@
  * @since 0.8.0
  */
 import type { BuiltInFunction, InternalFunction, TranslatedCodeLine } from "@kipper/core";
-import {genJSFunction, getJSFunctionSignature, JavaScriptTargetBuiltInGenerator} from "@kipper/target-js";
+import { JavaScriptTargetBuiltInGenerator } from "@kipper/target-js";
 import { getTSFunctionSignature, createTSFunctionSignature, getTypeScriptBuiltInIdentifier } from "./tools";
 import { KipperCompilableType } from "@kipper/core";
 

--- a/test/module/core/built-in-functions.test.ts
+++ b/test/module/core/built-in-functions.test.ts
@@ -1,0 +1,125 @@
+import { KipperJavaScriptTarget } from "@kipper/target-js";
+import { KipperTypeScriptTarget } from "@kipper/target-ts";
+import { CompileConfig, KipperCompiler, KipperCompileResult, KipperError } from "@kipper/core";
+import { assert } from "chai";
+import * as ts from "typescript";
+import { testPrintOutput } from "./core-functionality.test";
+
+/**
+ * Returns the JavaScript code from the given Kipper compilation result.
+ *
+ * This will automatically handle transpiling TypeScript code to JavaScript, if the Kipper compiler generated TypeScript
+ * code.
+ * @param result The Kipper compilation result.
+ */
+function getJSEvalCode(result: KipperCompileResult): string {
+	let code = result.write();
+	if (result.programCtx.target instanceof KipperTypeScriptTarget) {
+		code = ts.transpile(code);
+	}
+	return code;
+}
+
+describe("Built-in functions", () => {
+	const compiler = new KipperCompiler();
+	const tests = [new KipperJavaScriptTarget(), new KipperTypeScriptTarget()];
+
+	tests.forEach((target) => {
+		const config: CompileConfig = {
+			abortOnFirstError: true,
+			target: target,
+		};
+
+		describe(`print (${target.fileExtension})`, () => {
+			it("Should error with no argument", async () => {
+				const fileContent = "print();";
+				try {
+					await compiler.compile(fileContent, config);
+				} catch (e) {
+					assert((<KipperError>e).constructor.name === "InvalidAmountOfArgumentsError", "Expected different error");
+					assert((<KipperError>e).name === "ArgumentError", "Expected different error");
+					return;
+				}
+				assert.fail("Expected 'InvalidAmountOfArgumentsError'");
+			});
+
+			it("Should error with more than one argument", async () => {
+				const fileContent = "print('1', '2');";
+				try {
+					await compiler.compile(fileContent, config);
+				} catch (e) {
+					assert((<KipperError>e).constructor.name === "InvalidAmountOfArgumentsError", "Expected different error");
+					assert((<KipperError>e).name === "ArgumentError", "Expected different error");
+					return;
+				}
+				assert.fail("Expected 'InvalidAmountOfArgumentsError'");
+			});
+
+			it("Should error with an invalid argument type", async () => {
+				const fileContent = "print(1);";
+				try {
+					await compiler.compile(fileContent, config);
+				} catch (e) {
+					assert((<KipperError>e).constructor.name === "ArgumentTypeError", "Expected different error");
+					assert((<KipperError>e).name === "TypeError", "Expected different error");
+					return;
+				}
+				assert.fail("Expected 'InvalidAmountOfArgumentsError'");
+			});
+
+			it("Should print a string", async () => {
+				const fileContent = "print('Hello, world!');";
+				const result: KipperCompileResult = await compiler.compile(fileContent, config);
+
+				let code: string = getJSEvalCode(result);
+				testPrintOutput((out) => assert.equal(out, "Hello, world!"), code);
+			});
+		});
+
+		describe(`len (${target.fileExtension})`, () => {
+			it("Should error with no argument", async () => {
+				const fileContent = "len();";
+				try {
+					await compiler.compile(fileContent, config);
+				} catch (e) {
+					assert((<KipperError>e).constructor.name === "InvalidAmountOfArgumentsError", "Expected different error");
+					assert((<KipperError>e).name === "ArgumentError", "Expected different error");
+					return;
+				}
+				assert.fail("Expected 'InvalidAmountOfArgumentsError'");
+			});
+
+			it("Should error with more than one argument", async () => {
+				const fileContent = "len('1', '2');";
+				try {
+					await compiler.compile(fileContent, config);
+				} catch (e) {
+					assert((<KipperError>e).constructor.name === "InvalidAmountOfArgumentsError", "Expected different error");
+					assert((<KipperError>e).name === "ArgumentError", "Expected different error");
+					return;
+				}
+				assert.fail("Expected 'InvalidAmountOfArgumentsError'");
+			});
+
+			it("Should error with an invalid argument type", async () => {
+				const fileContent = "len(1);";
+				try {
+					await compiler.compile(fileContent, config);
+				} catch (e) {
+					assert((<KipperError>e).constructor.name === "ArgumentTypeError", "Expected different error");
+					assert((<KipperError>e).name === "TypeError", "Expected different error");
+					return;
+				}
+				assert.fail("Expected 'InvalidAmountOfArgumentsError'");
+			});
+
+			it("Should return the length of a string", async () => {
+				const fileContent = "print(len('Hello, world!') as str);";
+				const result: KipperCompileResult = await compiler.compile(fileContent, config);
+
+				let code: string = getJSEvalCode(result);
+				testPrintOutput((out) => assert.equal(out, "13"), code);
+			});
+		});
+	});
+});

--- a/test/module/core/compiler.test.ts
+++ b/test/module/core/compiler.test.ts
@@ -45,16 +45,16 @@ describe("KipperCompiler", () => {
 
 	describe("constructor", () => {
 		it("Empty Construction", () => {
-			let instance = new KipperCompiler();
-			assert(instance, "Has to be undefined");
-			assert(instance.logger !== undefined, "Set init value has to be equal to the property");
+			let result = new KipperCompiler();
+			assert(result, "Has to be undefined");
+			assert(result.logger !== undefined, "Set init value has to be equal to the property");
 		});
 
 		it("Construction with logger", () => {
 			let logger = new KipperLogger(() => {});
-			let instance = new KipperCompiler(logger);
-			assert(instance, "Has to be not undefined");
-			assert(instance.logger === logger, "Loggers must match");
+			let result = new KipperCompiler(logger);
+			assert(result, "Has to be not undefined");
+			assert(result.logger === logger, "Loggers must match");
 		});
 
 		it("Constructor with logging emitHandler", () => {
@@ -64,18 +64,18 @@ describe("KipperCompiler", () => {
 				emitHandlerWasCalled = true;
 			};
 			let logger = new KipperLogger(emitHandler);
-			let instance = new KipperCompiler(logger);
+			let result = new KipperCompiler(logger);
 
-			assert(instance, "Has to be not undefined");
-			assert(instance.logger === logger, "Set init value has to not be overwritten by 'avoidLogging'");
+			assert(result, "Has to be not undefined");
+			assert(result.logger === logger, "Set init value has to not be overwritten by 'avoidLogging'");
 			assert(logger.emitHandler === emitHandler, "Set 'emitHandler' has to match");
-			assert(instance.logger.emitHandler === emitHandler, "Set 'emitHandler' has to match");
+			assert(result.logger.emitHandler === emitHandler, "Set 'emitHandler' has to match");
 
 			logger.log(LogLevel.INFO, "This is a message");
 			assert(emitHandlerWasCalled, "Emit Handler should have been called");
 
 			emitHandlerWasCalled = false;
-			instance.logger.log(LogLevel.INFO, "This is a message");
+			result.logger.log(LogLevel.INFO, "This is a message");
 			assert(emitHandlerWasCalled, "Emit Handler should have been called");
 		});
 	});
@@ -214,67 +214,56 @@ describe("KipperCompiler", () => {
 			tests.forEach((target) => {
 				it(`Sample program (${target.fileExtension})`, async () => {
 					const fileContent = (await fs.readFile(mainFile, "utf8" as BufferEncoding)).toString();
-					const stream = new KipperParseStream({ stringContent: fileContent });
-					const instance: KipperCompileResult = await compiler.compile(stream, { target: target });
+					const result: KipperCompileResult = await compiler.compile(fileContent, { target: target });
 
-					assert(instance.programCtx);
-					assert(instance.programCtx.internals);
-					assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-					assert(instance.programCtx.stream === stream, "Expected matching streams");
-					assert(instance.programCtx.globalScope.entries.size === 4, "Expected four global scope entries");
-					assert(instance.programCtx.builtIns.length === 1, "Expected a single global function");
+					assert.isDefined(result.programCtx);
+					assert(result.programCtx.internals);
+					assert.equal(result.programCtx.errors.length, 0, "Expected no compilation errors");
+					assert.equal(result.programCtx.globalScope.entries.size, 4, "Expected four global scope entries");
 				});
 
 				it(`Arithmetics (${target.fileExtension})`, async () => {
 					const fileContent = (await fs.readFile(arithmeticsFile, "utf8" as BufferEncoding)).toString();
-					const stream = new KipperParseStream({ stringContent: fileContent });
-					const instance: KipperCompileResult = await compiler.compile(stream, { target: target });
+					const result: KipperCompileResult = await compiler.compile(fileContent, { target: target });
 
-					assert(instance.programCtx);
-					assert(instance.programCtx.internals);
-					assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-					assert(instance.programCtx.stream === stream, "Expected matching streams");
-					assert(instance.programCtx.globalScope.entries.size === 0, "Expected no global scope entries");
-					assert(instance.write().includes(fileContent), "Expected compiled code to not change");
+					assert.isDefined(result.programCtx);
+					assert.isDefined(result.programCtx.internals);
+					assert.equal(result.programCtx.errors.length, 0, "Expected no compilation errors");
+					assert.equal(result.programCtx.globalScope.entries.size, 0, "Expected no global scope entries");
+					assert.include(result.write(), fileContent, "Expected compiled code to not change");
 				});
 
 				it(`Variable Declaration (${target.fileExtension})`, async () => {
 					const fileContent = (await fs.readFile(variableDeclarationFile, "utf8" as BufferEncoding)).toString();
-					const stream = new KipperParseStream({ stringContent: fileContent });
-					const instance: KipperCompileResult = await compiler.compile(stream, { target: target });
+					const result: KipperCompileResult = await compiler.compile(fileContent, { target: target });
 
-					assert(instance.programCtx);
-					assert(instance.programCtx.internals);
-					assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-					assert(instance.programCtx.stream === stream, "Expected matching streams");
-					assert(instance.programCtx.globalScope.entries.size === 1, "Expected one global scope entry");
+					assert.isDefined(result.programCtx);
+					assert.isDefined(result.programCtx.internals);
+					assert.equal(result.programCtx.errors.length, 0, "Expected no compilation errors");
+					assert.equal(result.programCtx.globalScope.entries.size, 1, "Expected one global scope entry");
 				});
 
 				it(`Nested scopes (${target.fileExtension})`, async () => {
 					const fileContent = (await fs.readFile(nestedScopesFile, "utf8" as BufferEncoding)).toString();
-					const stream = new KipperParseStream({ stringContent: fileContent });
-					const instance: KipperCompileResult = await compiler.compile(stream, { target: target });
+					const result: KipperCompileResult = await compiler.compile(fileContent, { target: target });
 
-					assert(instance.programCtx);
-					assert(instance.programCtx.internals);
-					assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-					assert(instance.programCtx.stream === stream, "Expected matching streams");
-					assert(instance.programCtx.globalScope.entries.size === 4, "Expected four global scope entries");
+					assert.isDefined(result.programCtx);
+					assert.isDefined(result.programCtx.internals);
+					assert.equal(result.programCtx.errors.length, 0, "Expected no compilation errors");
+					assert.equal(result.programCtx.globalScope.entries.size, 4, "Expected four global scope entries");
 				});
 
 				it(`Single Function call (${target.fileExtension})`, async () => {
 					const fileContent = (await fs.readFile(singleFunctionFile, "utf8" as BufferEncoding)).toString();
-					const stream = new KipperParseStream({ stringContent: fileContent });
-					const instance: KipperCompileResult = await compiler.compile(stream, { target: target });
+					const result: KipperCompileResult = await compiler.compile(fileContent, { target: target });
 
-					assert(instance.programCtx);
-					assert(instance.programCtx.internals);
-					assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-					assert(instance.programCtx.stream === stream, "Expected matching streams");
-					assert(instance.programCtx.globalScope.entries.size === 0, "Expected no global scope entries");
+					assert.isDefined(result.programCtx);
+					assert.isDefined(result.programCtx.internals);
+					assert.equal(result.programCtx.errors.length, 0, "Expected no compilation errors");
+					assert.equal(result.programCtx.globalScope.entries.size, 0, "Expected no global scope entries");
 
 					// Compile the program to JavaScript and evaluate it
-					const jsCode = ts.transpile(instance.write());
+					const jsCode = ts.transpile(result.write());
 
 					// Overwrite built-in to access output
 					const prevLog = console.log;
@@ -292,127 +281,103 @@ describe("KipperCompiler", () => {
 
 				it(`Multi Function call (${target.fileExtension})`, async () => {
 					const fileContent = (await fs.readFile(multiFunctionFile, "utf8" as BufferEncoding)).toString();
-					const stream = new KipperParseStream({ stringContent: fileContent });
-					const instance: KipperCompileResult = await compiler.compile(stream, { target: target });
+					const result: KipperCompileResult = await compiler.compile(fileContent, { target: target });
 
-					assert(instance.programCtx);
-					assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-					assert(instance.programCtx.stream === stream, "Expected matching streams");
-					assert(instance.programCtx.globalScope.entries.size === 0, "Expected no global scope entries");
+					assert(result.programCtx);
+					assert.equal(result.programCtx.errors.length, 0, "Expected no compilation errors");
+					assert.equal(result.programCtx.globalScope.entries.size, 0, "Expected no global scope entries");
 
 					// Compile the program to JavaScript and evaluate it
-					const jsCode = ts.transpile(instance.write());
-					testPrintOutput(
-						(message: any) => {
-							// Assert that the output is "Hello world!"
-							assert(["Hello", "World", "!"].find((val) => val === message) !== undefined);
-						},
-						jsCode
-					);
+					const jsCode = ts.transpile(result.write());
+					testPrintOutput((message: any) => {
+						// Assert that the output is "Hello world!"
+						assert(["Hello", "World", "!"].find((val) => val === message) !== undefined);
+					}, jsCode);
 				});
 
 				it(`Single Function definition (${target.fileExtension})`, async () => {
 					const fileContent = (await fs.readFile(singleFunctionDefinitionFile, "utf8" as BufferEncoding)).toString();
-					const stream = new KipperParseStream({ stringContent: fileContent });
-					const instance: KipperCompileResult = await compiler.compile(stream, { target: target });
+					const result: KipperCompileResult = await compiler.compile(fileContent, { target: target });
 
-					assert(instance.programCtx);
-					assert(instance.programCtx.internals);
-					assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-					assert(instance.programCtx.stream === stream, "Expected matching streams");
-					assert(instance.programCtx.globalScope.entries.size === 1, "Expected one global scope entry");
+					assert.isDefined(result.programCtx);
+					assert.isDefined(result.programCtx.internals);
+					assert.equal(result.programCtx.errors.length, 0, "Expected no compilation errors");
+					assert.equal(result.programCtx.globalScope.entries.size, 1, "Expected one global scope entry");
 				});
 
 				it(`Multi Function definition (${target.fileExtension})`, async () => {
 					const fileContent = (await fs.readFile(multiFunctionDefinitionFile, "utf8" as BufferEncoding)).toString();
-					const stream = new KipperParseStream({ stringContent: fileContent });
-					const instance: KipperCompileResult = await compiler.compile(stream, { target: target });
+					const result: KipperCompileResult = await compiler.compile(fileContent, { target: target });
 
-					assert(instance.programCtx);
-					assert(instance.programCtx.internals);
-					assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-					assert(instance.programCtx.stream === stream, "Expected matching streams");
-					assert(instance.programCtx.globalScope.entries.size === 3, "Expected three global scope entries");
+					assert.isDefined(result.programCtx);
+					assert.isDefined(result.programCtx.internals);
+					assert.equal(result.programCtx.errors.length, 0, "Expected no compilation errors");
+					assert.equal(result.programCtx.globalScope.entries.size, 3, "Expected three global scope entries");
 				});
 
 				it(`Function call argument (${target.fileExtension})`, async () => {
 					const fileContent = (await fs.readFile(addedHelloWorldFile, "utf8" as BufferEncoding)).toString();
-					const stream = new KipperParseStream({ stringContent: fileContent });
-					const instance: KipperCompileResult = await compiler.compile(stream, { target: target });
+					const result: KipperCompileResult = await compiler.compile(fileContent, { target: target });
 
-					assert(instance.programCtx);
-					assert(instance.programCtx.internals);
-					assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-					assert(instance.programCtx.stream === stream, "Expected matching streams");
-					assert(instance.programCtx.globalScope.entries.size === 0, "Expected no global scope entries");
+					assert.isDefined(result.programCtx);
+					assert.isDefined(result.programCtx.internals);
+					assert.equal(result.programCtx.errors.length, 0, "Expected no compilation errors");
+					assert.equal(result.programCtx.globalScope.entries.size, 0, "Expected no global scope entries");
 
 					// Compile the program to JavaScript and evaluate it
-					const jsCode = ts.transpile(instance.write());
-					testPrintOutput(
-						(message: any) => {
-							// Assert that the output is "Hello world!"
-							assert(message === "Hello world!")
-						},
-						jsCode
-					);
+					const jsCode = ts.transpile(result.write());
+					testPrintOutput((message: any) => {
+						// Assert that the output is "Hello world!"
+						assert(message === "Hello world!");
+					}, jsCode);
 				});
 
 				it(`Variable assignment (${target.fileExtension})`, async () => {
 					const fileContent = (await fs.readFile(assignmentArithmeticsFile, "utf8" as BufferEncoding)).toString();
-					const stream = new KipperParseStream({ stringContent: fileContent });
-					const instance: KipperCompileResult = await compiler.compile(stream, { target: target });
+					const result: KipperCompileResult = await compiler.compile(fileContent, { target: target });
 
-					assert(instance.programCtx);
-					assert(instance.programCtx.internals);
-					assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-					assert(instance.programCtx.stream === stream, "Expected matching streams");
-					assert(instance.programCtx.globalScope.entries.size === 1, "Expected one global scope entry");
+					assert.isDefined(result.programCtx);
+					assert.isDefined(result.programCtx.internals);
+					assert.equal(result.programCtx.errors.length, 0, "Expected no compilation errors");
+					assert.equal(result.programCtx.globalScope.entries.size, 1, "Expected one global scope entry");
 
 					// Compile the program to JavaScript and evaluate it
-					const jsCode = ts.transpile(instance.write());
-					testPrintOutput(
-						(message: any) => {
-							assert(message === "45678");
-						},
-						jsCode
-					);
+					const jsCode = ts.transpile(result.write());
+					testPrintOutput((message: any) => {
+						assert(message === "45678");
+					}, jsCode);
 				});
 
 				it(`Assign (${target.fileExtension})`, async () => {
 					const fileContent = (await fs.readFile(assignFile, "utf8" as BufferEncoding)).toString();
-					const stream = new KipperParseStream({ stringContent: fileContent });
-					const instance: KipperCompileResult = await compiler.compile(stream, { target: target });
+					const result: KipperCompileResult = await compiler.compile(fileContent, { target: target });
 
-					assert(instance.programCtx);
-					assert(instance.programCtx.internals);
-					assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-					assert(instance.programCtx.stream === stream, "Expected matching streams");
-					assert(instance.programCtx.globalScope.entries.size === 1, "Expected one global scope entry");
+					assert.isDefined(result.programCtx);
+					assert.isDefined(result.programCtx.internals);
+					assert.equal(result.programCtx.errors.length, 0, "Expected no compilation errors");
+					assert.equal(result.programCtx.globalScope.entries.size, 1, "Expected one global scope entry");
 				});
 
 				it(`Bool (${target.fileExtension})`, async () => {
 					const fileContent = (await fs.readFile(boolFile, "utf8" as BufferEncoding)).toString();
-					const stream = new KipperParseStream({ stringContent: fileContent });
-					const instance: KipperCompileResult = await compiler.compile(stream, { target: target });
+					const result: KipperCompileResult = await compiler.compile(fileContent, { target: target });
 
-					assert(instance.programCtx);
-					assert(instance.programCtx.internals);
-					assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-					assert(instance.programCtx.stream === stream, "Expected matching streams");
-					assert(instance.programCtx.globalScope.entries.size === 2, "Expected two global scope entries");
+					assert.isDefined(result.programCtx);
+					assert.isDefined(result.programCtx.internals);
+					assert.equal(result.programCtx.errors.length, 0, "Expected no compilation errors");
+					assert.equal(result.programCtx.globalScope.entries.size, 2, "Expected two global scope entries");
 				});
 
 				it(`Type conversion (${target.fileExtension})`, async () => {
 					const fileContent = (await fs.readFile(typeConversionFile, "utf8" as BufferEncoding)).toString();
-					const stream = new KipperParseStream({ stringContent: fileContent });
-					const instance: KipperCompileResult = await compiler.compile(stream, { target: target });
+					const result: KipperCompileResult = await compiler.compile(fileContent, { target: target });
 
-					assert(instance.programCtx);
-					assert(instance.programCtx.internals);
-					assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-					assert(instance.programCtx.globalScope.entries.size === 4, "Expected four global scope entries");
+					assert.isDefined(result.programCtx);
+					assert.isDefined(result.programCtx.internals);
+					assert.equal(result.programCtx.errors.length, 0, "Expected no compilation errors");
+					assert.equal(result.programCtx.globalScope.entries.size, 4, "Expected four global scope entries");
 
-					const code = instance.write();
+					const code = result.write();
 					assert(code);
 					assert(code.includes(getTypeScriptBuiltInIdentifier("strToNum")));
 					assert(code.includes(getTypeScriptBuiltInIdentifier("numToStr")));
@@ -422,15 +387,14 @@ describe("KipperCompiler", () => {
 
 				it(`Expression statements (${target.fileExtension})`, async () => {
 					const fileContent = (await fs.readFile(expressionStatementsFile, "utf8" as BufferEncoding)).toString();
-					const stream = new KipperParseStream({ stringContent: fileContent });
-					const instance: KipperCompileResult = await compiler.compile(stream, { target: target });
+					const result: KipperCompileResult = await compiler.compile(fileContent, { target: target });
 
-					assert(instance.programCtx);
-					assert(instance.programCtx.internals);
-					assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-					assert(instance.programCtx.globalScope.entries.size === 3, "Expected three global scope entries");
+					assert.isDefined(result.programCtx);
+					assert.isDefined(result.programCtx.internals);
+					assert.equal(result.programCtx.errors.length, 0, "Expected no compilation errors");
+					assert.equal(result.programCtx.globalScope.entries.size, 3, "Expected three global scope entries");
 
-					const code = instance.write();
+					const code = result.write();
 					assert(code);
 					assert(code.includes(getTypeScriptBuiltInIdentifier("print")));
 					assert(code.includes(getTypeScriptBuiltInIdentifier("numToStr")));
@@ -438,90 +402,72 @@ describe("KipperCompiler", () => {
 
 				it(`Tangled expressions (${target.fileExtension})`, async () => {
 					const fileContent = (await fs.readFile(tangledExpressionsFile, "utf8" as BufferEncoding)).toString();
-					const stream = new KipperParseStream({ stringContent: fileContent });
-					const instance: KipperCompileResult = await compiler.compile(stream, { target: target });
+					const result: KipperCompileResult = await compiler.compile(fileContent, { target: target });
 
-					assert(instance.programCtx);
-					assert(instance.programCtx.internals);
-					assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-					assert(instance.programCtx.stream === stream, "Expected matching streams");
-					assert(instance.programCtx.globalScope.entries.size === 0, "Expected no global scope entries");
+					assert.isDefined(result.programCtx);
+					assert.isDefined(result.programCtx.internals);
+					assert.equal(result.programCtx.errors.length, 0, "Expected no compilation errors");
+					assert.equal(result.programCtx.globalScope.entries.size, 0, "Expected no global scope entries");
 
 					// Compile the program to JavaScript and evaluate it
-					const jsCode = ts.transpile(instance.write());
-					testPrintOutput(
-						(message: any) => {
-							assert(["Hello world!", "485", "72", "955"].find((val) => val === message));
-						},
-						jsCode
-					);
+					const jsCode = ts.transpile(result.write());
+					testPrintOutput((message: any) => {
+						assert(["Hello world!", "485", "72", "955"].find((val) => val === message));
+					}, jsCode);
 				});
 
 				it(`If statements (${target.fileExtension})`, async () => {
 					const fileContent = (await fs.readFile(ifStatementsFile, "utf8" as BufferEncoding)).toString();
-					const stream = new KipperParseStream({ stringContent: fileContent });
-					const instance: KipperCompileResult = await compiler.compile(stream, { target: target });
+					const result: KipperCompileResult = await compiler.compile(fileContent, { target: target });
 
-					assert(instance.programCtx);
-					assert(instance.programCtx.internals);
-					assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-					assert(instance.programCtx.stream === stream, "Expected matching streams");
-					assert(instance.programCtx.globalScope.entries.size === 0, "Expected no global scope entries");
+					assert.isDefined(result.programCtx);
+					assert.isDefined(result.programCtx.internals);
+					assert.equal(result.programCtx.errors.length, 0, "Expected no compilation errors");
+					assert.equal(result.programCtx.globalScope.entries.size, 0, "Expected no global scope entries");
 
-					const code = instance.write();
+					const code = result.write();
 					assert(code);
 					assert(code.includes(getTypeScriptBuiltInIdentifier("print")));
 					assert(code.includes(getTypeScriptBuiltInIdentifier("numToStr")));
 
 					// Compile the program to JavaScript and evaluate it
-					const jsCode = ts.transpile(instance.write());
-					testPrintOutput(
-						(message: any) => {
+					const jsCode = ts.transpile(result.write());
+					testPrintOutput((message: any) => {
 						assert("Hello world!" === message, "Expected 'Hello world!'");
-						},
-						jsCode
-					);
+					}, jsCode);
 				});
 
 				it(`While loop (${target.fileExtension})`, async () => {
 					const fileContent = (await fs.readFile(whileLoopFile, "utf8" as BufferEncoding)).toString();
-					const stream = new KipperParseStream({ stringContent: fileContent });
-					const instance: KipperCompileResult = await compiler.compile(stream, { target: target });
+					const result: KipperCompileResult = await compiler.compile(fileContent, { target: target });
 
-					const code = instance.write();
+					const code = result.write();
 					assert(code);
 					assert(code.includes(getTypeScriptBuiltInIdentifier("print")));
 					assert(code.includes(getTypeScriptBuiltInIdentifier("numToStr")));
 
 					// Compile the program to JavaScript and evaluate it
-					const jsCode = ts.transpile(instance.write());
-					testPrintOutput(
-						(message: any) => {
-							assert("10" === message, "Expected '10'");
-						},
-						jsCode
-					);
+					const jsCode = ts.transpile(result.write());
+					testPrintOutput((message: any) => {
+						assert("10" === message, "Expected '10'");
+					}, jsCode);
 				});
 
 				it(`For loop (${target.fileExtension})`, async () => {
 					const fileContent = (await fs.readFile(forLoopFile, "utf8" as BufferEncoding)).toString();
-					const stream = new KipperParseStream({ stringContent: fileContent });
-					const instance: KipperCompileResult = await compiler.compile(stream, { target: target });
+					const result: KipperCompileResult = await compiler.compile(fileContent, { target: target });
 
-					const code = instance.write();
+					const code = result.write();
 					assert(code);
 					assert(code.includes(getTypeScriptBuiltInIdentifier("print")));
 					assert(code.includes(getTypeScriptBuiltInIdentifier("numToStr")));
 
 					// Compile the program to JavaScript and evaluate it
 					let i = 0;
-					const jsCode = ts.transpile(instance.write());
-					testPrintOutput(
-						(message: any) => {
-							assert(String(i++) === message, `Expected '${String(i - 1)}' from for-loop`);
-						},
-						jsCode
-					);
+					const jsCode = ts.transpile(result.write());
+					testPrintOutput((message: any) => {
+						assert(String(i++) === message, `Expected '${String(i - 1)}' from for-loop`);
+					}, jsCode);
 				});
 			});
 		});

--- a/test/module/core/core-functionality.test.ts
+++ b/test/module/core/core-functionality.test.ts
@@ -580,7 +580,11 @@ describe("Core functionality", () => {
 			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
 
 			const code = instance.write();
-			assert.include(code, "for (let i: number = 0; i < 10; i += 1) \n  if (i !== 10) {\n    x = i;\n  }", "Invalid TypeScript code");
+			assert.include(
+				code,
+				"for (let i: number = 0; i < 10; i += 1) \n  if (i !== 10) {\n    x = i;\n  }",
+				"Invalid TypeScript code",
+			);
 
 			const jsCode = ts.transpile(code);
 			testPrintOutput((message: any) => assert.equal(message, "9", "Expected different output"), jsCode);
@@ -746,6 +750,4 @@ describe("Core functionality", () => {
 			testPrintOutput((message: any) => assert.equal(message, "6", "Expected different result"), jsCode);
 		});
 	});
-
-
 });

--- a/test/module/core/errors/kipper-error.ts
+++ b/test/module/core/errors/kipper-error.ts
@@ -8,7 +8,11 @@ describe("KipperError", () => {
 		try {
 			result = await new KipperCompiler().compile('var i: str = "4";\n var i: str = "4";', defaultConfig);
 		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "IdentifierAlreadyUsedByVariableError", "Expected proper error");
+			assert.equal(
+				(<KipperError>e).constructor.name,
+				"IdentifierAlreadyUsedByVariableError",
+				"Expected different error",
+			);
 			ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 			ensureTracebackDataExists(<KipperError>e);
 			assert.equal(

--- a/test/module/core/errors/semantic-errors/builtin-overwrite.ts
+++ b/test/module/core/errors/semantic-errors/builtin-overwrite.ts
@@ -19,7 +19,7 @@ describe("BuiltInOverwriteError", () => {
 				try {
 					result = await new KipperCompiler().compile(`var ${test.i}: num = 4;`, config);
 				} catch (e) {
-					assert.equal((<KipperError>e).constructor.name, "BuiltInOverwriteError", "Expected proper error");
+					assert.equal((<KipperError>e).constructor.name, "BuiltInOverwriteError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;
@@ -32,7 +32,7 @@ describe("BuiltInOverwriteError", () => {
 				try {
 					result = await new KipperCompiler().compile(`def ${test.i}() -> void {};`, config);
 				} catch (e) {
-					assert.equal((<KipperError>e).constructor.name, "BuiltInOverwriteError", "Expected proper error");
+					assert.equal((<KipperError>e).constructor.name, "BuiltInOverwriteError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;
@@ -45,7 +45,7 @@ describe("BuiltInOverwriteError", () => {
 				try {
 					result = await new KipperCompiler().compile(`def f(${test.i}: num) -> void {};`, config);
 				} catch (e) {
-					assert.equal((<KipperError>e).constructor.name, "BuiltInOverwriteError", "Expected proper error");
+					assert.equal((<KipperError>e).constructor.name, "BuiltInOverwriteError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;
@@ -60,7 +60,7 @@ describe("BuiltInOverwriteError", () => {
 				try {
 					result = await new KipperCompiler().compile(`{ var ${test.i}: num = 4; }`, config);
 				} catch (e) {
-					assert.equal((<KipperError>e).constructor.name, "BuiltInOverwriteError", "Expected proper error");
+					assert.equal((<KipperError>e).constructor.name, "BuiltInOverwriteError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;
@@ -75,7 +75,7 @@ describe("BuiltInOverwriteError", () => {
 				try {
 					result = await new KipperCompiler().compile(`{ { var ${test.i}: num = 4; } }`, config);
 				} catch (e) {
-					assert.equal((<KipperError>e).constructor.name, "BuiltInOverwriteError", "Expected proper error");
+					assert.equal((<KipperError>e).constructor.name, "BuiltInOverwriteError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;

--- a/test/module/core/errors/semantic-errors/identifier-already-used-by-parameter.ts
+++ b/test/module/core/errors/semantic-errors/identifier-already-used-by-parameter.ts
@@ -8,7 +8,7 @@ describe("IdentifierAlreadyUsedByParameterError", () => {
 		try {
 			result = await new KipperCompiler().compile("def f(x: num, x: num) -> void {};", defaultConfig);
 		} catch (e) {
-			assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByParameterError", "Expected proper error");
+			assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByParameterError", "Expected different error");
 			ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 			ensureTracebackDataExists(<KipperError>e);
 			return;
@@ -22,7 +22,10 @@ describe("IdentifierAlreadyUsedByParameterError", () => {
 			try {
 				result = await new KipperCompiler().compile("def f(x: num) -> void { var x: num = 4; };", defaultConfig);
 			} catch (e) {
-				assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByParameterError", "Expected proper error");
+				assert(
+					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByParameterError",
+					"Expected different error",
+				);
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -37,7 +40,10 @@ describe("IdentifierAlreadyUsedByParameterError", () => {
 			try {
 				result = await new KipperCompiler().compile("def f(x: num) -> void { { var x: num = 4; } };", defaultConfig);
 			} catch (e) {
-				assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByParameterError", "Expected proper error");
+				assert(
+					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByParameterError",
+					"Expected different error",
+				);
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;

--- a/test/module/core/errors/semantic-errors/identifier-already-used-by-variable.ts
+++ b/test/module/core/errors/semantic-errors/identifier-already-used-by-variable.ts
@@ -9,7 +9,10 @@ describe("IdentifierAlreadyUsedByVariableError", () => {
 			try {
 				result = await new KipperCompiler().compile("var x: num = 5; var x: num = 5;", defaultConfig);
 			} catch (e) {
-				assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError", "Expected proper error");
+				assert(
+					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError",
+					"Expected different error",
+				);
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -22,7 +25,10 @@ describe("IdentifierAlreadyUsedByVariableError", () => {
 			try {
 				result = await new KipperCompiler().compile("var x: num; def x() -> void {};", defaultConfig);
 			} catch (e) {
-				assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError", "Expected proper error");
+				assert(
+					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError",
+					"Expected different error",
+				);
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -35,7 +41,10 @@ describe("IdentifierAlreadyUsedByVariableError", () => {
 			try {
 				result = await new KipperCompiler().compile("var x: num; def f(x: num) -> void {};", defaultConfig);
 			} catch (e) {
-				assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError", "Expected proper error");
+				assert(
+					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError",
+					"Expected different error",
+				);
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -50,7 +59,10 @@ describe("IdentifierAlreadyUsedByVariableError", () => {
 			try {
 				result = await new KipperCompiler().compile("{ var x: num = 5; var x: num = 5; }", defaultConfig);
 			} catch (e) {
-				assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError", "Expected proper error");
+				assert(
+					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError",
+					"Expected different error",
+				);
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -67,7 +79,10 @@ describe("IdentifierAlreadyUsedByVariableError", () => {
 			try {
 				result = await new KipperCompiler().compile("var x: num = 5; { var x: num = 5; }", defaultConfig);
 			} catch (e) {
-				assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError", "Expected proper error");
+				assert(
+					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError",
+					"Expected different error",
+				);
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -84,7 +99,10 @@ describe("IdentifierAlreadyUsedByVariableError", () => {
 			try {
 				result = await new KipperCompiler().compile("var x: num = 5; { { var x: num = 5; } }", defaultConfig);
 			} catch (e) {
-				assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError", "Expected proper error");
+				assert(
+					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError",
+					"Expected different error",
+				);
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;

--- a/test/module/core/errors/semantic-errors/identifier-already-used-function.ts
+++ b/test/module/core/errors/semantic-errors/identifier-already-used-function.ts
@@ -9,7 +9,10 @@ describe("IdentifierAlreadyUsedByFunctionError", () => {
 			try {
 				result = await new KipperCompiler().compile("def x() -> void {}; var x: num = 4;", defaultConfig);
 			} catch (e) {
-				assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByFunctionError", "Expected proper error");
+				assert(
+					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByFunctionError",
+					"Expected different error",
+				);
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -22,7 +25,10 @@ describe("IdentifierAlreadyUsedByFunctionError", () => {
 			try {
 				result = await new KipperCompiler().compile("def x() -> void {} def x() -> void {}", defaultConfig);
 			} catch (e) {
-				assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByFunctionError", "Expected proper error");
+				assert(
+					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByFunctionError",
+					"Expected different error",
+				);
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -35,7 +41,10 @@ describe("IdentifierAlreadyUsedByFunctionError", () => {
 			try {
 				result = await new KipperCompiler().compile("def x() -> void {} def f(x: num) -> void {}", defaultConfig);
 			} catch (e) {
-				assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByFunctionError", "Expected proper error");
+				assert(
+					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByFunctionError",
+					"Expected different error",
+				);
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -50,7 +59,10 @@ describe("IdentifierAlreadyUsedByFunctionError", () => {
 			try {
 				result = await new KipperCompiler().compile("def x() -> void {}; { var x: num = 4; }", defaultConfig);
 			} catch (e) {
-				assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByFunctionError", "Expected proper error");
+				assert(
+					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByFunctionError",
+					"Expected different error",
+				);
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -65,7 +77,10 @@ describe("IdentifierAlreadyUsedByFunctionError", () => {
 			try {
 				result = await new KipperCompiler().compile("def x() -> void {}; { { var x: num = 4; } }", defaultConfig);
 			} catch (e) {
-				assert((<KipperError>e).constructor.name === "IdentifierAlreadyUsedByFunctionError", "Expected proper error");
+				assert(
+					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByFunctionError",
+					"Expected different error",
+				);
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;

--- a/test/module/core/errors/semantic-errors/incomplete-returns-in-code-paths.ts
+++ b/test/module/core/errors/semantic-errors/incomplete-returns-in-code-paths.ts
@@ -9,8 +9,12 @@ describe("IncompleteReturnsInCodePathsError", () => {
 			try {
 				result = await new KipperCompiler().compile(`def x() -> num {};`, defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "IncompleteReturnsInCodePathsError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal(
+					(<KipperError>e).constructor.name,
+					"IncompleteReturnsInCodePathsError",
+					"Expected different error",
+				);
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -25,8 +29,12 @@ describe("IncompleteReturnsInCodePathsError", () => {
 				// will always be true, but here we don't have that luxury (for now).
 				result = await new KipperCompiler().compile(`def x() -> num { if (true) { return 1; } };`, defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "IncompleteReturnsInCodePathsError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal(
+					(<KipperError>e).constructor.name,
+					"IncompleteReturnsInCodePathsError",
+					"Expected different error",
+				);
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -42,8 +50,12 @@ describe("IncompleteReturnsInCodePathsError", () => {
 					defaultConfig,
 				);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "IncompleteReturnsInCodePathsError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal(
+					(<KipperError>e).constructor.name,
+					"IncompleteReturnsInCodePathsError",
+					"Expected different error",
+				);
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -59,8 +71,12 @@ describe("IncompleteReturnsInCodePathsError", () => {
 					defaultConfig,
 				);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "IncompleteReturnsInCodePathsError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal(
+					(<KipperError>e).constructor.name,
+					"IncompleteReturnsInCodePathsError",
+					"Expected different error",
+				);
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -77,8 +93,8 @@ describe("IncompleteReturnsInCodePathsError", () => {
 						defaultConfig,
 					);
 				} catch (e) {
-					assert((<KipperError>e).constructor.name === "IncompleteReturnsInCodePathsError", "Expected proper error");
-					assert((<KipperError>e).name === "TypeError", "Expected proper error");
+					assert((<KipperError>e).constructor.name === "IncompleteReturnsInCodePathsError", "Expected different error");
+					assert((<KipperError>e).name === "TypeError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;
@@ -94,8 +110,8 @@ describe("IncompleteReturnsInCodePathsError", () => {
 						defaultConfig,
 					);
 				} catch (e) {
-					assert((<KipperError>e).constructor.name === "IncompleteReturnsInCodePathsError", "Expected proper error");
-					assert((<KipperError>e).name === "TypeError", "Expected proper error");
+					assert((<KipperError>e).constructor.name === "IncompleteReturnsInCodePathsError", "Expected different error");
+					assert((<KipperError>e).name === "TypeError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;
@@ -113,8 +129,8 @@ describe("IncompleteReturnsInCodePathsError", () => {
 						defaultConfig,
 					);
 				} catch (e) {
-					assert((<KipperError>e).constructor.name === "IncompleteReturnsInCodePathsError", "Expected proper error");
-					assert((<KipperError>e).name === "TypeError", "Expected proper error");
+					assert((<KipperError>e).constructor.name === "IncompleteReturnsInCodePathsError", "Expected different error");
+					assert((<KipperError>e).name === "TypeError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;
@@ -130,8 +146,8 @@ describe("IncompleteReturnsInCodePathsError", () => {
 						defaultConfig,
 					);
 				} catch (e) {
-					assert((<KipperError>e).constructor.name === "IncompleteReturnsInCodePathsError", "Expected proper error");
-					assert((<KipperError>e).name === "TypeError", "Expected proper error");
+					assert((<KipperError>e).constructor.name === "IncompleteReturnsInCodePathsError", "Expected different error");
+					assert((<KipperError>e).name === "TypeError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;
@@ -149,8 +165,8 @@ describe("IncompleteReturnsInCodePathsError", () => {
 						defaultConfig,
 					);
 				} catch (e) {
-					assert((<KipperError>e).constructor.name === "IncompleteReturnsInCodePathsError", "Expected proper error");
-					assert((<KipperError>e).name === "TypeError", "Expected proper error");
+					assert((<KipperError>e).constructor.name === "IncompleteReturnsInCodePathsError", "Expected different error");
+					assert((<KipperError>e).name === "TypeError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;
@@ -166,8 +182,8 @@ describe("IncompleteReturnsInCodePathsError", () => {
 						defaultConfig,
 					);
 				} catch (e) {
-					assert((<KipperError>e).constructor.name === "IncompleteReturnsInCodePathsError", "Expected proper error");
-					assert((<KipperError>e).name === "TypeError", "Expected proper error");
+					assert((<KipperError>e).constructor.name === "IncompleteReturnsInCodePathsError", "Expected different error");
+					assert((<KipperError>e).name === "TypeError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;

--- a/test/module/core/errors/semantic-errors/invalid-amount-of-arguments.ts
+++ b/test/module/core/errors/semantic-errors/invalid-amount-of-arguments.ts
@@ -9,8 +9,8 @@ describe("InvalidAmountOfArgumentsError", () => {
 			try {
 				result = await new KipperCompiler().compile('call print("x", "x");', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidAmountOfArgumentsError", "Expected proper error");
-				assert((<KipperError>e).name === "ArgumentError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "InvalidAmountOfArgumentsError", "Expected different error");
+				assert((<KipperError>e).name === "ArgumentError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -23,8 +23,8 @@ describe("InvalidAmountOfArgumentsError", () => {
 			try {
 				result = await new KipperCompiler().compile('call print("x", "x", "x");', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidAmountOfArgumentsError", "Expected proper error");
-				assert((<KipperError>e).name === "ArgumentError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "InvalidAmountOfArgumentsError", "Expected different error");
+				assert((<KipperError>e).name === "ArgumentError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -37,8 +37,8 @@ describe("InvalidAmountOfArgumentsError", () => {
 			try {
 				result = await new KipperCompiler().compile('call print("x", "x", "x", "x");', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidAmountOfArgumentsError", "Expected proper error");
-				assert((<KipperError>e).name === "ArgumentError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "InvalidAmountOfArgumentsError", "Expected different error");
+				assert((<KipperError>e).name === "ArgumentError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -51,8 +51,8 @@ describe("InvalidAmountOfArgumentsError", () => {
 			try {
 				result = await new KipperCompiler().compile("call print();", defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidAmountOfArgumentsError", "Expected proper error");
-				assert((<KipperError>e).name === "ArgumentError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "InvalidAmountOfArgumentsError", "Expected different error");
+				assert((<KipperError>e).name === "ArgumentError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;

--- a/test/module/core/errors/semantic-errors/invalid-assignment.ts
+++ b/test/module/core/errors/semantic-errors/invalid-assignment.ts
@@ -9,8 +9,8 @@ describe("InvalidAssignmentError", () => {
 			try {
 				result = await new KipperCompiler().compile("5 = 5;", { abortOnFirstError: true, target: defaultTarget });
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidAssignmentError", "Expected proper error");
-				assert((<KipperError>e).name === "InvalidAssignmentError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "InvalidAssignmentError", "Expected different error");
+				assert((<KipperError>e).name === "InvalidAssignmentError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -26,8 +26,8 @@ describe("InvalidAssignmentError", () => {
 					target: defaultTarget,
 				});
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidAssignmentError", "Expected proper error");
-				assert((<KipperError>e).name === "InvalidAssignmentError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "InvalidAssignmentError", "Expected different error");
+				assert((<KipperError>e).name === "InvalidAssignmentError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;

--- a/test/module/core/errors/semantic-errors/invalid-global.ts
+++ b/test/module/core/errors/semantic-errors/invalid-global.ts
@@ -16,7 +16,7 @@ describe("InvalidGlobalError", () => {
 				programCtx.registerBuiltIns({ identifier: globalName, params: [], returnType: "void" });
 				programCtx.registerBuiltIns({ identifier: globalName, params: [], returnType: "void" });
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidGlobalError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "InvalidGlobalError", "Expected different error");
 				assert((<KipperError>e).line !== undefined, "Expected existing 'line' meta field");
 				assert((<KipperError>e).col !== undefined, "Expected existing 'col' meta field");
 				assert((<KipperError>e).filePath !== undefined, "Expected existing 'filePath' meta field");

--- a/test/module/core/errors/semantic-errors/invalid-relational-comparison.ts
+++ b/test/module/core/errors/semantic-errors/invalid-relational-comparison.ts
@@ -8,8 +8,12 @@ describe("InvalidRelationalComparisonTypeError", () => {
 		try {
 			result = await new KipperCompiler().compile(`"5" > 5;`, defaultConfig);
 		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "InvalidRelationalComparisonTypeError", "Expected proper error");
-			assert((<KipperError>e).name === "TypeError", "Expected proper error");
+			assert.equal(
+				(<KipperError>e).constructor.name,
+				"InvalidRelationalComparisonTypeError",
+				"Expected different error",
+			);
+			assert((<KipperError>e).name === "TypeError", "Expected different error");
 			ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 			ensureTracebackDataExists(<KipperError>e);
 			return;

--- a/test/module/core/errors/semantic-errors/reserved-identifier-overwrite.ts
+++ b/test/module/core/errors/semantic-errors/reserved-identifier-overwrite.ts
@@ -8,8 +8,8 @@ describe("ReservedIdentifierOverwriteError", () => {
 		try {
 			result = await new KipperCompiler().compile("var instanceof: str;", defaultConfig);
 		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "ReservedIdentifierOverwriteError", "Expected proper error");
-			assert((<KipperError>e).name === "IdentifierError", "Expected proper error");
+			assert.equal((<KipperError>e).constructor.name, "ReservedIdentifierOverwriteError", "Expected different error");
+			assert((<KipperError>e).name === "IdentifierError", "Expected different error");
 			ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 			ensureTracebackDataExists(<KipperError>e);
 			return;

--- a/test/module/core/errors/semantic-errors/undefined-constant.ts
+++ b/test/module/core/errors/semantic-errors/undefined-constant.ts
@@ -8,8 +8,8 @@ describe("UndefinedConstantError", () => {
 		try {
 			result = await new KipperCompiler().compile(`const invalid: str;`, defaultConfig);
 		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "UndefinedConstantError", "Expected proper error");
-			assert((<KipperError>e).name === "UndefinedConstantError", "Expected proper error");
+			assert.equal((<KipperError>e).constructor.name, "UndefinedConstantError", "Expected different error");
+			assert((<KipperError>e).name === "UndefinedConstantError", "Expected different error");
 			ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 			ensureTracebackDataExists(<KipperError>e);
 			return;

--- a/test/module/core/errors/semantic-errors/undefined-reference.ts
+++ b/test/module/core/errors/semantic-errors/undefined-reference.ts
@@ -9,8 +9,8 @@ describe("UndefinedReferenceError", () => {
 			try {
 				result = await new KipperCompiler().compile(`var x: str; x += "5";`, defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "UndefinedReferenceError", "Expected proper error");
-				assert((<KipperError>e).name === "ReferenceError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "UndefinedReferenceError", "Expected different error");
+				assert((<KipperError>e).name === "ReferenceError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -23,8 +23,8 @@ describe("UndefinedReferenceError", () => {
 			try {
 				result = await new KipperCompiler().compile(`var x: num; x + 5;`, defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "UndefinedReferenceError", "Expected proper error");
-				assert((<KipperError>e).name === "ReferenceError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "UndefinedReferenceError", "Expected different error");
+				assert((<KipperError>e).name === "ReferenceError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -37,8 +37,8 @@ describe("UndefinedReferenceError", () => {
 			try {
 				result = await new KipperCompiler().compile(`var x: str; x;`, defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "UndefinedReferenceError", "Expected proper error");
-				assert((<KipperError>e).name === "ReferenceError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "UndefinedReferenceError", "Expected different error");
+				assert((<KipperError>e).name === "ReferenceError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;

--- a/test/module/core/errors/semantic-errors/unknown-reference.ts
+++ b/test/module/core/errors/semantic-errors/unknown-reference.ts
@@ -8,8 +8,8 @@ describe("UnknownReferenceError", () => {
 		try {
 			result = await new KipperCompiler().compile("x;", defaultConfig);
 		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "UnknownReferenceError", "Expected proper error");
-			assert((<KipperError>e).name === "ReferenceError", "Expected proper error");
+			assert.equal((<KipperError>e).constructor.name, "UnknownReferenceError", "Expected different error");
+			assert((<KipperError>e).name === "ReferenceError", "Expected different error");
 			ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 			ensureTracebackDataExists(<KipperError>e);
 			return;
@@ -22,8 +22,8 @@ describe("UnknownReferenceError", () => {
 		try {
 			result = await new KipperCompiler().compile('var x: num = call pr("pr");', defaultConfig);
 		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "UnknownReferenceError", "Expected proper error");
-			assert((<KipperError>e).name === "ReferenceError", "Expected proper error");
+			assert.equal((<KipperError>e).constructor.name, "UnknownReferenceError", "Expected different error");
+			assert((<KipperError>e).name === "ReferenceError", "Expected different error");
 			ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 			ensureTracebackDataExists(<KipperError>e);
 			return;
@@ -36,8 +36,8 @@ describe("UnknownReferenceError", () => {
 		try {
 			result = await new KipperCompiler().compile("var x: num = y + y;", defaultConfig);
 		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "UnknownReferenceError", "Expected proper error");
-			assert((<KipperError>e).name === "ReferenceError", "Expected proper error");
+			assert.equal((<KipperError>e).constructor.name, "UnknownReferenceError", "Expected different error");
+			assert((<KipperError>e).name === "ReferenceError", "Expected different error");
 			ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 			ensureTracebackDataExists(<KipperError>e);
 			return;
@@ -50,8 +50,8 @@ describe("UnknownReferenceError", () => {
 		try {
 			result = await new KipperCompiler().compile("{ { { { x; } } } }", defaultConfig);
 		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "UnknownReferenceError", "Expected proper error");
-			assert((<KipperError>e).name === "ReferenceError", "Expected proper error");
+			assert.equal((<KipperError>e).constructor.name, "UnknownReferenceError", "Expected different error");
+			assert((<KipperError>e).name === "ReferenceError", "Expected different error");
 			ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 			ensureTracebackDataExists(<KipperError>e);
 			return;

--- a/test/module/core/errors/syntax-errors/invalid-unary-exp-operand.ts
+++ b/test/module/core/errors/syntax-errors/invalid-unary-exp-operand.ts
@@ -9,8 +9,12 @@ describe("InvalidUnaryExpressionOperandError", () => {
 			try {
 				result = await new KipperCompiler().compile(`5++;`, defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidUnaryExpressionOperandError", "Expected proper error");
-				assert((<KipperError>e).name === "SyntaxError", "Expected proper error");
+				assert.equal(
+					(<KipperError>e).constructor.name,
+					"InvalidUnaryExpressionOperandError",
+					"Expected different error",
+				);
+				assert((<KipperError>e).name === "SyntaxError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -23,8 +27,12 @@ describe("InvalidUnaryExpressionOperandError", () => {
 			try {
 				result = await new KipperCompiler().compile(`(5)++;`, defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidUnaryExpressionOperandError", "Expected proper error");
-				assert((<KipperError>e).name === "SyntaxError", "Expected proper error");
+				assert.equal(
+					(<KipperError>e).constructor.name,
+					"InvalidUnaryExpressionOperandError",
+					"Expected different error",
+				);
+				assert((<KipperError>e).name === "SyntaxError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -37,8 +45,12 @@ describe("InvalidUnaryExpressionOperandError", () => {
 			try {
 				result = await new KipperCompiler().compile(`var x: num = 5; ++x++;`, defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidUnaryExpressionOperandError", "Expected proper error");
-				assert((<KipperError>e).name === "SyntaxError", "Expected proper error");
+				assert.equal(
+					(<KipperError>e).constructor.name,
+					"InvalidUnaryExpressionOperandError",
+					"Expected different error",
+				);
+				assert((<KipperError>e).name === "SyntaxError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -51,8 +63,12 @@ describe("InvalidUnaryExpressionOperandError", () => {
 			try {
 				result = await new KipperCompiler().compile(`var x: num = 5; ((x + 5))++;`, defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidUnaryExpressionOperandError", "Expected proper error");
-				assert((<KipperError>e).name === "SyntaxError", "Expected proper error");
+				assert.equal(
+					(<KipperError>e).constructor.name,
+					"InvalidUnaryExpressionOperandError",
+					"Expected different error",
+				);
+				assert((<KipperError>e).name === "SyntaxError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;

--- a/test/module/core/errors/syntax-errors/missing-function-body.ts
+++ b/test/module/core/errors/syntax-errors/missing-function-body.ts
@@ -8,8 +8,8 @@ describe("MissingFunctionBodyError", () => {
 		try {
 			result = await new KipperCompiler().compile("def x() -> void;", defaultConfig);
 		} catch (e) {
-			assert((<KipperSyntaxError>e).constructor.name === "MissingFunctionBodyError", "Expected proper error");
-			assert((<KipperSyntaxError>e).name === "SyntaxError", "Expected proper error");
+			assert((<KipperSyntaxError>e).constructor.name === "MissingFunctionBodyError", "Expected different error");
+			assert((<KipperSyntaxError>e).name === "SyntaxError", "Expected different error");
 			ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 			ensureTracebackDataExists(<KipperError>e);
 			return;

--- a/test/module/core/errors/syntax-errors/syntax-error.ts
+++ b/test/module/core/errors/syntax-errors/syntax-error.ts
@@ -10,7 +10,7 @@ describe("KipperSyntaxError", () => {
 		} catch (e) {
 			assert(
 				(<LexerOrParserSyntaxError<any>>e).constructor.name === "LexerOrParserSyntaxError",
-				"Expected proper error",
+				"Expected different error",
 			);
 			ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 			ensureTracebackDataExists(<KipperError>e);
@@ -26,7 +26,7 @@ describe("KipperSyntaxError", () => {
 		} catch (e) {
 			assert(
 				(<LexerOrParserSyntaxError<any>>e).constructor.name === "LexerOrParserSyntaxError",
-				"Expected proper error",
+				"Expected different error",
 			);
 			ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 			ensureTracebackDataExists(<KipperError>e);

--- a/test/module/core/errors/type-errors/argument-type-error.ts
+++ b/test/module/core/errors/type-errors/argument-type-error.ts
@@ -9,8 +9,8 @@ describe("ArgumentTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile(`print(1);`, defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArgumentTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArgumentTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -26,8 +26,8 @@ describe("ArgumentTypeError", () => {
 					defaultConfig,
 				);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArgumentTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArgumentTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -43,8 +43,8 @@ describe("ArgumentTypeError", () => {
 					defaultConfig,
 				);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArgumentTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArgumentTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;

--- a/test/module/core/errors/type-errors/arithmetic-operation.ts
+++ b/test/module/core/errors/type-errors/arithmetic-operation.ts
@@ -9,8 +9,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('"3" + 4;', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -23,8 +23,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('"3" - 4;', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -37,8 +37,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('"3" * 4;', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -51,8 +51,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('"3" ** 4;', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -65,8 +65,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('"3" / 4;', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -79,8 +79,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('"3" % 4;', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -93,8 +93,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('4 + "3";', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -107,8 +107,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('4 - "3";', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -121,8 +121,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('4 * "3";', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -135,8 +135,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('4 ** "3";', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -149,8 +149,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('4 / "3";', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -163,8 +163,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('4 % "3";', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -177,8 +177,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('"3" + true;', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -191,8 +191,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('"3" - true;', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -205,8 +205,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('"3" * true;', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -219,8 +219,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('"3" ** true;', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -233,8 +233,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('"3" / true;', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -247,8 +247,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('"3" % true;', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -261,8 +261,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('true + "3";', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -275,8 +275,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('true - "3";', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -289,8 +289,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('true * "3";', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -303,8 +303,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('true ** "3";', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -317,8 +317,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('true / "3";', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -331,8 +331,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('true % "3";', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -345,8 +345,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('var x: str = "3"; x -= "4";', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -359,8 +359,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('var x: str = "3"; x *= "4";', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -373,8 +373,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('var x: str = "3"; x /= "4";', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -387,8 +387,8 @@ describe("ArithmeticOperationTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('var x: str = "3"; x %= "4";', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;

--- a/test/module/core/errors/type-errors/assignment-type.ts
+++ b/test/module/core/errors/type-errors/assignment-type.ts
@@ -10,8 +10,8 @@ describe("AssignmentTypeError", () => {
 				try {
 					result = await new KipperCompiler().compile('var x: num = "5";', defaultConfig);
 				} catch (e) {
-					assert.equal((<KipperError>e).constructor.name, "AssignmentTypeError", "Expected proper error");
-					assert((<KipperError>e).name === "TypeError", "Expected proper error");
+					assert.equal((<KipperError>e).constructor.name, "AssignmentTypeError", "Expected different error");
+					assert((<KipperError>e).name === "TypeError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;
@@ -24,8 +24,8 @@ describe("AssignmentTypeError", () => {
 				try {
 					result = await new KipperCompiler().compile("var x: str = 5;", defaultConfig);
 				} catch (e) {
-					assert.equal((<KipperError>e).constructor.name, "AssignmentTypeError", "Expected proper error");
-					assert((<KipperError>e).name === "TypeError", "Expected proper error");
+					assert.equal((<KipperError>e).constructor.name, "AssignmentTypeError", "Expected different error");
+					assert((<KipperError>e).name === "TypeError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;
@@ -40,8 +40,8 @@ describe("AssignmentTypeError", () => {
 				try {
 					result = await new KipperCompiler().compile('var x: num; x = "5";', defaultConfig);
 				} catch (e) {
-					assert.equal((<KipperError>e).constructor.name, "AssignmentTypeError", "Expected proper error");
-					assert((<KipperError>e).name === "TypeError", "Expected proper error");
+					assert.equal((<KipperError>e).constructor.name, "AssignmentTypeError", "Expected different error");
+					assert((<KipperError>e).name === "TypeError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;
@@ -54,8 +54,8 @@ describe("AssignmentTypeError", () => {
 				try {
 					result = await new KipperCompiler().compile("var x: str; x = 5;", defaultConfig);
 				} catch (e) {
-					assert.equal((<KipperError>e).constructor.name, "AssignmentTypeError", "Expected proper error");
-					assert((<KipperError>e).name === "TypeError", "Expected proper error");
+					assert.equal((<KipperError>e).constructor.name, "AssignmentTypeError", "Expected different error");
+					assert((<KipperError>e).name === "TypeError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;
@@ -68,8 +68,8 @@ describe("AssignmentTypeError", () => {
 				try {
 					result = await new KipperCompiler().compile('var x: str = "3"; x += 4;', defaultConfig);
 				} catch (e) {
-					assert.equal((<KipperError>e).constructor.name, "AssignmentTypeError", "Expected proper error");
-					assert((<KipperError>e).name === "TypeError", "Expected proper error");
+					assert.equal((<KipperError>e).constructor.name, "AssignmentTypeError", "Expected different error");
+					assert((<KipperError>e).name === "TypeError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;
@@ -82,8 +82,8 @@ describe("AssignmentTypeError", () => {
 				try {
 					result = await new KipperCompiler().compile('var x: str = "3"; x -= 4;', defaultConfig);
 				} catch (e) {
-					assert.equal((<KipperError>e).constructor.name, "AssignmentTypeError", "Expected proper error");
-					assert((<KipperError>e).name === "TypeError", "Expected proper error");
+					assert.equal((<KipperError>e).constructor.name, "AssignmentTypeError", "Expected different error");
+					assert((<KipperError>e).name === "TypeError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;
@@ -96,8 +96,8 @@ describe("AssignmentTypeError", () => {
 				try {
 					result = await new KipperCompiler().compile('var x: str = "3"; x *= 4;', defaultConfig);
 				} catch (e) {
-					assert.equal((<KipperError>e).constructor.name, "AssignmentTypeError", "Expected proper error");
-					assert((<KipperError>e).name === "TypeError", "Expected proper error");
+					assert.equal((<KipperError>e).constructor.name, "AssignmentTypeError", "Expected different error");
+					assert((<KipperError>e).name === "TypeError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;
@@ -110,8 +110,8 @@ describe("AssignmentTypeError", () => {
 				try {
 					result = await new KipperCompiler().compile('var x: str = "3"; x /= 4;', defaultConfig);
 				} catch (e) {
-					assert.equal((<KipperError>e).constructor.name, "AssignmentTypeError", "Expected proper error");
-					assert((<KipperError>e).name === "TypeError", "Expected proper error");
+					assert.equal((<KipperError>e).constructor.name, "AssignmentTypeError", "Expected different error");
+					assert((<KipperError>e).name === "TypeError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;
@@ -124,8 +124,8 @@ describe("AssignmentTypeError", () => {
 				try {
 					result = await new KipperCompiler().compile('var x: str = "3"; x %= 4;', defaultConfig);
 				} catch (e) {
-					assert.equal((<KipperError>e).constructor.name, "AssignmentTypeError", "Expected proper error");
-					assert((<KipperError>e).name === "TypeError", "Expected proper error");
+					assert.equal((<KipperError>e).constructor.name, "AssignmentTypeError", "Expected different error");
+					assert((<KipperError>e).name === "TypeError", "Expected different error");
 					ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 					ensureTracebackDataExists(<KipperError>e);
 					return;

--- a/test/module/core/errors/type-errors/invalid-conversion.ts
+++ b/test/module/core/errors/type-errors/invalid-conversion.ts
@@ -9,8 +9,8 @@ describe("InvalidConversionTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile('"5" as func;', defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidConversionTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "InvalidConversionTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -23,8 +23,8 @@ describe("InvalidConversionTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile("5 as func;", defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidConversionTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "InvalidConversionTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -37,8 +37,8 @@ describe("InvalidConversionTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile("true as func;", defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidConversionTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "InvalidConversionTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -51,8 +51,8 @@ describe("InvalidConversionTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile("print as str;", defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidConversionTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "InvalidConversionTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -65,8 +65,8 @@ describe("InvalidConversionTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile("print as bool;", defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidConversionTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "InvalidConversionTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -79,8 +79,8 @@ describe("InvalidConversionTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile("print as bool;", defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidConversionTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "InvalidConversionTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;

--- a/test/module/core/errors/type-errors/invalid-key-type.ts
+++ b/test/module/core/errors/type-errors/invalid-key-type.ts
@@ -9,8 +9,8 @@ describe("InvalidKeyTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile(`const invalid: str = "3"; invalid["a"];`, defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidKeyTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "InvalidKeyTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -23,8 +23,8 @@ describe("InvalidKeyTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile(`const invalid: str = "3"; invalid["a":"b"];`, defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidKeyTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "InvalidKeyTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;

--- a/test/module/core/errors/type-errors/invalid-unary-exp.ts
+++ b/test/module/core/errors/type-errors/invalid-unary-exp.ts
@@ -9,8 +9,8 @@ describe("InvalidUnaryExpressionTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile(`+"5";`, defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidUnaryExpressionTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "InvalidUnaryExpressionTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -23,8 +23,8 @@ describe("InvalidUnaryExpressionTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile(`-"5";`, defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "InvalidUnaryExpressionTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "InvalidUnaryExpressionTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;

--- a/test/module/core/errors/type-errors/readonly-write.ts
+++ b/test/module/core/errors/type-errors/readonly-write.ts
@@ -8,8 +8,8 @@ describe("ReadOnlyWriteTypeError", () => {
 		try {
 			result = await new KipperCompiler().compile(`const invalid: str = "3"; invalid = "5";`, defaultConfig);
 		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "ReadOnlyWriteTypeError", "Expected proper error");
-			assert((<KipperError>e).name === "TypeError", "Expected proper error");
+			assert.equal((<KipperError>e).constructor.name, "ReadOnlyWriteTypeError", "Expected different error");
+			assert((<KipperError>e).name === "TypeError", "Expected different error");
 			ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 			ensureTracebackDataExists(<KipperError>e);
 			return;

--- a/test/module/core/errors/type-errors/unknown-type.ts
+++ b/test/module/core/errors/type-errors/unknown-type.ts
@@ -9,7 +9,7 @@ describe("UnknownTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile(`var invalid: ${typeName} = 4;`, defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "UnknownTypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "UnknownTypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;

--- a/test/module/core/errors/type-errors/value-not-indexable.ts
+++ b/test/module/core/errors/type-errors/value-not-indexable.ts
@@ -9,8 +9,8 @@ describe("ValueNotIndexableTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile(`const invalid: num = 1; invalid[0];`, defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ValueNotIndexableTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ValueNotIndexableTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;
@@ -23,8 +23,8 @@ describe("ValueNotIndexableTypeError", () => {
 			try {
 				result = await new KipperCompiler().compile(`const invalid: num = 1; invalid[0:1];`, defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ValueNotIndexableTypeError", "Expected proper error");
-				assert((<KipperError>e).name === "TypeError", "Expected proper error");
+				assert.equal((<KipperError>e).constructor.name, "ValueNotIndexableTypeError", "Expected different error");
+				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureErrorWasReported(typeof result === "object" ? result?.programCtx : undefined);
 				ensureTracebackDataExists(<KipperError>e);
 				return;

--- a/test/module/core/logger.test.ts
+++ b/test/module/core/logger.test.ts
@@ -79,7 +79,7 @@ describe("KipperLogger", () => {
 			} catch (e) {
 				assert(
 					(<LexerOrParserSyntaxError<any>>e).constructor.name === "LexerOrParserSyntaxError",
-					"Expected proper error",
+					"Expected different error",
 				);
 
 				// Check logging errors

--- a/test/module/core/not-implemented.test.ts
+++ b/test/module/core/not-implemented.test.ts
@@ -12,8 +12,8 @@ describe("NotImplemented", () => {
 				target: defaultTarget,
 			});
 		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "KipperNotImplementedError", "Expected proper error");
-			assert.equal((<KipperError>e).name, "NotImplementedError", "Expected proper error");
+			assert.equal((<KipperError>e).constructor.name, "KipperNotImplementedError", "Expected different error");
+			assert.equal((<KipperError>e).name, "NotImplementedError", "Expected different error");
 			return;
 		}
 		assert.fail("Expected NotImplementedError");
@@ -26,8 +26,8 @@ describe("NotImplemented", () => {
 				target: defaultTarget,
 			});
 		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "KipperNotImplementedError", "Expected proper error");
-			assert.equal((<KipperError>e).name, "NotImplementedError", "Expected proper error");
+			assert.equal((<KipperError>e).constructor.name, "KipperNotImplementedError", "Expected different error");
+			assert.equal((<KipperError>e).name, "NotImplementedError", "Expected different error");
 			return;
 		}
 		assert.fail("Expected NotImplementedError");
@@ -40,8 +40,8 @@ describe("NotImplemented", () => {
 				target: defaultTarget,
 			});
 		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "KipperNotImplementedError", "Expected proper error");
-			assert.equal((<KipperError>e).name, "NotImplementedError", "Expected proper error");
+			assert.equal((<KipperError>e).constructor.name, "KipperNotImplementedError", "Expected different error");
+			assert.equal((<KipperError>e).name, "NotImplementedError", "Expected different error");
 			return;
 		}
 		assert.fail("Expected NotImplementedError");
@@ -54,8 +54,8 @@ describe("NotImplemented", () => {
 				target: defaultTarget,
 			});
 		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "KipperNotImplementedError", "Expected proper error");
-			assert.equal((<KipperError>e).name, "NotImplementedError", "Expected proper error");
+			assert.equal((<KipperError>e).constructor.name, "KipperNotImplementedError", "Expected different error");
+			assert.equal((<KipperError>e).name, "NotImplementedError", "Expected different error");
 			return;
 		}
 		assert.fail("Expected NotImplementedError");
@@ -68,8 +68,8 @@ describe("NotImplemented", () => {
 				target: defaultTarget,
 			});
 		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "KipperNotImplementedError", "Expected proper error");
-			assert.equal((<KipperError>e).name, "NotImplementedError", "Expected proper error");
+			assert.equal((<KipperError>e).constructor.name, "KipperNotImplementedError", "Expected different error");
+			assert.equal((<KipperError>e).name, "NotImplementedError", "Expected different error");
 			return;
 		}
 		assert.fail("Expected NotImplementedError");


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it -->

- [x] New feature (Non-breaking change which adds functionality)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

<!-- Explain the reason for this pr, changes and solution briefly. -->

Added new built-in function `len()`, which returns the length of a string.

Closes #411 

## Summary of Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

- Added new built-in function `len()` and its function signautre.
- Implemented target-specific generation for the function `len()`.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Detailed Changelog

_Not present for website/docs changes_

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added and remove any header with no item.). -->

### Added

- Implemented new built-in function `len()`, which returns the length of a string (In the future also arrays). ([#411](https://github.com/Luna-Klatzer/Kipper/issues/411)).

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [x] #411 