### PR TITLE
Fixed bug causing useless statement warning not being raised for an arithmetic expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ To use development versions of Kipper download the
 
 ### Fixed
 
+- Bug causing the compiler to not detect the expected useless statement warning for a useless arithmetic 
+  expression. ([#426](https://github.com/Luna-Klatzer/Kipper/issues/426)).
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ To use development versions of Kipper download the
 
 ### Fixed
 
+- Fixed bug causing the compiler to not detect the expected useless statement warning for a useless arithmetic 
+  expression. ([#426](https://github.com/Luna-Klatzer/Kipper/issues/426)).
+
 ### Deprecated
 
 ### Removed

--- a/kipper/cli/README.md
+++ b/kipper/cli/README.md
@@ -21,9 +21,10 @@ and the [Kipper website](https://kipper-lang.org)._
 [![Publish size](https://badgen.net/packagephobia/publish/@kipper/cli)](https://packagephobia.com/result?p=@kipper/cli)
 
 <!-- toc -->
-* [Kipper CLI - `@kipper/cli`](#kipper-cli---kippercli)
-* [Usage](#usage)
-* [Commands](#commands)
+
+- [Kipper CLI - `@kipper/cli`](#kipper-cli---kippercli)
+- [Usage](#usage)
+- [Commands](#commands)
 <!-- tocstop -->
 
 ## General Information
@@ -38,6 +39,7 @@ and the [Kipper website](https://kipper-lang.org)._
 # Usage
 
 <!-- usage -->
+
 ```sh-session
 $ npm install -g @kipper/cli
 $ kipper COMMAND
@@ -49,16 +51,18 @@ USAGE
   $ kipper COMMAND
 ...
 ```
+
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-* [`kipper analyse [FILE]`](#kipper-analyse-file)
-* [`kipper compile [FILE]`](#kipper-compile-file)
-* [`kipper help [COMMAND]`](#kipper-help-command)
-* [`kipper run [FILE]`](#kipper-run-file)
-* [`kipper version`](#kipper-version)
+
+- [`kipper analyse [FILE]`](#kipper-analyse-file)
+- [`kipper compile [FILE]`](#kipper-compile-file)
+- [`kipper help [COMMAND]`](#kipper-help-command)
+- [`kipper run [FILE]`](#kipper-run-file)
+- [`kipper version`](#kipper-version)
 
 ## `kipper analyse [FILE]`
 
@@ -187,6 +191,7 @@ USAGE
 ```
 
 _See code: [src/commands/version.ts](https://github.com/Luna-Klatzer/Kipper/blob/v0.10.0/kipper/cli/src/commands/version.ts)_
+
 <!-- commandsstop -->
 
 ## Copyright and License

--- a/kipper/core/src/compiler/analysis/analyser/warning-issuer.ts
+++ b/kipper/core/src/compiler/analysis/analyser/warning-issuer.ts
@@ -66,10 +66,10 @@ export class KipperWarningIssuer extends KipperSemanticErrorHandler {
 	 */
 	public uselessStatement(expStatement: ExpressionStatement): void {
 		const hasSideEffects = (node: Expression): boolean =>
-			node.children.some((child) => child.hasSideEffects || hasSideEffects(child));
+			node.hasSideEffects() || node.children.some((child) => hasSideEffects(child));
 
 		// Check whether the expression statement has side effects
-		const expStatementHasSideEffects = expStatement.children.some((child) => hasSideEffects(child));
+		const expStatementHasSideEffects = expStatement.children.some(hasSideEffects);
 		if (!expStatementHasSideEffects) {
 			this.issueWarning(new UselessExpressionStatementWarning());
 		}

--- a/test/module/core/warnings/useless-statement.ts
+++ b/test/module/core/warnings/useless-statement.ts
@@ -4,7 +4,7 @@ import { assert } from "chai";
 
 describe("UselessExpressionStatementWarning", () => {
 	describe("Warning", () => {
-		it("Useless arithmetic expression", async () => {
+		it("Useless constant", async () => {
 			let result = await new KipperCompiler().compile("1;", defaultConfig);
 
 			// Ensure a warning is given and is not undefined
@@ -15,7 +15,41 @@ describe("UselessExpressionStatementWarning", () => {
 				"UselessExpressionStatementWarning",
 				"Expected different warning",
 			);
-			return;
+		});
+		[
+			{ code: "1 + 2;", name: "Single" },
+			{ code: "1 + 2 + 3 / 4 * 5 ** 6;", name: "Chained" },
+		].forEach((o) => {
+			it(`Useless arithmetic expression (${o.name})`, async () => {
+				let result = await new KipperCompiler().compile(o.code, defaultConfig);
+
+				// Ensure a warning is given and is not undefined
+				ensureTracebackDataExists(result.warnings[0]);
+				ensureWarningWasReported(result.programCtx);
+				assert.equal(
+					result.warnings[0].constructor.name,
+					"UselessExpressionStatementWarning",
+					"Expected different warning",
+				);
+			});
+		});
+
+		[
+			{ code: "true && false;", name: "Single" },
+			{ code: "true && false && true && false;", name: "Chained" },
+		].forEach((o) => {
+			it(`Useless boolean expression (${o.name})`, async () => {
+				let result = await new KipperCompiler().compile(o.code, defaultConfig);
+
+				// Ensure a warning is given and is not undefined
+				ensureTracebackDataExists(result.warnings[0]);
+				ensureWarningWasReported(result.programCtx);
+				assert.equal(
+					result.warnings[0].constructor.name,
+					"UselessExpressionStatementWarning",
+					"Expected different warning",
+				);
+			});
 		});
 
 		it("Useless identifier reference", async () => {
@@ -29,7 +63,6 @@ describe("UselessExpressionStatementWarning", () => {
 				"UselessExpressionStatementWarning",
 				"Expected different warning",
 			);
-			return;
 		});
 	});
 


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it -->

- [x] Bug fix (Non-breaking change which fixes an issue)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

<!-- Explain the reason for this pr, changes and solution briefly. -->

Fixed bug causing the compiler to not detect the expected useless statement warning for a useless arithmetic expression.

Closes #426 

## Summary of Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

- Bug causing the compiler to not detect the expected useless statement warning for a useless arithmetic expression.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Detailed Changelog

_Not present for website/docs changes_

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added and remove any header with no item.). -->

### Fixed

- Bug causing the compiler to not detect the expected useless statement warning for a useless arithmetic 
  expression. ([#426](https://github.com/Luna-Klatzer/Kipper/issues/426)).

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

<!-- Default: -->

No linked issues.
