### PR TITLE
Fixed bug of internal error being thrown after a redeclaration of a variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ To use development versions of Kipper download the
 
 ### Added
 
-- Support for complex string formatting (or also called templating) in the form of Python-like F-Strings. 
+- Support for complex string formatting (or also called templating) in the form of Python-like F-Strings.
   ([#287](https://github.com/Luna-Klatzer/Kipper/issues/287)).
 - New valid conversions:
   - `void` to `str`.
@@ -48,6 +48,9 @@ To use development versions of Kipper download the
   - `getTSFunction()` to `genTSFunction()`.
 
 ### Fixed
+
+- Redeclaration bug causing an `InternalError` after calling the compiler 
+  ([#462](https://github.om/Luna-Klatzer/Kipper/issues/462)).
 
 ### Deprecated
 

--- a/kipper/core/src/compiler/ast/analysable-ast-node.ts
+++ b/kipper/core/src/compiler/ast/analysable-ast-node.ts
@@ -268,9 +268,11 @@ export abstract class AnalysableASTNode<
 		// Start with the evaluation of the children
 		await this.semanticallyTypeCheckChildren();
 
-		// If the semantic analysis until now hasn't failed, do the semantic type checking of this node (if defined)
+		// If the semantic analysis until now has evaluated data, do the semantic type checking of this node (if defined)
 		// Per default, we will say the nodes themselves handle all errors, so we don't need to do anything here
 		// Note! Expressions do this differently and abort immediately all processing if one of the children failed.
+		// Additionally, this will also not check for 'this.hasFailed', as we still want to run type checking if possible
+		// even with a logic error in the code (so we only check for the semantic data)
 		if (this.semanticData && this.primarySemanticTypeChecking !== undefined) {
 			try {
 				await this.primarySemanticTypeChecking();
@@ -309,9 +311,11 @@ export abstract class AnalysableASTNode<
 		// Start with the evaluation of the children
 		await this.targetSemanticallyAnalyseChildren();
 
-		// If the semantic analysis until now hasn't failed, do the target semantic analysis of this node (if defined)
+		// If the semantic analysis until now has evaluated data, do the target semantic analysis of this node (if defined)
 		// Per default, we will say the nodes themselves handle all errors, so we don't need to do anything here
 		// Note! Expressions do this differently and abort immediately all processing if one of the children failed.
+		// Additionally, this will also not check for 'this.hasFailed', as we still want to run the target semantic
+		// analysis if possible even with a logic error in the code (so we only check for the semantic data)
 		if (this.semanticData && this.typeSemantics && this.targetSemanticAnalysis !== undefined) {
 			try {
 				await this.targetSemanticAnalysis(this);
@@ -335,7 +339,7 @@ export abstract class AnalysableASTNode<
 		}
 
 		// If the check for warnings function is defined, then call it
-		if (this.checkForWarnings && !this.hasFailed) {
+		if (!this.hasFailed && this.checkForWarnings) {
 			await this.checkForWarnings();
 		}
 	}

--- a/kipper/core/src/compiler/ast/nodes/declarations/variable-declaration.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/variable-declaration.ts
@@ -172,6 +172,7 @@ export class VariableDeclaration extends Declaration<VariableDeclarationSemantic
 		// If the variable is defined, check whether the assignment is valid
 		if (semanticData.value) {
 			semanticData.value.ensureTypeSemanticallyValid(); // Ensure the assignment didn't fail
+			this.ensureScopeDeclarationAvailableIfNeeded(); // Ensure the scope declaration is available
 			this.programCtx.typeCheck(this).validVariableDefinition(this.getScopeDeclaration(), semanticData.value);
 		}
 	}


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it -->

- [x] Bug fix (Non-breaking change which fixes an issue)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

<!-- Explain the reason for this pr, changes and solution briefly. -->

Fixed bug of internal error being thrown after a redeclaration of a variable.

Closes #462 

## Summary of Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

- Fixed bug according to #462.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Detailed Changelog

_Not present for website/docs changes_

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added and remove any header with no item.). -->

### Added

- New function `ensureScopeDeclarationAvailableIfNeeded`, which ensures that a scope declaration is available if needed. This is used during the semantic analysis/type checking of a declaration statement, which may need the scope declaration object during the processing.

### Fixed

- Redeclaration bug causing an `InternalError` after calling the compiler ([#462](https://github.om/Luna-Klatzer/Kipper/issues/462)).

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [x] #462 
