### PR TITLE
Removed deprecated flag `--abort-on-first-error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,8 @@ To use development versions of Kipper download the
 
 ### Removed
 
+- Removed deprecated flag `--abort-on-first-error` in favour of `--no-recover`.
+	([#501](https://github.com/Kipper-Lang/Kipper/issues/501)).
 - Removed CLI command `analyse` in favor of the flag `--dry-run` in the CLI command `compile`.
   ([#532](https://github.com/Kipper-Lang/Kipper/issues/532)).
 - Removed AST parent class `ConstantExpression`, its interfaces `ConstantExpressionSemantics` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ To use development versions of Kipper download the
 
 ### Changed
 
+- Fixed bug allowing the use of any expressinos for call expressions as that is not implemented yet.
 - Standardised error output for the CLI as described in [#435](https://github.com/Kipper-Lang/Kipper/issues/435).
   (This is the same change as in `0.10.3`, but was only added to the dev branch with the release of `0.11.0-alpha.1`
   i.e. `0.11.0-alpha.0` does _not_ have this change).

--- a/kipper/cli/src/commands/compile.ts
+++ b/kipper/cli/src/commands/compile.ts
@@ -27,11 +27,11 @@ export default class Compile extends Command {
 
 	static override examples: Array<string> = [
 		"kipper compile -t js",
-		"kipper compile -t ts -s \"print('Hello, World!')\"",
-		"kipper compile -t js -e utf8 -o build/ -s \"print('Hello, World!')\"",
-		"kipper compile -t ts -o build/ -e utf8 -s \"print('Hello, World!')\"",
-		"kipper compile -t js -o build/ -e utf8 -s \"print('Hello, World!')\" --warnings",
-		"kipper compile -t ts -o build/ -e utf8 -s \"print('Hello, World!')\" --warnings --log-timestamp",
+		"kipper compile -t ts -s \"print('Hello, World!');\"",
+		"kipper compile -t js -e utf8 -o build/ -s \"print('Hello, World!');\"",
+		"kipper compile -t ts -o build/ -e utf8 -s \"print('Hello, World!');\"",
+		"kipper compile -t js -o build/ -e utf8 -s \"print('Hello, World!');\" --warnings",
+		"kipper compile -t ts -o build/ -e utf8 -s \"print('Hello, World!');\" --warnings --log-timestamp",
 		"kipper compile -t js ./path/to/file.kip",
 		"kipper compile -t ts ./path/to/file.kip -o build/ --log-timestamp",
 		"kipper compile -t js ./path/to/file.kip -o build/ --warnings --log-timestamp",

--- a/kipper/cli/src/commands/compile.ts
+++ b/kipper/cli/src/commands/compile.ts
@@ -25,8 +25,18 @@ import path from "node:path";
 export default class Compile extends Command {
 	static override description: string = "Compile a Kipper program into the specified target language.";
 
-	// TODO! Add examples when the command moves out of development
-	static override examples: Array<string> = [];
+	static override examples: Array<string> = [
+		"kipper compile -t js",
+		"kipper compile -t ts -s \"print('Hello, World!')\"",
+		"kipper compile -t js -e utf-8 -o build/ -s \"print('Hello, World!')\"",
+		"kipper compile -t ts -o build/ -e utf-8 -s \"print('Hello, World!')\"",
+		"kipper compile -t js -o build/ -e utf-8 -s \"print('Hello, World!')\" --warnings",
+		"kipper compile -t ts -o build/ -e utf-8 -s \"print('Hello, World!')\" --warnings --log-timestamp",
+		"kipper compile -t js ./path/to/file.kip",
+		"kipper compile -t ts ./path/to/file.kip -o build/ --log-timestamp",
+		"kipper compile -t js ./path/to/file.kip -o build/ --warnings --log-timestamp",
+		"kipper compile -t ts ./path/to/file.kip -o build/ -e utf16le --warnings --log-timestamp",
+	];
 
 	static override args: args.Input = [
 		{

--- a/kipper/cli/src/commands/compile.ts
+++ b/kipper/cli/src/commands/compile.ts
@@ -28,10 +28,10 @@ export default class Compile extends Command {
 	static override examples: Array<string> = [
 		"kipper compile -t js",
 		"kipper compile -t ts -s \"print('Hello, World!')\"",
-		"kipper compile -t js -e utf-8 -o build/ -s \"print('Hello, World!')\"",
-		"kipper compile -t ts -o build/ -e utf-8 -s \"print('Hello, World!')\"",
-		"kipper compile -t js -o build/ -e utf-8 -s \"print('Hello, World!')\" --warnings",
-		"kipper compile -t ts -o build/ -e utf-8 -s \"print('Hello, World!')\" --warnings --log-timestamp",
+		"kipper compile -t js -e utf8 -o build/ -s \"print('Hello, World!')\"",
+		"kipper compile -t ts -o build/ -e utf8 -s \"print('Hello, World!')\"",
+		"kipper compile -t js -o build/ -e utf8 -s \"print('Hello, World!')\" --warnings",
+		"kipper compile -t ts -o build/ -e utf8 -s \"print('Hello, World!')\" --warnings --log-timestamp",
 		"kipper compile -t js ./path/to/file.kip",
 		"kipper compile -t ts ./path/to/file.kip -o build/ --log-timestamp",
 		"kipper compile -t js ./path/to/file.kip -o build/ --warnings --log-timestamp",
@@ -123,7 +123,7 @@ export default class Compile extends Command {
 			: preExistingCompileConfig?.target ?? getTarget("js");
 
 		// Output
-		const encoding = flags["encoding"] || "utf-8";
+		const encoding = flags["encoding"] || "utf8";
 		const fileName = stream instanceof KipperInputFile ? stream.path.name : stream.name;
 		const outPath = `${path.resolve(outDir)}/${fileName}.${target.fileExtension}`;
 

--- a/kipper/cli/src/commands/compile.ts
+++ b/kipper/cli/src/commands/compile.ts
@@ -103,15 +103,6 @@ export default class Compile extends Command {
 			description: "Recover from compiler errors and log all detected semantic issues.",
 			allowNo: true,
 		}),
-		/**
-		 * TODO! Remove this flag
-		 * @deprecated
-		 */
-		"abort-on-first-error": flags.boolean({
-			default: EvaluatedCompileConfig.defaults.abortOnFirstError,
-			description: "Abort on the first error the compiler encounters.",
-			allowNo: true,
-		}),
 	};
 
 	/**
@@ -189,11 +180,6 @@ export default class Compile extends Command {
 		try {
 			result = await compiler.compile(config.stream, config.compilerOptions);
 		} catch (e) {
-			if (e instanceof KipperError && config.compilerOptions.abortOnFirstError) {
-				// Ignore the error thrown by the compiler (the logger already logged it)
-				// TODO! This will be removed once 'abortOnFirstError' has been fully removed with v0.11.0 -> #501
-				return false;
-			}
 			throw e;
 		}
 

--- a/kipper/cli/src/commands/run.ts
+++ b/kipper/cli/src/commands/run.ts
@@ -14,8 +14,14 @@ import Compile from "./compile";
 export default class Run extends Compile {
 	static override description: string = "Compile and execute a Kipper program.";
 
-	// TODO! Add examples when the command moves out of development
-	static override examples: Array<string> = [];
+	static override examples: Array<string> = [
+		"kipper run -t js",
+		"kipper run -t ts -s \"print('Hello, World!')\"",
+		"kipper run -t js -e utf-8 -o build/ -s \"print('Hello, World!')\"",
+		"kipper run -t ts -o build/ -e utf-8 -s \"print('Hello, World!')\"",
+		"kipper run -t js -o build/ -e utf-8 -s \"print('Hello, World!')\" --warnings",
+		"kipper run -t ts -o build/ -e utf-8 -s \"print('Hello, World!')\" --warnings --log-timestamp",
+	];
 
 	static override args: args.Input = [
 		{

--- a/kipper/cli/src/commands/run.ts
+++ b/kipper/cli/src/commands/run.ts
@@ -16,11 +16,11 @@ export default class Run extends Compile {
 
 	static override examples: Array<string> = [
 		"kipper run -t js",
-		"kipper run -t ts -s \"print('Hello, World!')\"",
-		"kipper run -t js -e utf8 -o build/ -s \"print('Hello, World!')\"",
-		"kipper run -t ts -o build/ -e utf8 -s \"print('Hello, World!')\"",
-		"kipper run -t js -o build/ -e utf8 -s \"print('Hello, World!')\" --warnings",
-		"kipper run -t ts -o build/ -e utf8 -s \"print('Hello, World!')\" --warnings --log-timestamp",
+		"kipper run -t ts -s \"print('Hello, World!');\"",
+		"kipper run -t js -e utf8 -o build/ -s \"print('Hello, World!');\"",
+		"kipper run -t ts -o build/ -e utf8 -s \"print('Hello, World!');\"",
+		"kipper run -t js -o build/ -e utf8 -s \"print('Hello, World!');\" --warnings",
+		"kipper run -t ts -o build/ -e utf8 -s \"print('Hello, World!');\" --warnings --log-timestamp",
 	];
 
 	static override args: args.Input = [

--- a/kipper/cli/src/commands/run.ts
+++ b/kipper/cli/src/commands/run.ts
@@ -78,15 +78,6 @@ export default class Run extends Compile {
 			description: "Recover from compiler errors and display all detected compiler errors.",
 			allowNo: true,
 		}),
-		/**
-		 * TODO! Remove this flag
-		 * @deprecated
-		 */
-		"abort-on-first-error": flags.boolean({
-			default: EvaluatedCompileConfig.defaults.abortOnFirstError,
-			description: "Abort on the first error the compiler encounters. Same behaviour as '--no-recover'.",
-			allowNo: true,
-		}),
 	};
 
 	/**

--- a/kipper/cli/src/commands/run.ts
+++ b/kipper/cli/src/commands/run.ts
@@ -17,10 +17,10 @@ export default class Run extends Compile {
 	static override examples: Array<string> = [
 		"kipper run -t js",
 		"kipper run -t ts -s \"print('Hello, World!')\"",
-		"kipper run -t js -e utf-8 -o build/ -s \"print('Hello, World!')\"",
-		"kipper run -t ts -o build/ -e utf-8 -s \"print('Hello, World!')\"",
-		"kipper run -t js -o build/ -e utf-8 -s \"print('Hello, World!')\" --warnings",
-		"kipper run -t ts -o build/ -e utf-8 -s \"print('Hello, World!')\" --warnings --log-timestamp",
+		"kipper run -t js -e utf8 -o build/ -s \"print('Hello, World!')\"",
+		"kipper run -t ts -o build/ -e utf8 -s \"print('Hello, World!')\"",
+		"kipper run -t js -o build/ -e utf8 -s \"print('Hello, World!')\" --warnings",
+		"kipper run -t ts -o build/ -e utf8 -s \"print('Hello, World!')\" --warnings --log-timestamp",
 	];
 
 	static override args: args.Input = [
@@ -95,8 +95,8 @@ export default class Run extends Compile {
 	private async executeKipperProgram(entryFile: string): Promise<void> {
 		const kipperProgram = fork(this.detectTSNode(), [entryFile]);
 
-		// Per default the encoding should be 'utf-8'
-		kipperProgram.stdin?.setDefaultEncoding("utf-8");
+		// Per default the encoding should be 'utf8'
+		kipperProgram.stdin?.setDefaultEncoding("utf8");
 
 		// Close immediately after the Kipper program
 		kipperProgram.on("close", (code: number) => process.exit(code));

--- a/kipper/cli/src/decorators.ts
+++ b/kipper/cli/src/decorators.ts
@@ -21,7 +21,7 @@ export function prettifiedErrors<TProto extends Command>() {
 
 		const func = async function (this: Command, ...argArray: Array<any>): Promise<any> {
 			try {
-				await originalFunc.call(this, ...argArray);
+				return await originalFunc.call(this, ...argArray);
 			} catch (error) {
 				const cliError = error instanceof KipperCLIError || error instanceof OclifCLIError;
 				const configError = error instanceof ConfigError;

--- a/kipper/cli/src/input/input-file.ts
+++ b/kipper/cli/src/input/input-file.ts
@@ -14,13 +14,13 @@ import type { EvaluatedKipperConfigFile } from "@kipper/config";
  * Valid encodings that Kipper supports.
  * @since 0.1.0
  */
-export type KipperEncoding = "ascii" | "utf8" | "utf16le";
+export type KipperEncoding = "ascii" | "utf-8" | "utf8" | "utf16le";
 
 /**
  * Array of all valid encodings that Kipper supports.
  * @since 0.1.0
  */
-export const KipperEncodings: Array<KipperEncoding> = ["ascii", "utf8", "utf16le"];
+export const KipperEncodings: Array<KipperEncoding> = ["ascii", "utf-8", "utf8", "utf16le"];
 
 /**
  * Checks whether the encoding is supported. If it is, then it will return it as {@link KipperEncoding}, otherwise it

--- a/kipper/config/src/evaluated-kipper-config-file.ts
+++ b/kipper/config/src/evaluated-kipper-config-file.ts
@@ -1,4 +1,4 @@
-import { EvaluatedConfigValue } from "./abstract";
+import type { EvaluatedConfigValue } from "./abstract";
 import type { EvaluatedConfigFile } from "./abstract";
 import type * as semver from "semver";
 import type { CompileConfig, KipperCompileTarget } from "@kipper/core";


### PR DESCRIPTION
<!--
Please read through the given types of changes and select the correct one using an 'x' instead of the ' ' (space) in the brackets.

Note: Comments are marked by arrows, like here. They will not be visible in the final pull request!
-->

## What type of change does this PR perform?

<!-- Please put an X in the box of the line that applies -->
<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

- [ ] Info or documentation change (Non-breaking change that updates repo info files (e.g. README.md, CONTRIBUTING.md, etc.) or online documentation)
- [ ] Website (Change that changes the design or functionality of the websites or docs)
- [x] Development or internal changes (These changes do not add new features or fix bugs, but update the code in other ways)
- [x] Bug fix (Non-breaking change which fixes an issue)
- [ ] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Major bug fix or feature that would cause existing functionality not to work as expected.)
- [ ] Requires a documentation update, as it changes language or compiler behaviour

## Summary

<!-- Explain the reason for this pr, changes, and solution briefly. -->

Removed deprecated flag `--abort-on-first-error` and added CLI examples. 

Closes #501 

## Detailed Changelog

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added and remove any header with no item.). -->

### Removed

- Removed deprecated flag `--abort-on-first-error` in favour of `--no-recover`. ([#501](https://github.com/Kipper-Lang/Kipper/issues/501)).

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

None.

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [x] #501 
