### PR TITLE
v0.11.0-alpha.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ To use development versions of Kipper download the
   ([#502](https://github.com/Kipper-Lang/Kipper/issues/502)).
 - Support for complex string formatting (or also called templating) in the form of Python-like F-Strings.
   ([#287](https://github.com/Kipper-Lang/Kipper/issues/287)).
+- Support for string multiplication using the `*` operator.
+	([#478](https://github.com/Kipper-Lang/Kipper/issues/478)).
 - New valid conversions:
   - `void` to `str`.
   - `null` to `str`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ To use development versions of Kipper download the
 - Support for complex string formatting (or also called templating) in the form of Python-like F-Strings.
   ([#287](https://github.com/Kipper-Lang/Kipper/issues/287)).
 - Support for string multiplication using the `*` operator.
-	([#478](https://github.com/Kipper-Lang/Kipper/issues/478)).
+  ([#478](https://github.com/Kipper-Lang/Kipper/issues/478)).
 - New valid conversions:
   - `void` to `str`.
   - `null` to `str`.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ authors:
 identifiers:
   - type: url
     value: >-
-      https://github.com/Kipper-Lang/Kipper/releases/tag/v0.11.0-alpha.3
-    description: The GitHub release URL of tag 0.11.0-alpha.3
+      https://github.com/Kipper-Lang/Kipper/releases/tag/v0.11.0-alpha.4
+    description: The GitHub release URL of tag 0.11.0-alpha.4
 repository-code: 'https://github.com/Kipper-Lang/Kipper/'
 url: 'https://kipper-lang.org'
 abstract: >-
@@ -31,6 +31,6 @@ keywords:
   - oop-programming
   - type-safety
 license: GPL-3.0-or-later
-license-url: 'https://github.com/Kipper-Lang/Kipper/blob/v0.11.0-alpha.3/LICENSE'
-version: 0.11.0-alpha.3
+license-url: 'https://github.com/Kipper-Lang/Kipper/blob/v0.11.0-alpha.4/LICENSE'
+version: 0.11.0-alpha.4
 date-released: '2023-08-15'

--- a/kipper/cli/README.md
+++ b/kipper/cli/README.md
@@ -22,10 +22,9 @@ and the [Kipper website](https://kipper-lang.org)._
 [![DOI](https://zenodo.org/badge/411260595.svg)](https://zenodo.org/badge/latestdoi/411260595)
 
 <!-- toc -->
-
-- [Kipper CLI - `@kipper/cli` 🦊✨](#kipper-cli---kippercli-)
-- [Usage](#usage)
-- [Commands](#commands)
+* [Kipper CLI - `@kipper/cli` 🦊✨](#kipper-cli---kippercli-)
+* [Usage](#usage)
+* [Commands](#commands)
 <!-- tocstop -->
 
 ## General Information
@@ -40,31 +39,28 @@ and the [Kipper website](https://kipper-lang.org)._
 # Usage
 
 <!-- usage -->
-
 ```sh-session
 $ npm install -g @kipper/cli
 $ kipper COMMAND
 running command...
 $ kipper (--version)
-@kipper/cli/0.11.0-alpha.3 linux-x64 node-v20.10.0
+@kipper/cli/0.11.0-alpha.4 linux-x64 node-v20.10.0
 $ kipper --help [COMMAND]
 USAGE
   $ kipper COMMAND
 ...
 ```
-
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-
-- [`kipper analyse [FILE]`](#kipper-analyse-file)
-- [`kipper compile [FILE]`](#kipper-compile-file)
-- [`kipper help [COMMAND]`](#kipper-help-command)
-- [`kipper new [LOCATION]`](#kipper-new-location)
-- [`kipper run [FILE]`](#kipper-run-file)
-- [`kipper version`](#kipper-version)
+* [`kipper analyse [FILE]`](#kipper-analyse-file)
+* [`kipper compile [FILE]`](#kipper-compile-file)
+* [`kipper help [COMMAND]`](#kipper-help-command)
+* [`kipper new [LOCATION]`](#kipper-new-location)
+* [`kipper run [FILE]`](#kipper-run-file)
+* [`kipper version`](#kipper-version)
 
 ## `kipper analyse [FILE]`
 
@@ -86,7 +82,7 @@ OPTIONS
   -w, --[no-]warnings            Show warnings that were emitted during the analysis.
 ```
 
-_See code: [src/commands/analyse.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.11.0-alpha.3/kipper/cli/src/commands/analyse.ts)_
+_See code: [src/commands/analyse.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.11.0-alpha.4/kipper/cli/src/commands/analyse.ts)_
 
 ## `kipper compile [FILE]`
 
@@ -126,7 +122,7 @@ OPTIONS
   --[no-]recover                 Recover from compiler errors and log all detected semantic issues.
 ```
 
-_See code: [src/commands/compile.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.11.0-alpha.3/kipper/cli/src/commands/compile.ts)_
+_See code: [src/commands/compile.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.11.0-alpha.4/kipper/cli/src/commands/compile.ts)_
 
 ## `kipper help [COMMAND]`
 
@@ -143,7 +139,7 @@ OPTIONS
   --all  see all commands in CLI
 ```
 
-_See code: [src/commands/help.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.11.0-alpha.3/kipper/cli/src/commands/help.ts)_
+_See code: [src/commands/help.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.11.0-alpha.4/kipper/cli/src/commands/help.ts)_
 
 ## `kipper new [LOCATION]`
 
@@ -160,7 +156,7 @@ OPTIONS
   -d, --default  Use the default settings for the new project. Skips the setup wizard.
 ```
 
-_See code: [src/commands/new.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.11.0-alpha.3/kipper/cli/src/commands/new.ts)_
+_See code: [src/commands/new.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.11.0-alpha.4/kipper/cli/src/commands/new.ts)_
 
 ## `kipper run [FILE]`
 
@@ -199,7 +195,7 @@ OPTIONS
   --[no-]recover                 Recover from compiler errors and display all detected compiler errors.
 ```
 
-_See code: [src/commands/run.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.11.0-alpha.3/kipper/cli/src/commands/run.ts)_
+_See code: [src/commands/run.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.11.0-alpha.4/kipper/cli/src/commands/run.ts)_
 
 ## `kipper version`
 
@@ -210,8 +206,7 @@ USAGE
   $ kipper version
 ```
 
-_See code: [src/commands/version.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.11.0-alpha.3/kipper/cli/src/commands/version.ts)_
-
+_See code: [src/commands/version.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.11.0-alpha.4/kipper/cli/src/commands/version.ts)_
 <!-- commandsstop -->
 
 ## Contributing to Kipper

--- a/kipper/cli/README.md
+++ b/kipper/cli/README.md
@@ -22,9 +22,10 @@ and the [Kipper website](https://kipper-lang.org)._
 [![DOI](https://zenodo.org/badge/411260595.svg)](https://zenodo.org/badge/latestdoi/411260595)
 
 <!-- toc -->
-* [Kipper CLI - `@kipper/cli` 🦊✨](#kipper-cli---kippercli-)
-* [Usage](#usage)
-* [Commands](#commands)
+
+- [Kipper CLI - `@kipper/cli` 🦊✨](#kipper-cli---kippercli-)
+- [Usage](#usage)
+- [Commands](#commands)
 <!-- tocstop -->
 
 ## General Information
@@ -39,28 +40,31 @@ and the [Kipper website](https://kipper-lang.org)._
 # Usage
 
 <!-- usage -->
+
 ```sh-session
 $ npm install -g @kipper/cli
 $ kipper COMMAND
 running command...
 $ kipper (--version)
-@kipper/cli/0.11.0-alpha.3 linux-x64 node-v18.18.2
+@kipper/cli/0.11.0-alpha.3 linux-x64 node-v20.10.0
 $ kipper --help [COMMAND]
 USAGE
   $ kipper COMMAND
 ...
 ```
+
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-* [`kipper analyse [FILE]`](#kipper-analyse-file)
-* [`kipper compile [FILE]`](#kipper-compile-file)
-* [`kipper help [COMMAND]`](#kipper-help-command)
-* [`kipper new [LOCATION]`](#kipper-new-location)
-* [`kipper run [FILE]`](#kipper-run-file)
-* [`kipper version`](#kipper-version)
+
+- [`kipper analyse [FILE]`](#kipper-analyse-file)
+- [`kipper compile [FILE]`](#kipper-compile-file)
+- [`kipper help [COMMAND]`](#kipper-help-command)
+- [`kipper new [LOCATION]`](#kipper-new-location)
+- [`kipper run [FILE]`](#kipper-run-file)
+- [`kipper version`](#kipper-version)
 
 ## `kipper analyse [FILE]`
 
@@ -207,6 +211,7 @@ USAGE
 ```
 
 _See code: [src/commands/version.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.11.0-alpha.3/kipper/cli/src/commands/version.ts)_
+
 <!-- commandsstop -->
 
 ## Contributing to Kipper

--- a/kipper/cli/package.json
+++ b/kipper/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kipper/cli",
   "description": "The Kipper Command Line Interface (CLI).",
-  "version": "0.11.0-alpha.3",
+  "version": "0.11.0-alpha.4",
   "author": "Luna-Klatzer @Luna-Klatzer",
   "bin": {
     "kipper": "./bin/run"

--- a/kipper/cli/package.json
+++ b/kipper/cli/package.json
@@ -77,7 +77,7 @@
   },
   "scripts": {
     "postpack": "rimraf oclif.manifest.json",
-    "prepack": "rimraf lib && tsc -b && oclif manifest && oclif readme",
+    "prepack": "rimraf lib && pnpm run build && oclif manifest && oclif readme",
     "version": "oclif readme && git add README.md && pnpm version",
     "lint": "pnpm run tslint && pnpm run prettier",
     "lint:fix": "pnpm run tslint:fix && pnpm run prettier",

--- a/kipper/cli/src/index.ts
+++ b/kipper/cli/src/index.ts
@@ -13,7 +13,7 @@ export * from "./output/compile";
 // eslint-disable-next-line no-unused-vars
 export const name = "@kipper/cli";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.11.0-alpha.3";
+export const version = "0.11.0-alpha.4";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/config/package.json
+++ b/kipper/config/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kipper/config",
 	"description": "The config file support package adding support for kip-config.json/kipper-config.json 🦊",
-	"version": "0.11.0-alpha.3",
+	"version": "0.11.0-alpha.4",
 	"author": "Luna-Klatzer @Luna-Klatzer",
 	"dependencies": {
 		"is-plain-object": "5.0.0",

--- a/kipper/config/src/index.ts
+++ b/kipper/config/src/index.ts
@@ -12,7 +12,7 @@ export * from "./evaluated-kipper-config-file";
 // eslint-disable-next-line no-unused-vars
 export const name = "@kipper/config";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.11.0-alpha.3";
+export const version = "0.11.0-alpha.4";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/core/package.json
+++ b/kipper/core/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kipper/core",
 	"description": "The core implementation of the Kipper compiler 🦊",
-	"version": "0.11.0-alpha.3",
+	"version": "0.11.0-alpha.4",
 	"author": "Luna-Klatzer @Luna-Klatzer",
 	"dependencies": {
 		"antlr4ts": "^0.5.0-alpha.4",

--- a/kipper/core/src/compiler/analysis/analyser/type-checker.ts
+++ b/kipper/core/src/compiler/analysis/analyser/type-checker.ts
@@ -33,6 +33,7 @@ import {
 	KipperCompilableType,
 	kipperCompilableTypes,
 	kipperIncrementOrDecrementOperators,
+	kipperMultiplicativeOperators,
 	kipperPlusOperator,
 	KipperReferenceable,
 	KipperReferenceableFunction,
@@ -392,6 +393,11 @@ export class KipperTypeChecker extends KipperSemanticsAsserter {
 		if (leftOpType !== "num" || rightOpType !== "num") {
 			// Strings can use '+' to concat strings
 			if (op === kipperPlusOperator && leftOpType == kipperStrType && rightOpType == kipperStrType) {
+				return;
+			}
+
+			// Strings can use * to repeat a string n times
+			if (op === kipperMultiplicativeOperators[0] && leftOpType == kipperStrType && rightOpType == "num") {
 				return;
 			}
 

--- a/kipper/core/src/compiler/ast/nodes/expressions/cast-or-convert-expression/cast-or-convert-expression.ts
+++ b/kipper/core/src/compiler/ast/nodes/expressions/cast-or-convert-expression/cast-or-convert-expression.ts
@@ -134,14 +134,17 @@ export class CastOrConvertExpression extends Expression<
 			semanticData.castType.identifier,
 		);
 		if (internalIdentifier in kipperInternalBuiltInFunctions) {
-			this.programCtx.addInternalReference(this, kipperInternalBuiltInFunctions[internalIdentifier]);
+			this.programCtx.addInternalReference(
+				this,
+				kipperInternalBuiltInFunctions[internalIdentifier as keyof typeof kipperInternalBuiltInFunctions],
+			);
 		}
 	}
 
 	/**
 	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.
 	 *
-	 * This will log all warnings using {@link programCtx.logger} and store them in {@link KipperProgramContext.warnings}.
+	 * This will log all warnings using {@link this.programCtx.logger} and store them in {@link this.KipperProgramContext.warnings}.
 	 * @since 0.9.0
 	 */
 	public checkForWarnings = undefined; // TODO!

--- a/kipper/core/src/compiler/runtime-built-ins.ts
+++ b/kipper/core/src/compiler/runtime-built-ins.ts
@@ -181,7 +181,7 @@ export const kipperRuntimeBuiltInFunctions: Record<string, BuiltInFunction> = {
  * This contains *every* builtin that also must be implemented by every target in the {@link KipperTargetBuiltInGenerator}.
  * @since 0.8.0
  */
-export const kipperInternalBuiltInFunctions: Record<string, InternalFunction> = {
+export const kipperInternalBuiltInFunctions = {
 	numToStr: {
 		identifier: "numToStr",
 		params: [
@@ -284,7 +284,21 @@ export const kipperInternalBuiltInFunctions: Record<string, InternalFunction> = 
 		],
 		returnType: "str", // TODO: Implement this for all arrayLike types (At the moment only strings are supported)
 	},
-};
+	repeatString: {
+		identifier: "repeatString",
+		params: [
+			{
+				identifier: "toRepeat",
+				valueType: "str",
+			},
+			{
+				identifier: "times",
+				valueType: "num",
+			},
+		],
+		returnType: "str",
+	},
+} satisfies Record<string, InternalFunction>;
 
 /**
  * Contains all the built-in variables in Kipper that are available per default in every program.

--- a/kipper/core/src/compiler/target-presets/translation/built-ins-generator.ts
+++ b/kipper/core/src/compiler/target-presets/translation/built-ins-generator.ts
@@ -105,6 +105,18 @@ export abstract class KipperTargetBuiltInGenerator {
 	abstract index(funcSpec: InternalFunction, programCtx: KipperProgramContext): Promise<Array<TranslatedCodeLine>>;
 
 	/**
+	 * Repeat string function which provides the ability to repeat a string a given number of times.
+	 * @param funcSpec The specification for the function. This contains the overall metadata for the function that
+	 * should be followed. This is auto-inserted by the code-generator in {@link KipperProgramContext}.
+	 * @param programCtx The program context of the environment that is being compiled.
+	 * @since 0.10.0
+	 */
+	abstract repeatString(
+		funcSpec: InternalFunction,
+		programCtx: KipperProgramContext,
+	): Promise<Array<TranslatedCodeLine>>;
+
+	/**
 	 * Print function which provides default IO console output functionality.
 	 * @param funcSpec The specification for the function. This contains the overall metadata for the function that
 	 * should be followed. This is auto-inserted by the code-generator in {@link KipperProgramContext}.

--- a/kipper/core/src/index.ts
+++ b/kipper/core/src/index.ts
@@ -17,7 +17,7 @@ export * as utils from "./tools";
 // eslint-disable-next-line no-unused-vars
 export const name = "@kipper/core";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.11.0-alpha.3";
+export const version = "0.11.0-alpha.4";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/index.ts
+++ b/kipper/index.ts
@@ -13,7 +13,7 @@ export * from "@kipper/target-ts";
 // eslint-disable-next-line no-unused-vars
 export const name = "kipper";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.11.0-alpha.3";
+export const version = "0.11.0-alpha.4";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/target-js/package.json
+++ b/kipper/target-js/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kipper/target-js",
 	"description": "The JavaScript target for the Kipper compiler 🦊",
-	"version": "0.11.0-alpha.3",
+	"version": "0.11.0-alpha.4",
 	"author": "Luna-Klatzer @Luna-Klatzer",
 	"dependencies": {
 		"@kipper/core": "workspace:~",

--- a/kipper/target-js/src/built-in-generator.ts
+++ b/kipper/target-js/src/built-in-generator.ts
@@ -135,4 +135,12 @@ export class JavaScriptTargetBuiltInGenerator extends KipperTargetBuiltInGenerat
 	async __name__(varSpec: BuiltInVariable, programCtx: KipperProgramContext): Promise<Array<TranslatedCodeLine>> {
 		return [genJSVariable(varSpec, `"${programCtx.fileName}"`)];
 	}
+
+	async repeatString(funcSpec: InternalFunction): Promise<Array<TranslatedCodeLine>> {
+		const signature = getJSFunctionSignature(funcSpec);
+		const toRepeatIdentifier = signature.params[0];
+		const timesIdentifier = signature.params[1];
+
+		return genJSFunction(signature, `{ return ${toRepeatIdentifier}.repeat(${timesIdentifier}); }`);
+	}
 }

--- a/kipper/target-js/src/code-generator.ts
+++ b/kipper/target-js/src/code-generator.ts
@@ -595,9 +595,15 @@ export class JavaScriptTargetCodeGenerator extends KipperTargetCodeGenerator {
 	multiplicativeExpression = async (node: MultiplicativeExpression): Promise<TranslatedExpression> => {
 		// Get the semantic data
 		const semanticData = node.getSemanticData();
+		const stringRepeatFunction = TargetJS.getBuiltInIdentifier("repeatString");
 
 		const exp1: TranslatedExpression = await semanticData.leftOp.translateCtxAndChildren();
 		const exp2: TranslatedExpression = await semanticData.rightOp.translateCtxAndChildren();
+
+		if (semanticData.leftOp.getTypeSemanticData().evaluatedType.getCompilableType() === "str") {
+			return [stringRepeatFunction, "(", ...exp1, ", ", ...exp2, ")"];
+		}
+
 		return [...exp1, " ", semanticData.operator, " ", ...exp2];
 	};
 

--- a/kipper/target-js/src/code-generator.ts
+++ b/kipper/target-js/src/code-generator.ts
@@ -600,6 +600,7 @@ export class JavaScriptTargetCodeGenerator extends KipperTargetCodeGenerator {
 		const exp1: TranslatedExpression = await semanticData.leftOp.translateCtxAndChildren();
 		const exp2: TranslatedExpression = await semanticData.rightOp.translateCtxAndChildren();
 
+		// In this case it should be a string multiplication
 		if (semanticData.leftOp.getTypeSemanticData().evaluatedType.getCompilableType() === "str") {
 			return [stringRepeatFunction, "(", ...exp1, ", ", ...exp2, ")"];
 		}

--- a/kipper/target-js/src/index.ts
+++ b/kipper/target-js/src/index.ts
@@ -13,7 +13,7 @@ export * from "./tools";
 // eslint-disable-next-line no-unused-vars
 export const name = "@kipper/target-js";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.11.0-alpha.3";
+export const version = "0.11.0-alpha.4";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/target-ts/package.json
+++ b/kipper/target-ts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kipper/target-ts",
 	"description": "The TypeScript target for the Kipper compiler 🦊",
-	"version": "0.11.0-alpha.3",
+	"version": "0.11.0-alpha.4",
 	"author": "Luna-Klatzer @Luna-Klatzer",
 	"dependencies": {
 		"@kipper/target-js": "workspace:~",

--- a/kipper/target-ts/src/built-in-generator.ts
+++ b/kipper/target-ts/src/built-in-generator.ts
@@ -149,6 +149,14 @@ export class TypeScriptTargetBuiltInGenerator extends JavaScriptTargetBuiltInGen
 		return genTSFunction(signature, `{ return ${lenArgIdentifier}.length; }`);
 	}
 
+	async repeatString(funcSpec: BuiltInFunction): Promise<Array<TranslatedCodeLine>> {
+		const signature = getTSFunctionSignature(funcSpec);
+		const repeatArgIdentifier = signature.params[0].identifier;
+		const timesArgIdentifier = signature.params[1].identifier;
+
+		return genTSFunction(signature, `{ return ${repeatArgIdentifier}.repeat(${timesArgIdentifier}); }`);
+	}
+
 	async __name__(varSpec: BuiltInVariable, programCtx: KipperProgramContext): Promise<Array<TranslatedCodeLine>> {
 		return [genTSVariable(varSpec, `"${programCtx.fileName}"`)];
 	}

--- a/kipper/target-ts/src/index.ts
+++ b/kipper/target-ts/src/index.ts
@@ -13,7 +13,7 @@ export * from "./tools";
 // eslint-disable-next-line no-unused-vars
 export const name = "@kipper/target-ts";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.11.0-alpha.3";
+export const version = "0.11.0-alpha.4";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/web/package.json
+++ b/kipper/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kipper/web",
   "description": "The standalone web-module for the Kipper compiler 🦊",
-  "version": "0.11.0-alpha.3",
+  "version": "0.11.0-alpha.4",
   "author": "Luna-Klatzer @Luna-Klatzer",
   "devDependencies": {
     "@kipper/target-js": "workspace:~",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kipper",
   "description": "The Kipper programming language and compiler 🦊",
-  "version": "0.11.0-alpha.3",
+  "version": "0.11.0-alpha.4",
   "author": "Luna-Klatzer @Luna-Klatzer",
   "dependencies": {
     "@kipper/cli": "workspace:~",

--- a/test/kipper-files/string-multiplication.kip
+++ b/test/kipper-files/string-multiplication.kip
@@ -1,0 +1,3 @@
+var x: str = "hello";
+var y: str = x * 2;
+print(f"Result: {y as str}");

--- a/test/module/core/errors/type-errors/arithmetic-operation.ts
+++ b/test/module/core/errors/type-errors/arithmetic-operation.ts
@@ -330,6 +330,20 @@ describe("ArithmeticOperationTypeError", () => {
 	});
 
 	describe("NoError", () => {
+		describe("num*num", () => {
+			it("num*num", async () => {
+				let result: KipperCompileResult | undefined = undefined;
+				try {
+					result = await new KipperCompiler().compile("3 * 3;", defaultConfig);
+				} catch (e) {
+					assert.fail("Expected no 'ArithmeticOperationTypeError'");
+				}
+				assert.isDefined(result, "Expected defined compilation result");
+				assert.isDefined(result!!.programCtx, "Expected programCtx to be defined");
+				assert.isFalse(result!!.programCtx!!.hasFailed, "Expected no errors");
+			});
+		});
+
 		describe("*", () => {
 			it("str*num", async () => {
 				let result: KipperCompileResult | undefined = undefined;

--- a/test/module/core/errors/type-errors/arithmetic-operation.ts
+++ b/test/module/core/errors/type-errors/arithmetic-operation.ts
@@ -28,18 +28,6 @@ describe("ArithmeticOperationTypeError", () => {
 			assert.fail("Expected 'ArithmeticOperationTypeError'");
 		});
 
-		it("str*num", async () => {
-			try {
-				await new KipperCompiler().compile('"3" * 4;', defaultConfig);
-			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "ArithmeticOperationTypeError", "Expected different error");
-				assert((<KipperError>e).name === "TypeError", "Expected different error");
-				ensureTracebackDataExists(<KipperError>e);
-				return;
-			}
-			assert.fail("Expected 'ArithmeticOperationTypeError'");
-		});
-
 		it("str**num", async () => {
 			try {
 				await new KipperCompiler().compile('"3" ** 4;', defaultConfig);
@@ -342,6 +330,23 @@ describe("ArithmeticOperationTypeError", () => {
 	});
 
 	describe("NoError", () => {
+		describe("*", () => {
+			it("str*num", async () => {
+				let result: KipperCompileResult | undefined = undefined;
+				try {
+					result = await new KipperCompiler().compile('"3" * 3;', {
+						abortOnFirstError: true,
+						target: defaultTarget,
+					});
+				} catch (e) {
+					assert.fail("Expected no 'ArithmeticOperationTypeError'");
+				}
+				assert.isDefined(result, "Expected defined compilation result");
+				assert.isDefined(result!!.programCtx, "Expected programCtx to be defined");
+				assert.isFalse(result!!.programCtx!!.hasFailed, "Expected no errors");
+			});
+		});
+
 		describe("+", () => {
 			it("str", async () => {
 				let result: KipperCompileResult | undefined = undefined;


### PR DESCRIPTION
<!--
Please read through the given types of changes and select the correct one using an 'x' instead of the ' ' (space) in the brackets.

Note: Comments are marked by arrows, like here. They will not be visible in the final pull request!
-->

## What type of change does this PR perform?

<!-- Please put an X in the box of the line that applies -->
<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

- [ ] Maintenance (Non-breaking change that updates dependencies)
- [ ] Info or documentation change (Non-breaking change that updates repo info files (e.g. README.md, CONTRIBUTING.md, etc.) or online documentation)
- [ ] Website feature update or docs development changes (Change that changes the design or functionality of the websites or docs)
- [ ] Development or internal changes (These changes do not add new features or fix bugs, but update the code in other ways)
- [x] Bug fix (Non-breaking change which fixes an issue)
- [x] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Major bug fix or feature that would cause existing functionality not to work as expected.)
- [ ] Requires a documentation update, as it changes language or compiler behaviour

## Summary

<!-- Explain the reason for this pr, changes, and solution briefly. -->

New development version `0.11.0-alpha.4`, which fixes a bug in the last dev release package of `@kipper/cli` and adds support for string multiplications.

## List of Changes

<!-- Please explain the changes in this PR and their influence. If this fixes an issue, describe what fixed the issue. -->

<!-- Create for every essential change a list item (Link any issues, discussions or PRs if needed!) -->

- Added missing `templates` folder to the CLI package, which was incorrectly not included in the package for the release `v0.11.0-alpha.3`.
- Implemented support for `str * num` string multiplication.
- Added new internal function `repeatString` which is used underneath for the string repetition behaviour.
- Changes multiplication return type behaviour to be equal to the left operand.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

None.

## Detailed Changelog

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added and remove any header with no item.). -->

### Added

- Support for string multiplication using the `*` operator. ([#478](https://github.com/Kipper-Lang/Kipper/issues/478)).

<!-- Just write none if they are no changelog entries (although you should definitely do some if they change source code), like this:
None.
-->

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [x] #478
- [x] #528
