### PR TITLE
Fixed bug of invalid underline indent in error traceback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ To use development versions of Kipper download the
 	([#462](https://github.com/Luna-Klatzer/Kipper/issues/462)).
 - Compiler argument bug in `KipperCompiler`, where `abortOnFirstError` didn't precede `recover`, meaning that instead
   of an error being thrown the failed result was returned (As defined in the `recover` behaviour, which is incorrect).
+- Bug of invalid underline indent in error traceback.
+	([#434](https://github.com/Luna-Klatzer/Kipper/issues/434)).
 
 ### Deprecated
 

--- a/kipper/core/src/errors.ts
+++ b/kipper/core/src/errors.ts
@@ -82,6 +82,9 @@ export class KipperError extends Error {
 	 * @since 0.3.0
 	 */
 	public getTraceback(): string {
+		// Sanitize the traceback message (No actual newlines)
+		this.message = this.message.replace(/\n/g, "\\n");
+
 		const tokenSrc = (() => {
 			if (
 				this.tracebackData.location?.line !== undefined &&
@@ -93,8 +96,16 @@ export class KipperError extends Error {
 				let startOfError = this.tracebackData.location.col;
 
 				// In case the error is at the exact end of the line, mark the whole line as the error origin
-				if (startOfError === this.tracebackData.tokenSrc.length) {
-					startOfError = 0;
+				if (startOfError === (srcLine.length - 1)) {
+					let countOfLeadingSpaces = 0;
+					for (const char of srcLine) {
+						if (char === " ") {
+							countOfLeadingSpaces++;
+						} else {
+							break;
+						}
+					}
+					startOfError = countOfLeadingSpaces; // Set the start of the error to the first non-space character
 				}
 
 				let endOfError = startOfError + this.tracebackData.tokenSrc.length;

--- a/test/module/core/errors/kipper-error.ts
+++ b/test/module/core/errors/kipper-error.ts
@@ -3,25 +3,92 @@ import { defaultConfig, ensureTracebackDataExists } from "./index";
 import { assert } from "chai";
 
 describe("KipperError", () => {
-	it("getTraceback", async () => {
-		try {
-			await new KipperCompiler().compile('var i: str = "4";\n var i: str = "4";', defaultConfig);
-		} catch (e) {
-			assert.equal(
-				(<KipperError>e).constructor.name,
-				"IdentifierAlreadyUsedByVariableError",
-				"Expected different error",
-			);
-			ensureTracebackDataExists(<KipperError>e);
-			assert.equal(
-				(<KipperError>e).getTraceback(),
-				`Traceback:\nFile 'anonymous-script', line 2, col 1:\n` +
-					`   var i: str = "4";\n` +
-					`   ^^^^^^^^^^^^^^^^ \n` +
+	describe("getTraceback", () => {
+		it("Inside String Underline (No leading or trailing Spaces)", async () => {
+			try {
+				await new KipperCompiler().compile('var i: str = "4";\nvar i: str = "4";', defaultConfig);
+			} catch (e) {
+				assert.equal(
+					(<KipperError>e).constructor.name,
+					"IdentifierAlreadyUsedByVariableError",
+					"Expected different error",
+				);
+				ensureTracebackDataExists(<KipperError>e);
+				assert.equal(
+					(<KipperError>e).getTraceback(),
+					`Traceback:\nFile 'anonymous-script', line 2, col 0:\n` +
+					`  var i: str = "4";\n` +
+					`  ^^^^^^^^^^^^^^^^ \n` +
 					`${(<KipperError>e).name}: ${(<KipperError>e).message}`,
-			);
-			return;
-		}
-		assert.fail("Expected 'IdentifierAlreadyUsedByVariableError'");
+				);
+				return;
+			}
+			assert.fail("Expected 'IdentifierAlreadyUsedByVariableError'");
+		});
+
+		it("Inside String Underline (Leading Spaces)", async () => {
+			try {
+				await new KipperCompiler().compile('var i: str = "4";\n   var i: str = "4";', defaultConfig);
+			} catch (e) {
+				assert.equal(
+					(<KipperError>e).constructor.name,
+					"IdentifierAlreadyUsedByVariableError",
+					"Expected different error",
+				);
+				ensureTracebackDataExists(<KipperError>e);
+				assert.equal(
+					(<KipperError>e).getTraceback(),
+					`Traceback:\nFile 'anonymous-script', line 2, col 3:\n` +
+					`     var i: str = "4";\n` +
+					`     ^^^^^^^^^^^^^^^^ \n` +
+					`${(<KipperError>e).name}: ${(<KipperError>e).message}`,
+				);
+				return;
+			}
+			assert.fail("Expected 'IdentifierAlreadyUsedByVariableError'");
+		});
+
+		it("Inside String Underline (Trailing Spaces)", async () => {
+			try {
+				await new KipperCompiler().compile('var i: str = "4";\n   var i: str = "4";  ', defaultConfig);
+			} catch (e) {
+				assert.equal(
+					(<KipperError>e).constructor.name,
+					"IdentifierAlreadyUsedByVariableError",
+					"Expected different error",
+				);
+				ensureTracebackDataExists(<KipperError>e);
+				assert.equal(
+					(<KipperError>e).getTraceback(),
+					`Traceback:\nFile 'anonymous-script', line 2, col 3:\n` +
+					`     var i: str = "4";  \n` +
+					`     ^^^^^^^^^^^^^^^^   \n` +
+					`${(<KipperError>e).name}: ${(<KipperError>e).message}`,
+				);
+				return;
+			}
+			assert.fail("Expected 'IdentifierAlreadyUsedByVariableError'");
+		});
+
+		it("Whole String Underline", async () => {
+			try {
+				await new KipperCompiler().compile('\\\\\\\\', defaultConfig);
+			} catch (e) {
+				assert.equal(
+					(<KipperError>e).constructor.name,
+					"LexerOrParserSyntaxError",
+					"Expected different error",
+				);
+				ensureTracebackDataExists(<KipperError>e);
+				assert.equal(
+					(<KipperError>e).getTraceback(),
+					`Traceback:\nFile 'anonymous-script', line 1, col 0:\n` +
+					`  \\\\\\\\\n` +
+					`  ^^^^\n` +
+					`${(<KipperError>e).name}: ${(<KipperError>e).message}`,
+				);
+				return;
+			}
+		});
 	});
 });


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it -->

- [x] Bug fix (Non-breaking change which fixes an issue)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

<!-- Explain the reason for this pr, changes and solution briefly. -->

Fixes bug causing the compiler to generate an invalid traceback where the underline indent is off.

Closes #434 

## Summary of Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

- Updated traceback code generation, where the issue #434 occurred.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Detailed Changelog

_Not present for website/docs changes_

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added and remove any header with no item.). -->

### Fixed

- Bug of invalid underline indent in error traceback. ([#434](https://github.com/Luna-Klatzer/Kipper/issues/434)).

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [x] #434 