### PR TITLE
Implemented control flow statements `continue` and `break` for loop statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ To use development versions of Kipper download the
 - Support for single-line comments separated by a newline char.
   ([#400](https://github.com/Luna-Klatzer/Kipper/issues/400)).
 - Implemented new built-in function `len()`, which returns the length of a string (In the future also arrays).
-	([#411](https://github.com/Luna-Klatzer/Kipper/issues/411)).
+  ([#411](https://github.com/Luna-Klatzer/Kipper/issues/411)).
 - New built-in Kipper type `null` and `undefined`, and support for the constant identifier `void`, `null` and
   `undefined`.
 - New Kipper CLI flag `-t/--target` to specify the target to use for a compilation or execution.
@@ -133,6 +133,7 @@ To use development versions of Kipper download the
   - `AnalysableASTNode.ensureTypeSemanticallyValid()`, which throws a `MissingRequiredSemanticDataError` in case that
     the specified node failed during type checking. This is used by other nodes to ensure that the node is valid and
     its data can be safely accessed.
+  - `KipperSemanticChecker.getJumpStatementParent()`, which evaluates the parent iteration statement for a jump statement.
 - New types:
   - `TypeData`, which represents the type data of an `ASTNode`.
   - `NoTypeSemantics`, which hints that an `ASTNode` has no type semantic data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,9 @@ To use development versions of Kipper download the
 - Support for single-line comments separated by a newline char.
   ([#400](https://github.com/Luna-Klatzer/Kipper/issues/400)).
 - Implemented new built-in function `len()`, which returns the length of a string (In the future also arrays).
-	([#411](https://github.com/Luna-Klatzer/Kipper/issues/411)).
+  ([#411](https://github.com/Luna-Klatzer/Kipper/issues/411)).
+- Support for jump statements `continue` and `break` for iteration statements.
+	([#269](https://github.com/Luna-Klatzer/Kipper/issues/269)).
 - New built-in Kipper type `null` and `undefined`, and support for the constant identifier `void`, `null` and
   `undefined`.
 - New Kipper CLI flag `-t/--target` to specify the target to use for a compilation or execution.
@@ -133,6 +135,7 @@ To use development versions of Kipper download the
   - `AnalysableASTNode.ensureTypeSemanticallyValid()`, which throws a `MissingRequiredSemanticDataError` in case that
     the specified node failed during type checking. This is used by other nodes to ensure that the node is valid and
     its data can be safely accessed.
+  - `KipperSemanticChecker.getJumpStatementParent()`, which evaluates the parent iteration statement for a jump statement.
 - New types:
   - `TypeData`, which represents the type data of an `ASTNode`.
   - `NoTypeSemantics`, which hints that an `ASTNode` has no type semantic data.

--- a/kipper/core/src/compiler/analysis/analyser/semantic-checker.ts
+++ b/kipper/core/src/compiler/analysis/analyser/semantic-checker.ts
@@ -18,7 +18,9 @@ import {
 	CompoundStatement,
 	Expression,
 	FunctionDeclaration,
-	IdentifierPrimaryExpression, IterationStatement, JumpStatement,
+	IdentifierPrimaryExpression,
+	IterationStatement,
+	JumpStatement,
 	ReturnStatement,
 	VariableDeclaration,
 } from "../../ast";
@@ -33,7 +35,8 @@ import {
 	InvalidReturnStatementError,
 	UndefinedConstantError,
 	UndefinedReferenceError,
-	UnknownReferenceError, InvalidJumpStatementError,
+	UnknownReferenceError,
+	InvalidJumpStatementError,
 } from "../../../errors";
 
 /**

--- a/kipper/core/src/compiler/analysis/analyser/semantic-checker.ts
+++ b/kipper/core/src/compiler/analysis/analyser/semantic-checker.ts
@@ -18,7 +18,7 @@ import {
 	CompoundStatement,
 	Expression,
 	FunctionDeclaration,
-	IdentifierPrimaryExpression,
+	IdentifierPrimaryExpression, IterationStatement, JumpStatement,
 	ReturnStatement,
 	VariableDeclaration,
 } from "../../ast";
@@ -30,10 +30,10 @@ import {
 	InvalidAssignmentError,
 	InvalidGlobalError,
 	MissingFunctionBodyError,
-	ReturnStatementError,
+	InvalidReturnStatementError,
 	UndefinedConstantError,
 	UndefinedReferenceError,
-	UnknownReferenceError,
+	UnknownReferenceError, InvalidJumpStatementError,
 } from "../../../errors";
 
 /**
@@ -186,8 +186,8 @@ export class KipperSemanticChecker extends KipperSemanticsAsserter {
 	/**
 	 * Searches for the parent of the specified return statement and asserts that it is a function.
 	 * @param retStatement The return statement.
+	 * @throws {InvalidReturnStatementError} If the parent is not a function.
 	 * @returns The parent function if found.
-	 * @throws {ReturnStatementError} If the parent is not a function.
 	 * @since 0.10.0
 	 */
 	public getReturnStatementParent(retStatement: ReturnStatement): FunctionDeclaration {
@@ -199,7 +199,29 @@ export class KipperSemanticChecker extends KipperSemanticsAsserter {
 		}
 
 		if (currentParent === undefined) {
-			throw this.assertError(new ReturnStatementError());
+			throw this.assertError(new InvalidReturnStatementError());
+		}
+		return currentParent;
+	}
+
+	/**
+	 * Searches for the parent of the specified jump statement (either 'break' or 'continue' and asserts that it is an
+	 * iteration statement.)
+	 * @param jmpStatement The jump statement.
+	 * @throws {InvalidJumpStatementError} If the parent is not an iteration statement.
+	 * @returns The parent iteration statement if found.
+	 * @since 0.10.0
+	 */
+	public getJumpStatementParent(jmpStatement: JumpStatement): IterationStatement {
+		// Move up the parent chain and continue as long as there are parents and the current parent is not a function
+		// declaration. This is to ensure a return statement is always used inside a function.
+		let currentParent: CompilableNodeParent | undefined = jmpStatement.parent;
+		while (!(currentParent instanceof IterationStatement) && currentParent) {
+			currentParent = currentParent.parent;
+		}
+
+		if (currentParent === undefined) {
+			throw this.assertError(new InvalidJumpStatementError());
 		}
 		return currentParent;
 	}

--- a/kipper/core/src/compiler/ast/nodes/statements.ts
+++ b/kipper/core/src/compiler/ast/nodes/statements.ts
@@ -458,8 +458,8 @@ export type ParserIterationStatementKind =
  * using {@link translateCtxAndChildren}.
  */
 export abstract class IterationStatement<
-	Semantics extends IterationStatementSemantics,
-	TypeSemantics extends NoTypeSemantics,
+	Semantics extends IterationStatementSemantics = IterationStatementSemantics,
+	TypeSemantics extends NoTypeSemantics = NoTypeSemantics,
 > extends Statement<Semantics, TypeSemantics> {
 	protected abstract readonly _antlrRuleCtx: ParserIterationStatementContext;
 	public abstract readonly kind: ParserIterationStatementKind;
@@ -793,16 +793,12 @@ export class JumpStatement extends Statement<JumpStatementSemantics, NoTypeSeman
 	 */
 	public async primarySemanticAnalysis(): Promise<void> {
 		const jmpType = this.sourceCode.startsWith("break") ? "break" : "continue";
+		const parent = this.programCtx.semanticCheck(this).getJumpStatementParent(this);
 
 		this.semanticData = {
 			jmpType: jmpType,
+			parent: parent,
 		};
-
-		throw this.programCtx
-			.semanticCheck(this)
-			.notImplementedError(
-				new KipperNotImplementedError("Break and continue statements have not been implemented yet."),
-			);
 	}
 
 	/**
@@ -813,13 +809,7 @@ export class JumpStatement extends Statement<JumpStatementSemantics, NoTypeSeman
 	 * the children has already failed and as such no parent node should run type checking.
 	 * @since 0.7.0
 	 */
-	public async primarySemanticTypeChecking(): Promise<void> {
-		throw this.programCtx
-			.semanticCheck(this)
-			.notImplementedError(
-				new KipperNotImplementedError("Break and continue statements have not been implemented yet."),
-			);
-	}
+	public primarySemanticTypeChecking = undefined; // Jump statements will never have type checking
 
 	/**
 	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.

--- a/kipper/core/src/compiler/ast/semantic-data/statements.ts
+++ b/kipper/core/src/compiler/ast/semantic-data/statements.ts
@@ -5,7 +5,7 @@
 import type { SemanticData } from "../ast-node";
 import type { Expression, FunctionDeclaration, IfStatement, Statement, VariableDeclaration } from "../nodes";
 import type { JmpStatementType } from "../../const";
-import {IterationStatement} from "../nodes";
+import { IterationStatement } from "../nodes";
 
 /**
  * Semantics for AST Node {@link IfStatement}.

--- a/kipper/core/src/compiler/ast/semantic-data/statements.ts
+++ b/kipper/core/src/compiler/ast/semantic-data/statements.ts
@@ -5,6 +5,7 @@
 import type { SemanticData } from "../ast-node";
 import type { Expression, FunctionDeclaration, IfStatement, Statement, VariableDeclaration } from "../nodes";
 import type { JmpStatementType } from "../../const";
+import {IterationStatement} from "../nodes";
 
 /**
  * Semantics for AST Node {@link IfStatement}.
@@ -114,6 +115,11 @@ export interface JumpStatementSemantics extends SemanticData {
 	 * @since 0.10.0
 	 */
 	jmpType: JmpStatementType;
+	/**
+	 * The parent statement of the {@link JumpStatement jump statement}.
+	 * @since 0.10.0
+	 */
+	parent: IterationStatement;
 }
 
 /**

--- a/kipper/core/src/errors.ts
+++ b/kipper/core/src/errors.ts
@@ -322,9 +322,19 @@ export class KipperSyntaxError extends KipperError {
  * Error that is thrown when a return statement is used outside a function.
  * @since 0.10.0
  */
-export class ReturnStatementError extends KipperSyntaxError {
+export class InvalidReturnStatementError extends KipperSyntaxError {
 	constructor() {
-		super("A return statement can only be used in a function.");
+		super("A return statement can only be used inside a function body.");
+	}
+}
+
+/**
+ * Error that is thrown when a jump statement (either 'break' or 'continue') are used outside a loop.
+ * @since 0.10.0
+ */
+export class InvalidJumpStatementError extends KipperSyntaxError {
+	constructor() {
+		super("A jump statement can only be used inside a loop.");
 	}
 }
 

--- a/kipper/target-js/src/code-generator.ts
+++ b/kipper/target-js/src/code-generator.ts
@@ -319,7 +319,10 @@ export class JavaScriptTargetCodeGenerator extends KipperTargetCodeGenerator {
 	 * Translates a {@link JumpStatement} into the JavaScript language.
 	 */
 	jumpStatement = async (node: JumpStatement): Promise<Array<TranslatedCodeLine>> => {
-		return [];
+		const semanticData = node.getSemanticData();
+		return [
+			semanticData.jmpType === "break" ? ["break", ";"] : ["continue", ";"]
+		];
 	};
 
 	/**

--- a/kipper/target-js/src/code-generator.ts
+++ b/kipper/target-js/src/code-generator.ts
@@ -320,9 +320,7 @@ export class JavaScriptTargetCodeGenerator extends KipperTargetCodeGenerator {
 	 */
 	jumpStatement = async (node: JumpStatement): Promise<Array<TranslatedCodeLine>> => {
 		const semanticData = node.getSemanticData();
-		return [
-			semanticData.jmpType === "break" ? ["break", ";"] : ["continue", ";"]
-		];
+		return [semanticData.jmpType === "break" ? ["break", ";"] : ["continue", ";"]];
 	};
 
 	/**

--- a/kipper/target-ts/src/built-in-generator.ts
+++ b/kipper/target-ts/src/built-in-generator.ts
@@ -4,7 +4,7 @@
  * @since 0.8.0
  */
 import type { BuiltInFunction, InternalFunction, TranslatedCodeLine } from "@kipper/core";
-import {genJSFunction, getJSFunctionSignature, JavaScriptTargetBuiltInGenerator} from "@kipper/target-js";
+import { JavaScriptTargetBuiltInGenerator } from "@kipper/target-js";
 import { getTSFunctionSignature, createTSFunctionSignature, getTypeScriptBuiltInIdentifier } from "./tools";
 import { KipperCompilableType } from "@kipper/core";
 

--- a/test/module/core/core-functionality.test.ts
+++ b/test/module/core/core-functionality.test.ts
@@ -27,7 +27,7 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 			assert.include(instance.write(), "let x: number = 5;", "Expected variable declaration to be present in output");
 			assert.include(instance.write(), '__kipper.print("");', "Expected print call to be present in output");
 		});
@@ -37,7 +37,7 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 			assert.include(instance.write(), "let x: number = 5;", "Expected variable declaration to be present in output");
 			assert.include(instance.write(), '__kipper.print("");', "Expected print call to be present in output");
 		});
@@ -49,8 +49,8 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-			assert(instance.write().includes("let x: number;"), "Invalid TypeScript code");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
+			assert(instance.write().includes("let x: number;"), "Invalid TypeScript code (Expected different output)");
 		});
 	});
 
@@ -60,8 +60,8 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-			assert(instance.write().includes("let x: number = 4;"), "Invalid TypeScript code");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
+			assert(instance.write().includes("let x: number = 4;"), "Invalid TypeScript code (Expected different output)");
 		});
 
 		it("const", async () => {
@@ -69,8 +69,8 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-			assert(instance.write().includes("const x: number = 4;"), "Invalid TypeScript code");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
+			assert(instance.write().includes("const x: number = 4;"), "Invalid TypeScript code (Expected different output)");
 		});
 	});
 
@@ -80,8 +80,11 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-			assert(instance.write().includes("let x: number = 4;\nx = 5;"), "Invalid TypeScript code");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
+			assert(
+				instance.write().includes("let x: number = 4;\nx = 5;"),
+				"Invalid TypeScript code (Expected different output)",
+			);
 		});
 
 		it("str", async () => {
@@ -89,8 +92,11 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-			assert(instance.write().includes('let x: string = "4";\nx = "5";'), "Invalid TypeScript code");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
+			assert(
+				instance.write().includes('let x: string = "4";\nx = "5";'),
+				"Invalid TypeScript code (Expected different output)",
+			);
 		});
 	});
 
