### PR TITLE
Fixed bug where the `-t` flag was shown as possible alias for the flag `--log-timestamp` in the `compile` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ To use development versions of Kipper download the
 
 ### Fixed
 
+- CLI bug where the `-t` shortcut flag was incorrectly shown for the command `help compile`.
+	([#451](https://github.com/Luna-Klatzer/Kipper/issues/451))
+
 ### Deprecated
 
 ### Removed

--- a/kipper/cli/src/commands/compile.ts
+++ b/kipper/cli/src/commands/compile.ts
@@ -18,6 +18,7 @@ import { Logger } from "tslog";
 import { CLIEmitHandler, defaultCliLogger, defaultKipperLoggerConfig } from "../logger";
 import { KipperEncoding, KipperEncodings, KipperParseFile, verifyEncoding } from "../file-stream";
 import { getFile, getTarget, writeCompilationResult } from "../compile";
+import { EvaluatedCompileConfig } from "@kipper/core";
 
 export default class Compile extends Command {
 	static override description = "Compile a Kipper program into the specified target language.";
@@ -69,24 +70,24 @@ export default class Compile extends Command {
 			allowNo: true,
 		}),
 		warnings: flags.boolean({
+			// This is different to the compile config field 'warnings', since this is purely about the CLI output
 			char: "w",
 			default: true,
 			description: "Show warnings that were emitted during the compilation.",
 			allowNo: true,
 		}),
 		"log-timestamp": flags.boolean({
-			char: "t",
 			default: false,
 			description: "Show the timestamp of each log message.",
 			allowNo: true,
 		}),
 		recover: flags.boolean({
-			default: true,
+			default: EvaluatedCompileConfig.defaults.recover,
 			description: "Recover from compiler errors and log all detected semantic issues.",
 			allowNo: true,
 		}),
 		"abort-on-first-error": flags.boolean({
-			default: false,
+			default: EvaluatedCompileConfig.defaults.abortOnFirstError,
 			description: "Abort on the first error the compiler encounters.",
 			allowNo: true,
 		}),

--- a/kipper/cli/src/commands/run.ts
+++ b/kipper/cli/src/commands/run.ts
@@ -5,6 +5,7 @@
 import { Command, flags } from "@oclif/command";
 import {
 	defaultOptimisationOptions,
+	EvaluatedCompileConfig,
 	KipperCompiler,
 	KipperCompileResult,
 	KipperCompileTarget,
@@ -77,17 +78,18 @@ export default class Run extends Command {
 		}),
 		"optimise-internals": flags.boolean({
 			char: "i",
-			default: <boolean>defaultOptimisationOptions.optimiseInternals,
+			default: defaultOptimisationOptions.optimiseInternals,
 			description: "Optimise the generated internal functions using tree-shaking to reduce the size of the output.",
 			allowNo: true,
 		}),
 		"optimise-builtins": flags.boolean({
 			char: "b",
-			default: <boolean>defaultOptimisationOptions.optimiseInternals,
+			default: defaultOptimisationOptions.optimiseInternals,
 			description: "Optimise the generated built-in functions using tree-shaking to reduce the size of the output.",
 			allowNo: true,
 		}),
 		warnings: flags.boolean({
+			// This is different to the compile config field 'warnings', since this is purely about the CLI output
 			char: "w",
 			default: false, // Log warnings ONLY if the user intends to do so
 			description: "Show warnings that were emitted during the compilation.",
@@ -99,12 +101,12 @@ export default class Run extends Command {
 			allowNo: true,
 		}),
 		recover: flags.boolean({
-			default: true,
+			default: EvaluatedCompileConfig.defaults.recover,
 			description: "Recover from compiler errors and display all detected compiler errors.",
 			allowNo: true,
 		}),
 		"abort-on-first-error": flags.boolean({
-			default: false,
+			default: EvaluatedCompileConfig.defaults.abortOnFirstError,
 			description: "Abort on the first error the compiler encounters. Same behaviour as '--no-recover'.",
 			allowNo: true,
 		}),


### PR DESCRIPTION
## What type of change does this PR perform?

<!-- Add an x in the checkbox to mark it -->

- [x] Bug fix (Non-breaking change which fixes an issue)

<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

## Summary

<!-- Explain the reason for this pr, changes and solution briefly. -->

Fixed flag bug and made minor optimisations/clarifications in the affected code.

Closes #451

## Summary of Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

- Fixed the given bug according to the error description.
- Made minor optimisations/clarifications in the affected code.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

No.

<!-- Remove example text! -->

## Detailed Changelog

_Not present for website/docs changes_

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added and remove any header with no item.). -->

### Fixed

- CLI bug where the `-t` shortcut flag was incorrectly shown for the command `help compile`. ([#451](https://github.com/Luna-Klatzer/Kipper/issues/451))

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [x] #451 