@@ -100,8 +106,11 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-			assert(instance.write().includes("__kipper.print = __kipper.print;"), "Invalid TypeScript code");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
+			assert(
+				instance.write().includes("__kipper.print = __kipper.print;"),
+				"Invalid TypeScript code (Expected different output)",
+			);
 		});
 
 		it("two expressions", async () => {
@@ -109,9 +118,9 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-			assert(instance.write().includes("12 * 93;"), "Invalid TypeScript code");
-			assert(instance.write().includes('"5" + "1";'), "Invalid TypeScript code");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
+			assert(instance.write().includes("12 * 93;"), "Invalid TypeScript code (Expected different output)");
+			assert(instance.write().includes('"5" + "1";'), "Invalid TypeScript code (Expected different output)");
 		});
 
 		it("three expressions", async () => {
@@ -119,10 +128,10 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-			assert(instance.write().includes('__kipper.print("x");'), "Invalid TypeScript code");
-			assert(instance.write().includes('__kipper.print("y");'), "Invalid TypeScript code");
-			assert(instance.write().includes('__kipper.print("z");'), "Invalid TypeScript code");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
+			assert(instance.write().includes('__kipper.print("x");'), "Invalid TypeScript code (Expected different output)");
+			assert(instance.write().includes('__kipper.print("y");'), "Invalid TypeScript code (Expected different output)");
+			assert(instance.write().includes('__kipper.print("z");'), "Invalid TypeScript code (Expected different output)");
 		});
 	});
 
@@ -132,9 +141,15 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-			assert(instance.write().includes("let x: void = void(0);"), "Invalid TypeScript code");
-			assert(instance.write().includes("let y: void = undefined;"), "Invalid TypeScript code");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
+			assert(
+				instance.write().includes("let x: void = void(0);"),
+				"Invalid TypeScript code (Expected different output)",
+			);
+			assert(
+				instance.write().includes("let y: void = undefined;"),
+				"Invalid TypeScript code (Expected different output)",
+			);
 		});
 
 		it("null", async () => {
@@ -142,8 +157,8 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-			assert(instance.write().includes("let x: null = null;"), "Invalid TypeScript code");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
+			assert(instance.write().includes("let x: null = null;"), "Invalid TypeScript code (Expected different output)");
 		});
 
 		it("undefined", async () => {
@@ -151,9 +166,15 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-			assert(instance.write().includes("let x: undefined = undefined;"), "Invalid TypeScript code");
-			assert(instance.write().includes("let y: void = undefined;"), "Invalid TypeScript code");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
+			assert(
+				instance.write().includes("let x: undefined = undefined;"),
+				"Invalid TypeScript code (Expected different output)",
+			);
+			assert(
+				instance.write().includes("let y: void = undefined;"),
+				"Invalid TypeScript code (Expected different output)",
+			);
 		});
 	});
 
@@ -163,8 +184,8 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-			assert(instance.write().includes("+4;"), "Invalid TypeScript code");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
+			assert(instance.write().includes("+4;"), "Invalid TypeScript code (Expected different output)");
 		});
 
 		it("unary minus", async () => {
@@ -172,8 +193,8 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-			assert(instance.write().includes("-4;"), "Invalid TypeScript code");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
+			assert(instance.write().includes("-4;"), "Invalid TypeScript code (Expected different output)");
 		});
 
 		// Technically, this is a logical operator, but it's considered a unary operator in Kipper, as it modifies
@@ -183,8 +204,8 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
-			assert(instance.write().includes("!true;"), "Invalid TypeScript code");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
+			assert(instance.write().includes("!true;"), "Invalid TypeScript code (Expected different output)");
 		});
 
 		describe("--", () => {
@@ -238,8 +259,11 @@ describe("Core functionality", () => {
 				assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
 
 				const code = instance.write();
-				assert.include(code, "let x: number = 4;", "Invalid TypeScript code");
-				assert(code.includes('if (x > 3 && x < 5) {\n  __kipper.print("Works");\n}'), "Invalid TypeScript code");
+				assert.include(code, "let x: number = 4;", "Invalid TypeScript code (Expected different output)");
+				assert(
+					code.includes('if (x > 3 && x < 5) {\n  __kipper.print("Works");\n}'),
+					"Invalid TypeScript code (Expected different output)",
+				);
 
 				const jsCode = ts.transpile(code);
 				// Overwrite built-in to access output
@@ -262,8 +286,11 @@ describe("Core functionality", () => {
 				assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
 
 				const code = instance.write();
-				assert.include(code, "let x: number = 4;", "Invalid TypeScript code");
-				assert(code.includes('if (x > 3 && x < 2) {\n  __kipper.print("Works");\n}'), "Invalid TypeScript code");
+				assert.include(code, "let x: number = 4;", "Invalid TypeScript code (Expected different output)");
+				assert(
+					code.includes('if (x > 3 && x < 2) {\n  __kipper.print("Works");\n}'),
+					"Invalid TypeScript code (Expected different output)",
+				);
 
 				const jsCode = ts.transpile(code);
 				testPrintOutput(() => assert(false, "Expected no output"), jsCode);
@@ -277,8 +304,11 @@ describe("Core functionality", () => {
 				assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
 
 				const code = instance.write();
-				assert.include(code, "let x: number = 4;", "Invalid TypeScript code");
-				assert(code.includes('if (x > 5 && x < 3) {\n  __kipper.print("Works");\n}'), "Invalid TypeScript code");
+				assert.include(code, "let x: number = 4;", "Invalid TypeScript code (Expected different output)");
+				assert(
+					code.includes('if (x > 5 && x < 3) {\n  __kipper.print("Works");\n}'),
+					"Invalid TypeScript code (Expected different output)",
+				);
 
 				const jsCode = ts.transpile(code);
 				testPrintOutput(() => assert(false, "Expected no output"), jsCode);
@@ -292,8 +322,11 @@ describe("Core functionality", () => {
 				assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
 
 				const code = instance.write();
-				assert.include(code, "let x: number = 4;", "Invalid TypeScript code");
-				assert(code.includes('if (x > 5 && x < 8) {\n  __kipper.print("Works");\n}'), "Invalid TypeScript code");
+				assert.include(code, "let x: number = 4;", "Invalid TypeScript code (Expected different output)");
+				assert(
+					code.includes('if (x > 5 && x < 8) {\n  __kipper.print("Works");\n}'),
+					"Invalid TypeScript code (Expected different output)",
+				);
 
 				const jsCode = ts.transpile(code);
 				testPrintOutput(() => assert(false, "Expected no output"), jsCode);
@@ -309,8 +342,11 @@ describe("Core functionality", () => {
 				assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
 
 				const code = instance.write();
-				assert.include(code, "let x: number = 4;", "Invalid TypeScript code");
-				assert(code.includes('if (x > 3 || x < 5) {\n  __kipper.print("Works");\n}'), "Invalid TypeScript code");
+				assert.include(code, "let x: number = 4;", "Invalid TypeScript code (Expected different output)");
+				assert(
+					code.includes('if (x > 3 || x < 5) {\n  __kipper.print("Works");\n}'),
+					"Invalid TypeScript code (Expected different output)",
+				);
 
 				const jsCode = ts.transpile(code);
 				testPrintOutput((message: any) => assert.equal(message, "Works", "Expected different output"), jsCode);
@@ -324,8 +360,11 @@ describe("Core functionality", () => {
 				assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
 
 				const code = instance.write();
-				assert.include(code, "let x: number = 4;", "Invalid TypeScript code");
-				assert(code.includes('if (x > 3 || x < 2) {\n  __kipper.print("Works");\n}'), "Invalid TypeScript code");
+				assert.include(code, "let x: number = 4;", "Invalid TypeScript code (Expected different output)");
+				assert(
+					code.includes('if (x > 3 || x < 2) {\n  __kipper.print("Works");\n}'),
+					"Invalid TypeScript code (Expected different output)",
+				);
 
 				const jsCode = ts.transpile(code);
 				testPrintOutput((message: any) => assert.equal(message, "Works", "Expected different output"), jsCode);
@@ -339,8 +378,11 @@ describe("Core functionality", () => {
 				assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
 
 				const code = instance.write();
-				assert.include(code, "let x: number = 4;", "Invalid TypeScript code");
-				assert(code.includes('if (x > 5 || x < 3) {\n  __kipper.print("Works");\n}'), "Invalid TypeScript code");
+				assert.include(code, "let x: number = 4;", "Invalid TypeScript code (Expected different output)");
+				assert(
+					code.includes('if (x > 5 || x < 3) {\n  __kipper.print("Works");\n}'),
+					"Invalid TypeScript code (Expected different output)",
+				);
 
 				const jsCode = ts.transpile(code);
 				testPrintOutput((message: any) => assert.equal(message, "Works", "Expected different output"), jsCode);
@@ -354,8 +396,11 @@ describe("Core functionality", () => {
 				assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
 
 				const code = instance.write();
-				assert.include(code, "let x: number = 4;", "Invalid TypeScript code");
-				assert(code.includes('if (x > 5 || x > 8) {\n  __kipper.print("Works");\n}'), "Invalid TypeScript code");
+				assert.include(code, "let x: number = 4;", "Invalid TypeScript code (Expected different output)");
+				assert(
+					code.includes('if (x > 5 || x > 8) {\n  __kipper.print("Works");\n}'),
+					"Invalid TypeScript code (Expected different output)",
+				);
 
 				const jsCode = ts.transpile(code);
 				testPrintOutput(() => assert(false, "Expected no output"), jsCode);
@@ -369,11 +414,15 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
-			assert.include(code, "let x: number = 4;", "Invalid TypeScript code");
-			assert.include(code, 'if (x === 4) {\n  __kipper.print("Works");\n}', "Invalid TypeScript code");
+			assert.include(code, "let x: number = 4;", "Invalid TypeScript code (Expected different output)");
+			assert.include(
+				code,
+				'if (x === 4) {\n  __kipper.print("Works");\n}',
+				"Invalid TypeScript code (Expected different output)",
+			);
 
 			const jsCode = ts.transpile(code);
 			testPrintOutput((message: any) => assert.equal(message, "Works", "Expected different output"), jsCode);
@@ -384,11 +433,14 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
-			assert.include(code, "let x: number = 4;", "Invalid TypeScript code");
-			assert(code.includes('if (x !== 5) {\n  __kipper.print("Works");\n}'), "Invalid TypeScript code");
+			assert.include(code, "let x: number = 4;", "Invalid TypeScript code (Expected different output)");
+			assert(
+				code.includes('if (x !== 5) {\n  __kipper.print("Works");\n}'),
+				"Invalid TypeScript code (Expected different output)",
+			);
 
 			const jsCode = ts.transpile(code);
 			testPrintOutput((message: any) => assert.equal(message, "Works", "Expected different output"), jsCode);
@@ -399,11 +451,14 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
-			assert.include(code, "let x: number = 4;", "Invalid TypeScript code");
-			assert(code.includes('if (x < 5) {\n  __kipper.print("Works");\n}'), "Invalid TypeScript code");
+			assert.include(code, "let x: number = 4;", "Invalid TypeScript code (Expected different output)");
+			assert(
+				code.includes('if (x < 5) {\n  __kipper.print("Works");\n}'),
+				"Invalid TypeScript code (Expected different output)",
+			);
 
 			const jsCode = ts.transpile(code);
 			testPrintOutput((message: any) => assert.equal(message, "Works", "Expected different output"), jsCode);
@@ -414,11 +469,14 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
-			assert.include(code, "let x: number = 4;", "Invalid TypeScript code");
-			assert(code.includes('if (x <= 5) {\n  __kipper.print("Works");\n}'), "Invalid TypeScript code");
+			assert.include(code, "let x: number = 4;", "Invalid TypeScript code (Expected different output)");
+			assert(
+				code.includes('if (x <= 5) {\n  __kipper.print("Works");\n}'),
+				"Invalid TypeScript code (Expected different output)",
+			);
 
 			const jsCode = ts.transpile(code);
 			testPrintOutput((message: any) => assert.equal(message, "Works", "Expected different output"), jsCode);
@@ -429,11 +487,14 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
-			assert.include(code, "let x: number = 5;", "Invalid TypeScript code");
-			assert(code.includes('if (x > 4) {\n  __kipper.print("Works");\n}'), "Invalid TypeScript code");
+			assert.include(code, "let x: number = 5;", "Invalid TypeScript code (Expected different output)");
+			assert(
+				code.includes('if (x > 4) {\n  __kipper.print("Works");\n}'),
+				"Invalid TypeScript code (Expected different output)",
+			);
 
 			const jsCode = ts.transpile(code);
 			testPrintOutput((message: any) => assert.equal(message, "Works", "Expected different output"), jsCode);
@@ -444,11 +505,14 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
-			assert.include(code, "let x: number = 5;", "Invalid TypeScript code");
-			assert(code.includes('if (x >= 4) {\n  __kipper.print("Works");\n}'), "Invalid TypeScript code");
+			assert.include(code, "let x: number = 5;", "Invalid TypeScript code (Expected different output)");
+			assert(
+				code.includes('if (x >= 4) {\n  __kipper.print("Works");\n}'),
+				"Invalid TypeScript code (Expected different output)",
+			);
 
 			const jsCode = ts.transpile(code);
 			testPrintOutput((message: any) => assert.equal(message, "Works", "Expected different output"), jsCode);
@@ -461,10 +525,14 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
-			assert.include(code, "if (true) {\n  let x: number = 5;\n}", "Invalid TypeScript code");
+			assert.include(
+				code,
+				"if (true) {\n  let x: number = 5;\n}",
+				"Invalid TypeScript code (Expected different output)",
+			);
 		});
 
 		it("Two if-else branches", async () => {
@@ -472,13 +540,13 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
 			assert.include(
 				code,
 				"if (true) {\n  let x: number = 5;\n} else {\n  let x: number = 5;\n}",
-				"Invalid TypeScript code",
+				"Invalid TypeScript code (Expected different output)",
 			);
 		});
 
@@ -487,14 +555,14 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
 			assert.include(
 				code,
 				"if (true) {\n  let x: number = 5;\n} else if (true) {\n  let x: number = 5;\n} else {\n  let x: number =" +
 					" 5;\n}",
-				"Invalid TypeScript code",
+				"Invalid TypeScript code (Expected different output)",
 			);
 		});
 	});
@@ -505,10 +573,10 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
-			assert.include(code, "while (x <= 5) {\n  x += 1;\n}", "Invalid TypeScript code");
+			assert.include(code, "while (x <= 5) {\n  x += 1;\n}", "Invalid TypeScript code (Expected different output)");
 
 			const jsCode = ts.transpile(code);
 			testPrintOutput((message: any) => assert.equal(message, "6", "Expected different output"), jsCode);
@@ -519,10 +587,10 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
-			assert.include(code, "while (x <= 10) \n  x += 1;", "Invalid TypeScript code");
+			assert.include(code, "while (x <= 10) \n  x += 1;", "Invalid TypeScript code (Expected different output)");
 
 			const jsCode = ts.transpile(code);
 			testPrintOutput((message: any) => assert.equal(message, "11", "Expected different output"), jsCode);
@@ -533,13 +601,54 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
-			assert.include(code, "while (x < 10) \n  if (x !== 10) {\n    x += 1;\n  }", "Invalid TypeScript code");
+			assert.include(
+				code,
+				"while (x < 10) \n  if (x !== 10) {\n    x += 1;\n  }",
+				"Invalid TypeScript code (Expected different output)",
+			);
 
 			const jsCode = ts.transpile(code);
 			testPrintOutput((message: any) => assert.equal(message, "10", "Expected different output"), jsCode);
+		});
+
+		it("Can be interrupted with break", async () => {
+			const fileContent = "var x: num = 1; while (x < 10) { if (x == 5) break; x += 1; }; print(x as str);";
+			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
+
+			assert.isDefined(instance.programCtx);
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
+
+			const code = instance.write();
+			assert.include(
+				code,
+				"while (x < 10) {\n  if (x === 5) {\n    break;\n  } \n  x += 1;\n}",
+				"Invalid TypeScript code (Expected different output)",
+			);
+
+			const jsCode = ts.transpile(code);
+			testPrintOutput((message: any) => assert.equal(message, "5", "Expected different output"), jsCode);
+		});
+
+		it("Can be interrupted with continue", async () => {
+			const fileContent =
+				"var x: num = 1; var y: num = 1; while (x < 10) { x++; if (x > 5) continue; y++; }; print(y as str);";
+			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
+
+			assert.isDefined(instance.programCtx);
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
+
+			const code = instance.write();
+			assert.include(
+				code,
+				"while (x < 10) {\n  x++;\n  if (x > 5) {\n    continue;\n  } \n  y++;\n}",
+				"Invalid TypeScript code (Expected different output)",
+			);
+
+			const jsCode = ts.transpile(code);
+			testPrintOutput((message: any) => assert.equal(message, "5", "Expected different output"), jsCode);
 		});
 	});
 
@@ -549,10 +658,14 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
-			assert.include(code, "for (let i: number = 0; i < 10; i += 1) {\n  x = i;\n}", "Invalid TypeScript code");
+			assert.include(
+				code,
+				"for (let i: number = 0; i < 10; i += 1) {\n  x = i;\n}",
+				"Invalid TypeScript code (Expected different output)",
+			);
 
 			const jsCode = ts.transpile(code);
 			testPrintOutput((message: any) => assert.equal(message, "9", "Expected different output"), jsCode);
@@ -563,10 +676,14 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
-			assert.include(code, "for (let i: number = 0; i < 10; i += 1) \n  x = i;", "Invalid TypeScript code");
+			assert.include(
+				code,
+				"for (let i: number = 0; i < 10; i += 1) \n  x = i;",
+				"Invalid TypeScript code (Expected different output)",
+			);
 
 			const jsCode = ts.transpile(code);
 			testPrintOutput((message: any) => assert.equal(message, "9", "Expected different output"), jsCode);
@@ -577,13 +694,51 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
 			assert.include(
 				code,
 				"for (let i: number = 0; i < 10; i += 1) \n  if (i !== 10) {\n    x = i;\n  }",
-				"Invalid TypeScript code",
+				"Invalid TypeScript code (Expected different output)",
+			);
+
+			const jsCode = ts.transpile(code);
+			testPrintOutput((message: any) => assert.equal(message, "9", "Expected different output"), jsCode);
+		});
+
+		it("Can be interrupted with break", async () => {
+			const fileContent =
+				"var x: num = 1; for (var i: num = 0; i < 10; i += 1) { if (i == 5) break; x = i; }; print(x as str);";
+			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
+
+			assert.isDefined(instance.programCtx);
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
+
+			const code = instance.write();
+			assert.include(
+				code,
+				"for (let i: number = 0; i < 10; i += 1) {\n  if (i === 5) {\n    break;\n  } \n  x = i;\n}",
+				"Invalid TypeScript code (Expected different output)",
+			);
+
+			const jsCode = ts.transpile(code);
+			testPrintOutput((message: any) => assert.equal(message, "4", "Expected different output"), jsCode);
+		});
+
+		it("Can be interrupted with continue", async () => {
+			const fileContent =
+				"var x: num = 1; for (var i: num = 0; i < 10; i += 1) { if (i == 5) continue; x = i; }; print(x as str);";
+			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
+
+			assert.isDefined(instance.programCtx);
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
+
+			const code = instance.write();
+			assert.include(
+				code,
+				"for (let i: number = 0; i < 10; i += 1) {\n  if (i === 5) {\n    continue;\n  } \n  x = i;\n}",
+				"Invalid TypeScript code (Expected different output)",
 			);
 
 			const jsCode = ts.transpile(code);
@@ -690,10 +845,10 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
-			assert.include(code, "function test(): void {\n}", "Invalid TypeScript code");
+			assert.include(code, "function test(): void {\n}", "Invalid TypeScript code (Expected different output)");
 		});
 
 		it("Call", async () => {
@@ -701,13 +856,13 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
 			assert.include(
 				code,
 				'function test(): void {\n  __kipper.print("Works");\n  return;\n}',
-				"Invalid TypeScript code",
+				"Invalid TypeScript code (Expected different output)",
 			);
 
 			const jsCode = ts.transpile(code);
@@ -719,13 +874,13 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
 			assert.include(
 				code,
 				"function test(): number {\n  return 5;\n}\n__kipper.print(__kipper.numToStr(test()));",
-				"Invalid TypeScript code",
+				"Invalid TypeScript code (Expected different output)",
 			);
 
 			const jsCode = ts.transpile(code);
@@ -737,13 +892,13 @@ describe("Core functionality", () => {
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
-			assert(instance.programCtx.errors.length === 0, "Expected no compilation errors");
+			assert.equal(instance.programCtx.errors.length, 0, "Expected no compilation errors");
 
 			const code = instance.write();
 			assert.include(
 				code,
 				"function test(x: number, y: string): number {\n  return x + __kipper.strToNum(y);\n}",
-				"Invalid TypeScript code",
+				"Invalid TypeScript code (Expected different output)",
 			);
 
 			const jsCode = ts.transpile(code);

--- a/test/module/core/not-implemented.test.ts
+++ b/test/module/core/not-implemented.test.ts
@@ -60,18 +60,4 @@ describe("NotImplemented", () => {
 		}
 		assert.fail("Expected NotImplementedError");
 	});
-
-	it("Jump Statements", async () => {
-		try {
-			await new KipperCompiler().compile("break;", {
-				abortOnFirstError: true,
-				target: defaultTarget,
-			});
-		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "KipperNotImplementedError", "Expected different error");
-			assert.equal((<KipperError>e).name, "NotImplementedError", "Expected different error");
-			return;
-		}
-		assert.fail("Expected NotImplementedError");
-	});
 });


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it -->

- [x] New feature (Non-breaking change which adds functionality)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

<!-- Explain the reason for this pr, changes and solution briefly. -->

Implemented support for jump statements (or control flow statements) `continue` and `break` in iteration statements.

Closes #269 

## Summary of Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

- Finished implementation of the jump statements, as they were already partially implemented.
- Added semantic checks to ensure the statements are only used inside loops.
- Implemented code generation for both `continue` and `break`.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Detailed Changelog

_Not present for website/docs changes_

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added and remove any header with no item.). -->

### Added

- Support for jump statements `continue` and `break` for iteration statements. ([#269](https://github.com/Luna-Klatzer/Kipper/issues/269)).
- New function `KipperSemanticChecker.getJumpStatementParent()`, which evaluates the parent iteration statement for a jump statement.


## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [x] #269 
