### PR TITLE
v0.12.0-alpha.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,6 @@ To use development versions of Kipper download the
 
 ### Added
 
-- Semantic checking and code generation for the `new` keyword expression to be able to create new instances of
-  classes. ([#679](https://github.com/Kipper-Lang/Kipper/issues/679))
-- Support for the typeof operator, which returns the runtime type of a value.
-  ([#663](https://github.com/Kipper-Lang/Kipper/issues/663))
-- Support for Nix Flakes and direnv, which allows for a more reproducible and consistent development environment.
 - Support for dot notation for accessing properties of objects. ([#67](https://github.com/Kipper-Lang/Kipper/issues/67))
 - Support for classes, class methods, class properties and class constructors.
   ([#665](https://github.com/Kipper-Lang/Kipper/issues/665))
@@ -30,10 +25,12 @@ To use development versions of Kipper download the
   ([#526](https://github.com/Kipper-Lang/Kipper/issues/526))
 - Support for calling lambdas and functions stored in variables or expressions.
   ([#674](https://github.com/Kipper-Lang/Kipper/issues/674))
-- Implemented internal representation for custom types such as objects, interfaces and classes. This change means that
-  the entire core type system has been reworked and adjusted to also support custom types as well as complex types
-  (objects, arrays etc.). This does not inherently add functionality but serves as the stepping stone for the
-  implementation of all custom types in the future. ([#524](https://github.com/Kipper-Lang/Kipper/issues/524))
+- Semantic checking and code generation for the `new` keyword expression to be able to create new instances of
+	classes. ([#679](https://github.com/Kipper-Lang/Kipper/issues/679))
+- Support for the `this` keyword inside a class method to access the current instance of the class.
+	([#697](https://github.com/Kipper-Lang/Kipper/issues/697))
+- Support for the typeof operator, which returns the runtime type of a value.
+	([#663](https://github.com/Kipper-Lang/Kipper/issues/663))
 - Implemented the generic `Array<T>` type and single-type array initializers.
   ([#499](https://github.com/Kipper-Lang/Kipper/issues/499))
 - Support for index-based array assignments. ([#669](https://github.com/Kipper-Lang/Kipper/issues/669))
@@ -43,8 +40,15 @@ To use development versions of Kipper download the
   parameter inside a generic type specifier.
 - Implemented constant `NaN`, which represents the `NaN` value in JavaScript (Not a Number).
   ([#671](https://github.com/Kipper-Lang/Kipper/issues/671))
+- Support for Nix Flakes and direnv, which allows for a more reproducible and consistent development environment.
 - Support for internal type unions in built-in and internal functions.
   ([#496](https://github.com/Kipper-Lang/Kipper/issues/496))
+- Implemented internal representation for custom types such as objects, interfaces and classes. This change means that
+	the entire core type system has been reworked and adjusted to also support custom types as well as complex types
+	(objects, arrays etc.). This does not inherently add functionality but serves as the stepping stone for the
+	implementation of all custom types in the future. ([#524](https://github.com/Kipper-Lang/Kipper/issues/524))
+- Implemented internal preliminary type checking and "ahead of time" type evaluation to allow for self-referential
+	types and type checking of recursive types.
 - New module:
   - `semantics/runtime-built-ins`, which contains runtime built-in functions, variables and types.
   - `semantics/runtime-internals`, which contains the runtime internal functions.
@@ -75,7 +79,9 @@ To use development versions of Kipper download the
   - `BuiltInTypeFunc`, which represents the `Func<T..., R>` type.
   - `BuiltInTypeObj`, which represents the `obj` type.
   - `ScopeTypeDeclaration`, which represents a scope type declaration.
-  - `CustomType`, which is a class extending from `ProcessedType` and implementing the functionality for a custom type such as a interface or class.
+  - `CustomType`, which is a class extending from `ProcessedType` and implementing the functionality for a custom type such as an interface or class.
+  - `UserScope`, which represents a user scope i.e. any scope except the universe scope.
+  - `ClassScopeThisDeclaration`, which represents the `this` declaration of a class.
 - New errors:
   - `TypeCanNotBeUsedForTypeCheckingError`, which is thrown when a type is used for type checking, but is not a valid
     type. This is an error indicating an invalid logic that should be fixed.
@@ -93,6 +99,8 @@ To use development versions of Kipper download the
   - `ValueTypeNotIndexableWithGivenAccessor`, which is thrown when a value type is not indexable with the given
     accessor.
   - `PropertyDoesNotExistError`, which is thrown when a property does not exist on a type.
+  - `DuplicateUniverseKeyError`, which is thrown when a key is duplicated in the universe scope.
+  - `IdentifierAlreadyUsedByMemberError`, which is thrown when an identifier is already used by another property.
 - New interfaces and types:
   - `InterfaceDeclarationSemantics`, which represents the semantics of an interface declaration.
   - `InterfaceDeclarationTypeSemantics`, which represents the type semantics of an interface declaration.
@@ -114,10 +122,16 @@ To use development versions of Kipper download the
   - `NewInstantiationExpressionTypeSemantics`, which represents the type semantics of a new instantiation expression.
   - `TypeofExpressionSemantics`, which represents the semantics of a typeof expression.
   - `TypeofExpressionTypeSemantics`, which represents the type semantics of a typeof expression.
+  - `KipperCallable`, which is an alias for `FunctionDeclaration`, `LambdaPrimaryExpression` and
+    `ClassMethodDeclaration`.
+  - `TypeDeclarationPropertyTypeSemantics`, which represents the type semantics of a type declaration property.
 - New functions:
-  - `KipperTypeChecker.validArrayExpression`, which ensures that an array expression is valid.
-  - `generateInterfaceRuntimeTypeChecks` which generates runtime type checks for an interface.
-  - `getRuntimeType`, which gets the corresponding runtime representation of a built-in type.
+  - `KipperTypeChecker.validArrayExpression()`, which ensures that an array expression is valid.
+  - `ClassDeclaration.getThis()`, which returns the `this` type of the class.
+  - `ClassScope.getThis()`, which returns the `this` type of the class. This is a simple alias for the method in the
+    `ClassDeclaration` class.
+  - `generateInterfaceRuntimeTypeChecks()` which generates runtime type checks for an interface.
+  - `getRuntimeType()`, which gets the corresponding runtime representation of a built-in type.
 - New properties:
   - `BuiltInFunction.funcType`, which returns a function type for the built-in function.
   - `FunctionDeclarationTypeSemantics.type`, which returns the type of the function declaration i.e. the function type.
@@ -125,6 +139,17 @@ To use development versions of Kipper download the
     function type.
   - `FunctionCallExpressionTypeSemantics.funcOrExp`, which returns the function or expression that is called. This
     always stores some sort of value that extends `BuiltInTypeFunc`.
+  - `CustomType.clsExtends`, which returns the class that the custom type extends. This is only applicable for classes.
+  - `CustomType.clsImplements`, which returns the interfaces that the custom type implements. This is only applicable
+    for classes.
+  - `CustomType.intfExtends`, which returns the interfaces that the custom type extends. This is only applicable for
+    interfaces.
+  - `CustomType._clsStaticFields`, which returns the static fields of the custom type. This is only applicable for
+    classes.
+  - `ASTNode.preliminaryTypeSemantics`, which runs the preliminary type semantics of the node as well as the preliminary
+    type semantics of all its children. This is a recursive function.
+  - `ASTNode.primaryPreliminaryTypeSemantics`, which returns the primary preliminary type semantics of the node. May be
+    undefined if there is no primary preliminary type semantics for the given node.
 - New runtime error `KipperError`, which serves as the base for `TypeError` and `IndexError`.
 
 ### Changed
@@ -143,6 +168,7 @@ To use development versions of Kipper download the
   - Class `UncheckedType` to `RawType`.
   - Class `CheckedType` to `ProcessedType`.
   - Class `UndefinedCustomType` to `UndefinedType`.
+  - Method `KipperProgramContext._initUniversalReferencables()` to `_initUniversalReferenceables()`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,11 @@ To use development versions of Kipper download the
 - Support for calling lambdas and functions stored in variables or expressions.
   ([#674](https://github.com/Kipper-Lang/Kipper/issues/674))
 - Semantic checking and code generation for the `new` keyword expression to be able to create new instances of
-	classes. ([#679](https://github.com/Kipper-Lang/Kipper/issues/679))
+  classes. ([#679](https://github.com/Kipper-Lang/Kipper/issues/679))
 - Support for the `this` keyword inside a class method to access the current instance of the class.
-	([#697](https://github.com/Kipper-Lang/Kipper/issues/697))
+  ([#697](https://github.com/Kipper-Lang/Kipper/issues/697))
 - Support for the typeof operator, which returns the runtime type of a value.
-	([#663](https://github.com/Kipper-Lang/Kipper/issues/663))
+  ([#663](https://github.com/Kipper-Lang/Kipper/issues/663))
 - Implemented the generic `Array<T>` type and single-type array initializers.
   ([#499](https://github.com/Kipper-Lang/Kipper/issues/499))
 - Support for index-based array assignments. ([#669](https://github.com/Kipper-Lang/Kipper/issues/669))
@@ -44,11 +44,11 @@ To use development versions of Kipper download the
 - Support for internal type unions in built-in and internal functions.
   ([#496](https://github.com/Kipper-Lang/Kipper/issues/496))
 - Implemented internal representation for custom types such as objects, interfaces and classes. This change means that
-	the entire core type system has been reworked and adjusted to also support custom types as well as complex types
-	(objects, arrays etc.). This does not inherently add functionality but serves as the stepping stone for the
-	implementation of all custom types in the future. ([#524](https://github.com/Kipper-Lang/Kipper/issues/524))
+  the entire core type system has been reworked and adjusted to also support custom types as well as complex types
+  (objects, arrays etc.). This does not inherently add functionality but serves as the stepping stone for the
+  implementation of all custom types in the future. ([#524](https://github.com/Kipper-Lang/Kipper/issues/524))
 - Implemented internal preliminary type checking and "ahead of time" type evaluation to allow for self-referential
-	types and type checking of recursive types.
+  types and type checking of recursive types.
 - New module:
   - `semantics/runtime-built-ins`, which contains runtime built-in functions, variables and types.
   - `semantics/runtime-internals`, which contains the runtime internal functions.
@@ -177,9 +177,9 @@ To use development versions of Kipper download the
 - CLI command `run` not properly reporting internal or unexpected errors, as they were already prettified in the
   internally called up command `compile`.
 - Previously invalid parent type checking and evaluation performed in `ReturnStatement`. This was now made absolute by
-	the introduction of the preliminary type checking and "ahead of time" type evaluation, as that now allows for
-	self-referential types and type checking of recursive types i.e. the return statement now knows the type of its 
-	function even though it is not yet fully processed.
+  the introduction of the preliminary type checking and "ahead of time" type evaluation, as that now allows for
+  self-referential types and type checking of recursive types i.e. the return statement now knows the type of its
+  function even though it is not yet fully processed.
 - Duplicate universe entry registration in the `KipperProgramContext` for built-in types, functions and variables.
 
 ### Deprecated
@@ -189,7 +189,7 @@ To use development versions of Kipper download the
 - Type `Reference` as it is no longer needed and has been replaced by `KipperReferenceable`.
 - Function `FunctionCallExpressionTypeSemantics.func`, which is now has been replaced by `funcOrExp`.
 - Function `KipperProgramContext.setUpBuiltInsInGlobalScope()`, which is no longer needed as the universe scope now
-	handles all built-in types, functions and variables.
+  handles all built-in types, functions and variables.
 
 </details>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,13 +176,20 @@ To use development versions of Kipper download the
   now enables proper type checking for function references.
 - CLI command `run` not properly reporting internal or unexpected errors, as they were already prettified in the
   internally called up command `compile`.
+- Previously invalid parent type checking and evaluation performed in `ReturnStatement`. This was now made absolute by
+	the introduction of the preliminary type checking and "ahead of time" type evaluation, as that now allows for
+	self-referential types and type checking of recursive types i.e. the return statement now knows the type of its 
+	function even though it is not yet fully processed.
+- Duplicate universe entry registration in the `KipperProgramContext` for built-in types, functions and variables.
 
 ### Deprecated
 
 ### Removed
 
 - Type `Reference` as it is no longer needed and has been replaced by `KipperReferenceable`.
-- `FunctionCallExpressionTypeSemantics.func`, which is now has been replaced by `funcOrExp`.
+- Function `FunctionCallExpressionTypeSemantics.func`, which is now has been replaced by `funcOrExp`.
+- Function `KipperProgramContext.setUpBuiltInsInGlobalScope()`, which is no longer needed as the universe scope now
+	handles all built-in types, functions and variables.
 
 </details>
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,8 +21,8 @@ authors:
 identifiers:
   - type: url
     value: >-
-      https://github.com/Kipper-Lang/Kipper/releases/tag/v0.12.0-alpha.3
-    description: The GitHub release URL of tag 0.12.0-alpha.0
+      https://github.com/Kipper-Lang/Kipper/releases/tag/v0.12.0-alpha.4
+    description: The GitHub release URL of tag 0.12.0-alpha.4
 repository-code: 'https://github.com/Kipper-Lang/Kipper/'
 url: 'https://kipper-lang.org'
 abstract: >-
@@ -39,6 +39,6 @@ keywords:
   - oop-programming
   - type-safety
 license: GPL-3.0-or-later
-license-url: 'https://github.com/Kipper-Lang/Kipper/blob/v0.12.0-alpha.3/LICENSE'
-version: 0.12.0-alpha.3
+license-url: 'https://github.com/Kipper-Lang/Kipper/blob/v0.12.0-alpha.4/LICENSE'
+version: 0.12.0-alpha.4
 date-released: '2024-09-07'

--- a/kipper/cli/README.md
+++ b/kipper/cli/README.md
@@ -22,9 +22,10 @@ and the [Kipper website](https://kipper-lang.org)._
 [![DOI](https://zenodo.org/badge/411260595.svg)](https://zenodo.org/badge/latestdoi/411260595)
 
 <!-- toc -->
-* [Kipper CLI - `@kipper/cli` 🦊✨](#kipper-cli---kippercli-)
-* [Usage](#usage)
-* [Commands](#commands)
+
+- [Kipper CLI - `@kipper/cli` 🦊✨](#kipper-cli---kippercli-)
+- [Usage](#usage)
+- [Commands](#commands)
 <!-- tocstop -->
 
 ## General Information
@@ -39,6 +40,7 @@ and the [Kipper website](https://kipper-lang.org)._
 # Usage
 
 <!-- usage -->
+
 ```sh-session
 $ npm install -g @kipper/cli
 $ kipper COMMAND
@@ -50,16 +52,18 @@ USAGE
   $ kipper COMMAND
 ...
 ```
+
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-* [`kipper compile [FILE]`](#kipper-compile-file)
-* [`kipper help [COMMAND]`](#kipper-help-command)
-* [`kipper new [LOCATION]`](#kipper-new-location)
-* [`kipper run [FILE]`](#kipper-run-file)
-* [`kipper version`](#kipper-version)
+
+- [`kipper compile [FILE]`](#kipper-compile-file)
+- [`kipper help [COMMAND]`](#kipper-help-command)
+- [`kipper new [LOCATION]`](#kipper-new-location)
+- [`kipper run [FILE]`](#kipper-run-file)
+- [`kipper version`](#kipper-version)
 
 ## `kipper compile [FILE]`
 
@@ -202,6 +206,7 @@ USAGE
 ```
 
 _See code: [src/commands/version.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.0-alpha.3/kipper/cli/src/commands/version.ts)_
+
 <!-- commandsstop -->
 
 ## Contributing to Kipper

--- a/kipper/cli/README.md
+++ b/kipper/cli/README.md
@@ -22,10 +22,9 @@ and the [Kipper website](https://kipper-lang.org)._
 [![DOI](https://zenodo.org/badge/411260595.svg)](https://zenodo.org/badge/latestdoi/411260595)
 
 <!-- toc -->
-
-- [Kipper CLI - `@kipper/cli` 🦊✨](#kipper-cli---kippercli-)
-- [Usage](#usage)
-- [Commands](#commands)
+* [Kipper CLI - `@kipper/cli` 🦊✨](#kipper-cli---kippercli-)
+* [Usage](#usage)
+* [Commands](#commands)
 <!-- tocstop -->
 
 ## General Information
@@ -40,30 +39,27 @@ and the [Kipper website](https://kipper-lang.org)._
 # Usage
 
 <!-- usage -->
-
 ```sh-session
 $ npm install -g @kipper/cli
 $ kipper COMMAND
 running command...
 $ kipper (--version)
-@kipper/cli/0.12.0-alpha.3 linux-x64 node-v20.15.0
+@kipper/cli/0.12.0-alpha.4 linux-x64 node-v20.15.0
 $ kipper --help [COMMAND]
 USAGE
   $ kipper COMMAND
 ...
 ```
-
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-
-- [`kipper compile [FILE]`](#kipper-compile-file)
-- [`kipper help [COMMAND]`](#kipper-help-command)
-- [`kipper new [LOCATION]`](#kipper-new-location)
-- [`kipper run [FILE]`](#kipper-run-file)
-- [`kipper version`](#kipper-version)
+* [`kipper compile [FILE]`](#kipper-compile-file)
+* [`kipper help [COMMAND]`](#kipper-help-command)
+* [`kipper new [LOCATION]`](#kipper-new-location)
+* [`kipper run [FILE]`](#kipper-run-file)
+* [`kipper version`](#kipper-version)
 
 ## `kipper compile [FILE]`
 
@@ -115,7 +111,7 @@ EXAMPLES
   kipper compile -t ts ./path/to/file.kip -o build/ -e utf16le --warnings --log-timestamp
 ```
 
-_See code: [src/commands/compile.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.0-alpha.3/kipper/cli/src/commands/compile.ts)_
+_See code: [src/commands/compile.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.0-alpha.4/kipper/cli/src/commands/compile.ts)_
 
 ## `kipper help [COMMAND]`
 
@@ -132,7 +128,7 @@ OPTIONS
   --all  see all commands in CLI
 ```
 
-_See code: [src/commands/help.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.0-alpha.3/kipper/cli/src/commands/help.ts)_
+_See code: [src/commands/help.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.0-alpha.4/kipper/cli/src/commands/help.ts)_
 
 ## `kipper new [LOCATION]`
 
@@ -149,7 +145,7 @@ OPTIONS
   -d, --default  Use the default settings for the new project. Skips the setup wizard.
 ```
 
-_See code: [src/commands/new.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.0-alpha.3/kipper/cli/src/commands/new.ts)_
+_See code: [src/commands/new.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.0-alpha.4/kipper/cli/src/commands/new.ts)_
 
 ## `kipper run [FILE]`
 
@@ -194,7 +190,7 @@ EXAMPLES
   kipper run -t ts -o build/ -e utf8 -s "print('Hello, World!');" --warnings --log-timestamp
 ```
 
-_See code: [src/commands/run.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.0-alpha.3/kipper/cli/src/commands/run.ts)_
+_See code: [src/commands/run.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.0-alpha.4/kipper/cli/src/commands/run.ts)_
 
 ## `kipper version`
 
@@ -205,8 +201,7 @@ USAGE
   $ kipper version
 ```
 
-_See code: [src/commands/version.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.0-alpha.3/kipper/cli/src/commands/version.ts)_
-
+_See code: [src/commands/version.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.0-alpha.4/kipper/cli/src/commands/version.ts)_
 <!-- commandsstop -->
 
 ## Contributing to Kipper

--- a/kipper/cli/package.json
+++ b/kipper/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kipper/cli",
   "description": "The Kipper Command Line Interface (CLI).",
-  "version": "0.12.0-alpha.3",
+  "version": "0.12.0-alpha.4",
   "author": "Luna-Klatzer @Luna-Klatzer",
   "bin": {
     "kipper": "./bin/run",

--- a/kipper/cli/src/index.ts
+++ b/kipper/cli/src/index.ts
@@ -13,7 +13,7 @@ export * from "./output/compile";
 // eslint-disable-next-line no-unused-vars
 export const name = "@kipper/cli";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.12.0-alpha.3";
+export const version = "0.12.0-alpha.4";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/config/package.json
+++ b/kipper/config/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kipper/config",
 	"description": "The config file support package adding support for kip-config.json/kipper-config.json 🦊",
-	"version": "0.12.0-alpha.3",
+	"version": "0.12.0-alpha.4",
 	"author": "Luna-Klatzer @Luna-Klatzer",
 	"dependencies": {
 		"is-plain-object": "5.0.0",

--- a/kipper/config/src/index.ts
+++ b/kipper/config/src/index.ts
@@ -12,7 +12,7 @@ export * from "./evaluated-kipper-config-file";
 // eslint-disable-next-line no-unused-vars
 export const name = "@kipper/config";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.12.0-alpha.3";
+export const version = "0.12.0-alpha.4";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/core/package.json
+++ b/kipper/core/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kipper/core",
 	"description": "The core implementation of the Kipper compiler 🦊",
-	"version": "0.12.0-alpha.3",
+	"version": "0.12.0-alpha.4",
 	"author": "Luna-Klatzer @Luna-Klatzer",
 	"dependencies": {
 		"antlr4ts": "^0.5.0-alpha.4",

--- a/kipper/core/src/compiler/ast/nodes/declarations/function-declaration/function-declaration.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/function-declaration/function-declaration.ts
@@ -197,14 +197,12 @@ export class FunctionDeclaration
 	}
 
 	/**
-	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
-	 * and throw errors if encountered.
+	 * Preliminary registers the class declaration type to allow for internal self-referential type checking.
 	 *
-	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
-	 * the children has already failed and as such no parent node should run type checking.
-	 * @since 0.7.0
+	 * This is part of the "Ahead of time" type evaluation, which is done before the main type checking.
+	 * @since 0.12.0
 	 */
-	public async primarySemanticTypeChecking(): Promise<void> {
+	public async primaryPreliminaryTypeChecking(): Promise<void> {
 		const semanticData = this.getSemanticData();
 		const paramTypes = semanticData.params.map((param) => param.getTypeSemanticData().valueType);
 		const returnType = semanticData.returnTypeSpecifier.getTypeSemanticData().storedType;
@@ -216,6 +214,7 @@ export class FunctionDeclaration
 		// Ensure that all code paths return a value
 		this.programCtx.typeCheck(this).validReturnCodePathsInFunctionBody(this);
 	}
+	public readonly primarySemanticTypeChecking: undefined;
 
 	/**
 	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.

--- a/kipper/core/src/compiler/ast/nodes/declarations/parameter-declaration/parameter-declaration.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/parameter-declaration/parameter-declaration.ts
@@ -145,14 +145,12 @@ export class ParameterDeclaration extends Declaration<
 	}
 
 	/**
-	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
-	 * and throw errors if encountered.
+	 * Preliminary registers the class declaration type to allow for internal self-referential type checking.
 	 *
-	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
-	 * the children has already failed and as such no parent node should run type checking.
-	 * @since 0.7.0
+	 * This is part of the "Ahead of time" type evaluation, which is done before the main type checking.
+	 * @since 0.12.0
 	 */
-	public async primarySemanticTypeChecking(): Promise<void> {
+	public async primaryPreliminaryTypeChecking(): Promise<void> {
 		const semanticData = this.getSemanticData();
 
 		// Get the type that will be returned using the value type specifier
@@ -161,6 +159,7 @@ export class ParameterDeclaration extends Declaration<
 			valueType: valueType,
 		};
 	}
+	public readonly primarySemanticTypeChecking: undefined;
 
 	/**
 	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.

--- a/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/class-declaration/class-member-declaration/class-constructor-declaration/class-constructor-declaration-type-semantics.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/class-declaration/class-member-declaration/class-constructor-declaration/class-constructor-declaration-type-semantics.ts
@@ -1,4 +1,4 @@
-import type { ProcessedType } from "../../../../../../../semantics";
+import type { BuiltInTypeFunc } from "../../../../../../../semantics";
 import type { ClassMemberDeclarationTypeSemantics } from "../class-member-declaration-type-semantics";
 
 /**
@@ -7,8 +7,8 @@ import type { ClassMemberDeclarationTypeSemantics } from "../class-member-declar
  */
 export interface ClassConstructorDeclarationTypeSemantics extends ClassMemberDeclarationTypeSemantics {
 	/**
-	 * The processed type of this member property.
+	 * The processed type of this member property. This is always {@link BuiltInTypeFunc a function}.
 	 * @since 0.12.0
 	 */
-	valueType: ProcessedType;
+	valueType: BuiltInTypeFunc;
 }

--- a/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/class-declaration/class-member-declaration/class-constructor-declaration/class-constructor-declaration.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/class-declaration/class-member-declaration/class-constructor-declaration/class-constructor-declaration.ts
@@ -154,18 +154,17 @@ export class ClassConstructorDeclaration
 	}
 
 	/**
-	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
-	 * and throw errors if encountered.
+	 * Preliminary registers the class declaration type to allow for internal self-referential type checking.
 	 *
-	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
-	 * the children has already failed and as such no parent node should run type checking.
+	 * This is part of the "Ahead of time" type evaluation, which is done before the main type checking.
 	 * @since 0.12.0
 	 */
-	public async primarySemanticTypeChecking(): Promise<void> {
+	public async primaryPreliminaryTypeChecking(): Promise<void> {
 		this.typeSemantics = {
 			valueType: BuiltInTypes.Func,
 		};
 	}
+	public readonly primarySemanticTypeChecking: undefined;
 
 	/**
 	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.

--- a/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/class-declaration/class-member-declaration/class-member-declaration-type-semantics.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/class-declaration/class-member-declaration/class-member-declaration-type-semantics.ts
@@ -1,14 +1,7 @@
-import type { DeclarationTypeSemantics } from "../../../declaration-type-semantics";
-import type { ProcessedType } from "../../../../../../semantics";
+import type { TypeDeclarationPropertyTypeSemantics } from "../../type-declaration-property-type-semantics";
 
 /**
  * Type semantics for a {@link InterfaceMemberDeclaration}.
  * @since 0.12.0
  */
-export interface ClassMemberDeclarationTypeSemantics extends DeclarationTypeSemantics {
-	/**
-	 * The processed type of this member property.
-	 * @since 0.12.0
-	 */
-	valueType: ProcessedType;
-}
+export interface ClassMemberDeclarationTypeSemantics extends TypeDeclarationPropertyTypeSemantics {}

--- a/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/class-declaration/class-member-declaration/class-method-declaration/class-method-declaration-semantics.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/class-declaration/class-member-declaration/class-method-declaration/class-method-declaration-semantics.ts
@@ -2,6 +2,7 @@ import type { IdentifierTypeSpecifierExpression } from "../../../../../expressio
 import type { ParameterDeclaration } from "../../../../parameter-declaration";
 import type { CompoundStatement } from "../../../../../statements";
 import type { ClassMemberDeclarationSemantics } from "../class-member-declaration-semantics";
+import type { RawType } from "../../../../../../../semantics";
 
 /**
  * Semantics for AST Node {@link InterfacePropertyDeclaration}.
@@ -22,7 +23,12 @@ export interface ClassMethodDeclarationSemantics extends ClassMemberDeclarationS
 	 * The return type of this method.
 	 * @since 0.12.0
 	 */
-	returnType: IdentifierTypeSpecifierExpression;
+	returnType: RawType;
+	/**
+	 * The type specifier expression for the return type.
+	 * @since 0.11.0
+	 */
+	returnTypeSpecifier: IdentifierTypeSpecifierExpression;
 	/**
 	 * The body of the function.
 	 * @since 0.10.0

--- a/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/class-declaration/class-member-declaration/class-method-declaration/class-method-declaration-type-semantics.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/class-declaration/class-member-declaration/class-method-declaration/class-method-declaration-type-semantics.ts
@@ -1,4 +1,4 @@
-import type { ProcessedType } from "../../../../../../../semantics";
+import type { BuiltInTypeFunc } from "../../../../../../../semantics";
 import type { ClassMemberDeclarationTypeSemantics } from "../class-member-declaration-type-semantics";
 
 /**
@@ -7,8 +7,8 @@ import type { ClassMemberDeclarationTypeSemantics } from "../class-member-declar
  */
 export interface ClassMethodDeclarationTypeSemantics extends ClassMemberDeclarationTypeSemantics {
 	/**
-	 * The processed type of this member property. This always of type {@link BuiltInTypeFunc}.
+	 * The processed type of this member property. This is always {@link BuiltInTypeFunc a function}.
 	 * @since 0.12.0
 	 */
-	valueType: ProcessedType;
+	valueType: BuiltInTypeFunc;
 }

--- a/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/class-declaration/class-member-declaration/class-method-declaration/class-method-declaration.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/class-declaration/class-member-declaration/class-method-declaration/class-method-declaration.ts
@@ -163,7 +163,8 @@ export class ClassMethodDeclaration
 
 		this.semanticData = {
 			identifier: identifier,
-			returnType: retTypeSpecifier,
+			returnTypeSpecifier: retTypeSpecifier,
+			returnType: retTypeSpecifier.getSemanticData().rawType,
 			parameters: params,
 			functionBody: <CompoundStatement>functionBody,
 		};
@@ -171,23 +172,22 @@ export class ClassMethodDeclaration
 	}
 
 	/**
-	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
-	 * and throw errors if encountered.
+	 * Preliminary registers the class declaration type to allow for internal self-referential type checking.
 	 *
-	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
-	 * the children has already failed and as such no parent node should run type checking.
+	 * This is part of the "Ahead of time" type evaluation, which is done before the main type checking.
 	 * @since 0.12.0
 	 */
-	public async primarySemanticTypeChecking(): Promise<void> {
+	public async primaryPreliminaryTypeChecking(): Promise<void> {
 		const semanticData = this.getSemanticData();
 
 		// Get the type that will be returned using the return type specifier
-		const returnType = semanticData.returnType.getTypeSemanticData().storedType;
+		const returnType = semanticData.returnTypeSpecifier.getTypeSemanticData().storedType;
 		this.typeSemantics = {
 			returnType: returnType,
 			valueType: BuiltInTypes.Func,
 		};
 	}
+	public readonly primarySemanticTypeChecking: undefined;
 
 	/**
 	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.

--- a/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/class-declaration/class-member-declaration/class-property-declaration/class-property-declaration-type-semantics.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/class-declaration/class-member-declaration/class-property-declaration/class-property-declaration-type-semantics.ts
@@ -1,14 +1,7 @@
-import type { ProcessedType } from "../../../../../../../semantics";
 import type { ClassMemberDeclarationTypeSemantics } from "../class-member-declaration-type-semantics";
 
 /**
  * Type semantics for AST Node {@link InterfacePropertyDeclaration}.
  * @since 0.12.0
  */
-export interface ClassPropertyDeclarationTypeSemantics extends ClassMemberDeclarationTypeSemantics {
-	/**
-	 * The processed type of this member property.
-	 * @since 0.12.0
-	 */
-	valueType: ProcessedType;
-}
+export interface ClassPropertyDeclarationTypeSemantics extends ClassMemberDeclarationTypeSemantics {}

--- a/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/class-declaration/class-member-declaration/class-property-declaration/class-property-declaration.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/class-declaration/class-member-declaration/class-property-declaration/class-property-declaration.ts
@@ -128,14 +128,12 @@ export class ClassPropertyDeclaration extends ClassMemberDeclaration<
 	}
 
 	/**
-	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
-	 * and throw errors if encountered.
+	 * Preliminary registers the class declaration type to allow for internal self-referential type checking.
 	 *
-	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
-	 * the children has already failed and as such no parent node should run type checking.
+	 * This is part of the "Ahead of time" type evaluation, which is done before the main type checking.
 	 * @since 0.12.0
 	 */
-	public async primarySemanticTypeChecking(): Promise<void> {
+	public async primaryPreliminaryTypeChecking(): Promise<void> {
 		const semanticData = this.getSemanticData();
 
 		// Get the type that will be returned using the value type specifier
@@ -145,6 +143,7 @@ export class ClassPropertyDeclaration extends ClassMemberDeclaration<
 			valueType: valueType,
 		};
 	}
+	public readonly primarySemanticTypeChecking: undefined;
 
 	/**
 	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.

--- a/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/interface-declaration/interface-declaration.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/interface-declaration/interface-declaration.ts
@@ -124,18 +124,17 @@ export class InterfaceDeclaration extends TypeDeclaration<
 	}
 
 	/**
-	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
-	 * and throw errors if encountered.
+	 * Preliminary registers the class declaration type to allow for internal self-referential type checking.
 	 *
-	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
-	 * the children has already failed and as such no parent node should run type checking.
-	 * @since 0.11.0
+	 * This is part of the "Ahead of time" type evaluation, which is done before the main type checking.
+	 * @since 0.12.0
 	 */
-	public async primarySemanticTypeChecking(): Promise<void> {
+	public async primaryPreliminaryTypeChecking(): Promise<void> {
 		this.typeSemantics = {
 			valueType: CustomType.fromInterfaceDeclaration(this),
 		};
 	}
+	public readonly primarySemanticTypeChecking: undefined;
 
 	/**
 	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.

--- a/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/interface-declaration/interface-member-declaration/interface-member-declaration-type-semantics.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/interface-declaration/interface-member-declaration/interface-member-declaration-type-semantics.ts
@@ -1,7 +1,7 @@
-import type { TypeDeclarationTypeSemantics } from "../../type-declaration-type-semantics";
+import type { TypeDeclarationPropertyTypeSemantics } from "../../type-declaration-property-type-semantics";
 
 /**
  * Type semantics for a {@link InterfaceMemberDeclaration}.
  * @since 0.12.0
  */
-export interface InterfaceMemberDeclarationTypeSemantics extends TypeDeclarationTypeSemantics {}
+export interface InterfaceMemberDeclarationTypeSemantics extends TypeDeclarationPropertyTypeSemantics {}

--- a/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/interface-declaration/interface-member-declaration/interface-method-declaration/interface-method-declaration-type-semantics.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/interface-declaration/interface-member-declaration/interface-method-declaration/interface-method-declaration-type-semantics.ts
@@ -1,14 +1,14 @@
-import type { TypeDeclarationTypeSemantics } from "../../../type-declaration-type-semantics";
-import type { ProcessedType } from "../../../../../../../semantics";
+import type { BuiltInTypeFunc } from "../../../../../../../semantics";
+import type { TypeDeclarationPropertyTypeSemantics } from "../../../type-declaration-property-type-semantics";
 
 /**
- *
+ * Type semantics for AST Node {@link InterfaceMethodDeclaration}.
  * @since 0.12.0
  */
-export interface InterfaceMethodDeclarationTypeSemantics extends TypeDeclarationTypeSemantics {
+export interface InterfaceMethodDeclarationTypeSemantics extends TypeDeclarationPropertyTypeSemantics {
 	/**
-	 * The processed type of this member property.
+	 * The processed type of this member property. This is always {@link BuiltInTypeFunc a function}.
 	 * @since 0.12.0
 	 */
-	valueType: ProcessedType;
+	valueType: BuiltInTypeFunc;
 }

--- a/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/interface-declaration/interface-member-declaration/interface-method-declaration/interface-method-declaration.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/interface-declaration/interface-member-declaration/interface-method-declaration/interface-method-declaration.ts
@@ -150,14 +150,12 @@ export class InterfaceMethodDeclaration extends InterfaceMemberDeclaration<
 	}
 
 	/**
-	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
-	 * and throw errors if encountered.
+	 * Preliminary registers the class declaration type to allow for internal self-referential type checking.
 	 *
-	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
-	 * the children has already failed and as such no parent node should run type checking.
+	 * This is part of the "Ahead of time" type evaluation, which is done before the main type checking.
 	 * @since 0.12.0
 	 */
-	public async primarySemanticTypeChecking(): Promise<void> {
+	public async primaryPreliminaryTypeChecking(): Promise<void> {
 		const semanticData = this.getSemanticData();
 
 		// Get the type that will be returned using the return type specifier
@@ -167,6 +165,7 @@ export class InterfaceMethodDeclaration extends InterfaceMemberDeclaration<
 			valueType: BuiltInTypes.Func,
 		};
 	}
+	public readonly primarySemanticTypeChecking: undefined;
 
 	/**
 	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.

--- a/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/interface-declaration/interface-member-declaration/interface-property-declaration/interface-property-declaration-type-semantics.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/interface-declaration/interface-member-declaration/interface-property-declaration/interface-property-declaration-type-semantics.ts
@@ -1,14 +1,7 @@
-import type { TypeDeclarationTypeSemantics } from "../../../type-declaration-type-semantics";
-import type { ProcessedType } from "../../../../../../../semantics";
+import type { TypeDeclarationPropertyTypeSemantics } from "../../../type-declaration-property-type-semantics";
 
 /**
  * Type semantics for AST Node {@link InterfacePropertyDeclaration}.
  * @since 0.12.0
  */
-export interface InterfacePropertyDeclarationTypeSemantics extends TypeDeclarationTypeSemantics {
-	/**
-	 * The processed type of this member property.
-	 * @since 0.12.0
-	 */
-	valueType: ProcessedType;
-}
+export interface InterfacePropertyDeclarationTypeSemantics extends TypeDeclarationPropertyTypeSemantics {}

--- a/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/interface-declaration/interface-member-declaration/interface-property-declaration/interface-property-declaration.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/interface-declaration/interface-member-declaration/interface-property-declaration/interface-property-declaration.ts
@@ -124,14 +124,12 @@ export class InterfacePropertyDeclaration extends InterfaceMemberDeclaration<
 	}
 
 	/**
-	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
-	 * and throw errors if encountered.
+	 * Preliminary registers the class declaration type to allow for internal self-referential type checking.
 	 *
-	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
-	 * the children has already failed and as such no parent node should run type checking.
+	 * This is part of the "Ahead of time" type evaluation, which is done before the main type checking.
 	 * @since 0.12.0
 	 */
-	public async primarySemanticTypeChecking(): Promise<void> {
+	public async primaryPreliminaryTypeChecking(): Promise<void> {
 		const semanticData = this.getSemanticData();
 
 		// Get the type that will be returned using the value type specifier
@@ -141,6 +139,7 @@ export class InterfacePropertyDeclaration extends InterfaceMemberDeclaration<
 			valueType: valueType,
 		};
 	}
+	public readonly primarySemanticTypeChecking: undefined;
 
 	/**
 	 * Semantically analyses the code inside this AST node and checks for possible warnings or problematic code.

--- a/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/type-declaration-property-type-semantics.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/type-declaration-property-type-semantics.ts
@@ -1,0 +1,16 @@
+import type { ProcessedType } from "../../../../semantics";
+import type { DeclarationTypeSemantics } from "../declaration-type-semantics";
+
+/**
+ * Type semantics for a property declaration inside a {@link TypeDeclaration}.
+ *
+ * This is a simple helper interface for the properties inside classes and interfaces.
+ * @since 0.12.0
+ */
+export interface TypeDeclarationPropertyTypeSemantics extends DeclarationTypeSemantics {
+	/**
+	 * The processed type of the type declaration.
+	 * @since 0.12.0
+	 */
+	valueType: ProcessedType;
+}

--- a/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/type-declaration-type-semantics.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/type-declaration-type-semantics.ts
@@ -1,11 +1,11 @@
-import type { TypeData } from "../../../ast-node";
 import type { ProcessedType } from "../../../../semantics";
+import type { DeclarationTypeSemantics } from "../declaration-type-semantics";
 
 /**
  * Type semantics for a {@link TypeDeclaration}.
  * @since 0.11.0
  */
-export interface TypeDeclarationTypeSemantics extends TypeData {
+export interface TypeDeclarationTypeSemantics extends DeclarationTypeSemantics {
 	/**
 	 * The processed type of the type declaration.
 	 * @since 0.11.0

--- a/kipper/core/src/compiler/ast/nodes/declarations/variable-declaration/variable-declaration.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/variable-declaration/variable-declaration.ts
@@ -185,14 +185,12 @@ export class VariableDeclaration extends Declaration<VariableDeclarationSemantic
 	}
 
 	/**
-	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
-	 * and throw errors if encountered.
+	 * Preliminary registers the class declaration type to allow for internal self-referential type checking.
 	 *
-	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
-	 * the children has already failed and as such no parent node should run type checking.
-	 * @since 0.7.0
+	 * This is part of the "Ahead of time" type evaluation, which is done before the main type checking.
+	 * @since 0.12.0
 	 */
-	public async primarySemanticTypeChecking(): Promise<void> {
+	public async primaryPreliminaryTypeChecking(): Promise<void> {
 		const semanticData = this.getSemanticData();
 
 		// Get the type that will be returned using the value type specifier
@@ -201,6 +199,17 @@ export class VariableDeclaration extends Declaration<VariableDeclarationSemantic
 		this.typeSemantics = {
 			valueType: valueType,
 		};
+	}
+
+	/**
+	 * The primary type checking for this AST node. This will throw an error if the type checking fails.
+	 *
+	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
+	 * the children has already failed and as such no parent node should run type checking.
+	 * @since 0.7.0
+	 */
+	public async primarySemanticTypeChecking(): Promise<void> {
+		const semanticData = this.getSemanticData();
 
 		// If the variable is defined, check whether the assignment is valid
 		if (semanticData.value) {

--- a/kipper/core/src/compiler/ast/nodes/expressions/primary-expression/lambda-primary-expression/lambda-primary-expression.ts
+++ b/kipper/core/src/compiler/ast/nodes/expressions/primary-expression/lambda-primary-expression/lambda-primary-expression.ts
@@ -12,8 +12,8 @@ import { KindParseRuleMapping, ParseRuleKindMapping } from "../../../../../lexer
 import type { CompilableASTNode } from "../../../../compilable-ast-node";
 import type { ScopeNode } from "../../../../scope-node";
 import type { Statement } from "../../../statements";
-import { CompoundStatement } from "../../../statements";
 import type { IdentifierTypeSpecifierExpression } from "../../type-specifier-expression";
+import { CompoundStatement } from "../../../statements";
 import { ParameterDeclaration } from "../../../declarations";
 import { UnableToDetermineSemanticDataError } from "../../../../../../errors";
 import { BuiltInTypeFunc, LambdaScope } from "../../../../../semantics";
@@ -143,14 +143,12 @@ export class LambdaPrimaryExpression
 	}
 
 	/**
-	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
-	 * and throw errors if encountered.
+	 * Preliminary registers the class declaration type to allow for internal self-referential type checking.
 	 *
-	 * This will not run in case that {@link this.hasFailed} is true, as that indicates that the type checking of
-	 * the children has already failed and as such no parent node should run type checking.
-	 * @since 0.11.0
+	 * This is part of the "Ahead of time" type evaluation, which is done before the main type checking.
+	 * @since 0.12.0
 	 */
-	public async primarySemanticTypeChecking(): Promise<void> {
+	public async primaryPreliminaryTypeChecking(): Promise<void> {
 		const semanticData = this.getSemanticData();
 		const paramTypes = semanticData.params.map((param) => param.getTypeSemanticData().valueType);
 		const returnType = semanticData.returnTypeSpecifier.getTypeSemanticData().storedType;
@@ -166,6 +164,7 @@ export class LambdaPrimaryExpression
 			this.programCtx.typeCheck(this).validReturnCodePathsInFunctionBody(this);
 		}
 	}
+	public readonly primarySemanticTypeChecking: undefined;
 
 	public checkForWarnings = undefined;
 

--- a/kipper/core/src/compiler/ast/nodes/expressions/type-specifier-expression/generic-type-specifier-expression/generic-type-specifier-expression.ts
+++ b/kipper/core/src/compiler/ast/nodes/expressions/type-specifier-expression/generic-type-specifier-expression/generic-type-specifier-expression.ts
@@ -101,11 +101,12 @@ export class GenericTypeSpecifierExpression extends TypeSpecifierExpression<
 	}
 
 	/**
-	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
-	 * and throw errors if encountered.
-	 * @since 0.8.0
+	 * Preliminary registers the class declaration type to allow for internal self-referential type checking.
+	 *
+	 * This is part of the "Ahead of time" type evaluation, which is done before the main type checking.
+	 * @since 0.12.0
 	 */
-	public async primarySemanticTypeChecking(): Promise<void> {
+	public async primaryPreliminaryTypeChecking(): Promise<void> {
 		const semanticData = this.getSemanticData();
 		const valueType = this.programCtx.typeCheck(this).getCheckedType(semanticData.rawType, this.scope);
 		const providedArguments = semanticData.genericArguments.map((arg) => arg.getTypeSemanticData().storedType);
@@ -179,6 +180,7 @@ export class GenericTypeSpecifierExpression extends TypeSpecifierExpression<
 			storedType: (<GenericType<GenericTypeArguments>>valueType).changeGenericTypeArguments(newGenericArguments),
 		};
 	}
+	public readonly primarySemanticTypeChecking: undefined;
 
 	public checkForWarnings = undefined; // TODO!
 

--- a/kipper/core/src/compiler/ast/nodes/expressions/type-specifier-expression/identifier-type-specifier-expression/identifier-type-specifier-expression.ts
+++ b/kipper/core/src/compiler/ast/nodes/expressions/type-specifier-expression/identifier-type-specifier-expression/identifier-type-specifier-expression.ts
@@ -97,11 +97,12 @@ export class IdentifierTypeSpecifierExpression extends TypeSpecifierExpression<
 	}
 
 	/**
-	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
-	 * and throw errors if encountered.
-	 * @since 0.8.0
+	 * Preliminary registers the class declaration type to allow for internal self-referential type checking.
+	 *
+	 * This is part of the "Ahead of time" type evaluation, which is done before the main type checking.
+	 * @since 0.12.0
 	 */
-	public async primarySemanticTypeChecking(): Promise<void> {
+	public async primaryPreliminaryTypeChecking(): Promise<void> {
 		const semanticData = this.getSemanticData();
 
 		// Create a checked type instance (this function handles error recovery and invalid types)
@@ -112,6 +113,7 @@ export class IdentifierTypeSpecifierExpression extends TypeSpecifierExpression<
 			storedType: valueType,
 		};
 	}
+	public readonly primarySemanticTypeChecking: undefined;
 
 	public checkForWarnings = undefined; // TODO!
 

--- a/kipper/core/src/compiler/ast/nodes/expressions/type-specifier-expression/typeof-type-specifier-expression/typeof-type-specifier-expression.ts
+++ b/kipper/core/src/compiler/ast/nodes/expressions/type-specifier-expression/typeof-type-specifier-expression/typeof-type-specifier-expression.ts
@@ -96,13 +96,13 @@ export class TypeofTypeSpecifierExpression extends TypeSpecifierExpression<
 			},
 		};
 	}
-
 	/**
-	 * Performs type checking for this AST Node. This will log all warnings using {@link programCtx.logger}
-	 * and throw errors if encountered.
-	 * @since 0.8.0
+	 * Preliminary registers the class declaration type to allow for internal self-referential type checking.
+	 *
+	 * This is part of the "Ahead of time" type evaluation, which is done before the main type checking.
+	 * @since 0.12.0
 	 */
-	public async primarySemanticTypeChecking(): Promise<void> {
+	public async primaryPreliminaryTypeChecking(): Promise<void> {
 		const semanticData = this.getSemanticData();
 		const valueReference = semanticData.ref;
 
@@ -111,6 +111,7 @@ export class TypeofTypeSpecifierExpression extends TypeSpecifierExpression<
 			storedType: valueReference.refTarget.type,
 		};
 	}
+	public readonly primarySemanticTypeChecking: undefined;
 
 	public checkForWarnings = undefined; // TODO!
 

--- a/kipper/core/src/compiler/ast/nodes/root-ast-node.ts
+++ b/kipper/core/src/compiler/ast/nodes/root-ast-node.ts
@@ -190,6 +190,16 @@ export class RootASTNode extends ParserASTNode<NoSemantics, NoTypeSemantics> imp
 			}
 		}
 
+		// Perform preliminary semantic analysis in case any specific type evaluation is required prematurely (ahead of
+		// time type evaluation)
+		for (let child of this.children) {
+			try {
+				await child.preliminaryTypeChecking();
+			} catch (e) {
+				await this.handleSemanticError(<Error>e);
+			}
+		}
+
 		// Perform type-checking based on the existing AST nodes and evaluated semantics
 		for (let child of this.children) {
 			try {

--- a/kipper/core/src/compiler/ast/nodes/statements/return-statement/return-statement-semantics.ts
+++ b/kipper/core/src/compiler/ast/nodes/statements/return-statement/return-statement-semantics.ts
@@ -3,8 +3,8 @@
  * @since 0.10.0
  */
 import type { SemanticData } from "../../../ast-node";
-import type { Expression, LambdaPrimaryExpression } from "../../expressions";
-import type { FunctionDeclaration } from "../../declarations";
+import type { Expression } from "../../expressions";
+import type { KipperCallable } from "../../../../const";
 
 /**
  * Semantics for AST Node {@link ReturnStatement}.
@@ -20,5 +20,5 @@ export interface ReturnStatementSemantics extends SemanticData {
 	 * The function that this return statement is in.
 	 * @since 0.10.0
 	 */
-	function: FunctionDeclaration | LambdaPrimaryExpression;
+	function: KipperCallable;
 }

--- a/kipper/core/src/compiler/const.ts
+++ b/kipper/core/src/compiler/const.ts
@@ -3,6 +3,7 @@
  * @since 0.3.0
  */
 import type { ScopeDeclaration } from "./semantics";
+import type { ClassMethodDeclaration, FunctionDeclaration, LambdaPrimaryExpression } from "./ast";
 
 /**
  * If this variable is true, then this environment is assumed to be inside a browser and special browser support should
@@ -646,6 +647,12 @@ export type KipperReferenceable = ScopeDeclaration;
  * @since 0.10.0
  */
 export type JmpStatementType = "continue" | "break";
+
+/**
+ * Represents all possible callable ast nodes inside Kipper.
+ * @since 0.12.0
+ */
+export type KipperCallable = FunctionDeclaration | LambdaPrimaryExpression | ClassMethodDeclaration;
 
 /**
  * Represents the internal identifier for a Kipper constructor.

--- a/kipper/core/src/compiler/lexer-parser/antlr/KipperLexer.ts
+++ b/kipper/core/src/compiler/lexer-parser/antlr/KipperLexer.ts
@@ -2,12 +2,12 @@
 
 import KipperLexerBase from "./base/KipperLexerBase";
 
-import { ATN } from "antlr4ts/atn/ATN";
+import type { ATN } from "antlr4ts/atn/ATN";
 import { ATNDeserializer } from "antlr4ts/atn/ATNDeserializer";
-import { CharStream } from "antlr4ts/CharStream";
+import type { CharStream } from "antlr4ts/CharStream";
 import { LexerATNSimulator } from "antlr4ts/atn/LexerATNSimulator";
-import { RuleContext } from "antlr4ts/RuleContext";
-import { Vocabulary } from "antlr4ts/Vocabulary";
+import type { RuleContext } from "antlr4ts/RuleContext";
+import type { Vocabulary } from "antlr4ts/Vocabulary";
 import { VocabularyImpl } from "antlr4ts/VocabularyImpl";
 
 import * as Utils from "antlr4ts/misc/Utils";

--- a/kipper/core/src/compiler/lexer-parser/antlr/KipperParser.ts
+++ b/kipper/core/src/compiler/lexer-parser/antlr/KipperParser.ts
@@ -2,28 +2,29 @@
 
 // Import the required class for the ctx super class, as well as the 'ASTKind' type defining all possible syntax
 // kind values.
-import { ASTKind, KipperParserRuleContext, ParseRuleKindMapping } from "..";
+import type { ASTKind } from "..";
+import { KipperParserRuleContext, ParseRuleKindMapping } from "..";
 import KipperParserBase from "./base/KipperParserBase";
 
 import { ATN } from "antlr4ts/atn/ATN";
 import { ATNDeserializer } from "antlr4ts/atn/ATNDeserializer";
 import { FailedPredicateException } from "antlr4ts/FailedPredicateException";
 import { NoViableAltException } from "antlr4ts/NoViableAltException";
-import { ParserRuleContext } from "antlr4ts/ParserRuleContext";
+import type { ParserRuleContext } from "antlr4ts/ParserRuleContext";
 import { ParserATNSimulator } from "antlr4ts/atn/ParserATNSimulator";
 import { RecognitionException } from "antlr4ts/RecognitionException";
-import { RuleContext } from "antlr4ts/RuleContext";
+import type { RuleContext } from "antlr4ts/RuleContext";
 //import { RuleVersion } from "antlr4ts/RuleVersion";
-import { TerminalNode } from "antlr4ts/tree/TerminalNode";
+import type { TerminalNode } from "antlr4ts/tree/TerminalNode";
 import { Token } from "antlr4ts/Token";
-import { TokenStream } from "antlr4ts/TokenStream";
-import { Vocabulary } from "antlr4ts/Vocabulary";
+import type { TokenStream } from "antlr4ts/TokenStream";
+import type { Vocabulary } from "antlr4ts/Vocabulary";
 import { VocabularyImpl } from "antlr4ts/VocabularyImpl";
 
 import * as Utils from "antlr4ts/misc/Utils";
 
-import { KipperParserListener } from "./KipperParserListener";
-import { KipperParserVisitor } from "./KipperParserVisitor";
+import type { KipperParserListener } from "./KipperParserListener";
+import type { KipperParserVisitor } from "./KipperParserVisitor";
 
 export class KipperParser extends KipperParserBase {
 	public static readonly FStringExpStart = 1;

--- a/kipper/core/src/compiler/lexer-parser/antlr/KipperParserListener.ts
+++ b/kipper/core/src/compiler/lexer-parser/antlr/KipperParserListener.ts
@@ -3,9 +3,9 @@
 // Import the required class for the ctx super class, as well as the 'ASTKind' type defining all possible syntax
 // kind values.
 
-import { ParseTreeListener } from "antlr4ts/tree/ParseTreeListener";
+import type { ParseTreeListener } from "antlr4ts/tree/ParseTreeListener";
 
-import {
+import type {
 	ActualAdditiveExpressionContext,
 	ActualAssignmentExpressionContext,
 	ActualBitwiseAndExpressionContext,

--- a/kipper/core/src/compiler/lexer-parser/antlr/KipperParserVisitor.ts
+++ b/kipper/core/src/compiler/lexer-parser/antlr/KipperParserVisitor.ts
@@ -3,9 +3,9 @@
 // Import the required class for the ctx super class, as well as the 'ASTKind' type defining all possible syntax
 // kind values.
 
-import { ParseTreeVisitor } from "antlr4ts/tree/ParseTreeVisitor";
+import type { ParseTreeVisitor } from "antlr4ts/tree/ParseTreeVisitor";
 
-import {
+import type {
 	ActualAdditiveExpressionContext,
 	ActualAssignmentExpressionContext,
 	ActualBitwiseAndExpressionContext,

--- a/kipper/core/src/compiler/program-ctx.ts
+++ b/kipper/core/src/compiler/program-ctx.ts
@@ -30,7 +30,6 @@ import type {
 } from "./semantics";
 import {
 	BuiltInFunctions,
-	BuiltInTypes,
 	BuiltInVariables,
 	KipperSemanticChecker,
 	KipperTypeChecker,
@@ -212,7 +211,9 @@ export class KipperProgramContext {
 		this._internalReferences = [];
 		this._warnings = [];
 		this._errors = [];
-		this._initUniversalReferencables(compileConfig);
+
+		this.logger.debug("Setting up built-ins in global scope.");
+		this._initUniversalReferenceables(compileConfig);
 	}
 
 	// @ts-ignore
@@ -485,19 +486,6 @@ export class KipperProgramContext {
 	}
 
 	/**
-	 * Sets up the built-ins for this program. This function should be called before the semantic analysis is run.
-	 *
-	 * TODO! For now this only registers the built-in types in the global scope so they can be use, but in the future
-	 * this should also generate the built-in functions and variables.
-	 * @since 0.11.0
-	 */
-	public async setUpBuiltInsInGlobalScope(): Promise<void> {
-		for (const [_, type] of Object.entries(BuiltInTypes)) {
-			this._universeScope.addType(type);
-		}
-	}
-
-	/**
 	 * Runs the semantic analysis for this {@link KipperProgramContext program}. This function will log debugging messages
 	 * and warnings using the {@link this.logger logger of this instance} and throw errors in case any logical issues are
 	 * detected.
@@ -599,8 +587,6 @@ export class KipperProgramContext {
 		this._rootASTNode = await this.generateAbstractSyntaxTree();
 
 		// Running the semantic analysis for the AST
-		this.logger.debug("Setting up built-ins in global scope.");
-		await this.setUpBuiltInsInGlobalScope();
 		this.logger.info(`Analysing semantics.`);
 		await this.semanticAnalysis();
 
@@ -796,7 +782,7 @@ export class KipperProgramContext {
 	}
 
 	/**
-	 * Initialises the universal referencables for the program context, by registering all built-in functions and
+	 * Initialises the universal Referenceables for the program context, by registering all built-in functions and
 	 * variables as well as adding all the extension functions and variables.
 	 *
 	 * This will initialise {@link this._universeScope}.
@@ -804,7 +790,7 @@ export class KipperProgramContext {
 	 * @private
 	 * @since 0.11.0
 	 */
-	private _initUniversalReferencables(compileConfig: EvaluatedCompileConfig) {
+	private _initUniversalReferenceables(compileConfig: EvaluatedCompileConfig) {
 		// Register all built-in functions
 		const globalFunctions = [...Object.values(BuiltInFunctions), ...compileConfig.extendBuiltInFunctions];
 		this.registerBuiltInFunctions(globalFunctions);
@@ -821,9 +807,11 @@ export class KipperProgramContext {
 
 		this._universeScope.init();
 		for (const extFunction of compileConfig.extendBuiltInFunctions) {
+			this.logger.debug(`Adding extended built-in function '${extFunction.identifier}'.`);
 			this._universeScope.addFunction(extFunction);
 		}
 		for (const extVariable of compileConfig.extendBuiltInVariables) {
+			this.logger.debug(`Adding extended built-in variable '${extVariable.identifier}'.`);
 			this._universeScope.addVariable(extVariable);
 		}
 	}

--- a/kipper/core/src/compiler/semantics/analyser/type-checker.ts
+++ b/kipper/core/src/compiler/semantics/analyser/type-checker.ts
@@ -143,10 +143,9 @@ export class KipperTypeChecker extends KipperSemanticsAsserter {
 		}
 
 		// Assuming obj.fields is a Map or an iterable collection of [key, value] pairs
-		for (const [fieldIdentifier, type] of obj.fields) {
-			if (fieldIdentifier === identifier) {
-				return type;
-			}
+		const fieldType = obj.getProperty(identifier);
+		if (fieldType) {
+			return fieldType;
 		}
 
 		// If no matching field was found, throw an error
@@ -543,12 +542,8 @@ export class KipperTypeChecker extends KipperSemanticsAsserter {
 		// If the return statement has no return value, then the value is automatically 'void'
 		const statementValueType = semanticData.returnValue?.getTypeSemanticData().evaluatedType ?? BuiltInTypes.void;
 
-		// TODO! DON'T DO THIS. THIS IS PUTTING TYPE CHECKING OF A PARENT INTO A CHILD
-		// TODO! REALLY WE NEED TO REMOVE THIS SOON
-		const functionReturnType = this.getCheckedType(
-			semanticData.function.getSemanticData().returnType,
-			semanticData.function.scope,
-		);
+		// As the function type is evaluated preliminary, we can safely assume that the type is valid and use it
+		const functionReturnType = semanticData.function.getTypeSemanticData().type.returnType;
 
 		// If either one of the types is undefined, skip type checking (the types are invalid anyway)
 		if (statementValueType === undefined || functionReturnType === undefined) {
@@ -652,6 +647,7 @@ export class KipperTypeChecker extends KipperSemanticsAsserter {
 	/**
 	 * Checks whether the members of the passed {@link objLike} can be accessed. (As well if there are members)
 	 * @param objLike The object-like expression to check.
+	 * @param accessType The type of accessor that is used to access the members.
 	 * @throws {TypeError} If the object expression is not an object.
 	 * @since 0.10.0
 	 */

--- a/kipper/core/src/compiler/semantics/symbol-table/base/user-scope.ts
+++ b/kipper/core/src/compiler/semantics/symbol-table/base/user-scope.ts
@@ -1,0 +1,25 @@
+import { Scope } from "./scope";
+import type { CompilableASTNode, Declaration, RootASTNode, ScopeNode } from "../../../ast";
+
+/**
+ * Represents any scope that the user can access and write to in a Kipper program.
+ *
+ * This in practise means any scope except the universe scope.
+ * @since 0.12.0
+ */
+export abstract class UserScope<VarT = any, FuncT = any, TypeT = any> extends Scope<VarT, FuncT, TypeT> {
+	protected constructor(public readonly ctx: (ScopeNode<UserScope> & CompilableASTNode) | RootASTNode) {
+		super();
+	}
+
+	/**
+	 * Ensures that the given declaration is not already used in the current scope.
+	 * @param identifier The identifier to check.
+	 * @param declaration The declaration to check.
+	 * @private
+	 * @since 0.12.0
+	 */
+	protected ensureNotUsed(identifier: string, declaration: Declaration): void {
+		this.ctx.programCtx.semanticCheck(declaration).identifierNotUsed(declaration, identifier, this);
+	}
+}

--- a/kipper/core/src/compiler/semantics/symbol-table/entry/class-scope-this-declaration.ts
+++ b/kipper/core/src/compiler/semantics/symbol-table/entry/class-scope-this-declaration.ts
@@ -1,0 +1,97 @@
+import type { ClassDeclaration, TypeDeclaration } from "../../../ast";
+import type { ProcessedType } from "../../types";
+import { ScopeDeclaration } from "./scope-declaration";
+
+/**
+ * A scope declaration for the "this" keyword inside a class. This is almost identical to a {@link ScopeTypeDeclaration}
+ * for a class, but it is specifically initialised prematurely to allow for references to "this" inside the class.
+ * @since 0.12.0
+ */
+export class ClassScopeThisDeclaration extends ScopeDeclaration {
+	public constructor(public readonly _declaration: ClassDeclaration) {
+		super();
+	}
+
+	/**
+	 * The identifier of this declaration. This is always "this" as we are referring to the "this" keyword inside a class.
+	 * @since 0.12.0
+	 */
+	public get identifier(): string {
+		return "this";
+	}
+
+	/**
+	 * Returns whether this type declaration is a built-in type.
+	 *
+	 * As this is an auto-initialised declaration custom to every class, it will never be a built-in type.
+	 * @since 0.12.0
+	 */
+	public override get isBuiltIn(): boolean {
+		return false;
+	}
+
+	/**
+	 * Returns the built-in structure of this declaration, if this declaration is based on one.
+	 *
+	 * As this is an auto-initialised declaration custom to every class, it will never be based on a built-in type.
+	 * @since 0.12.0
+	 */
+	public override get builtInStructure(): undefined {
+		return undefined;
+	}
+
+	/**
+	 * Returns the {@link InterfaceDeclaration} or {@link ClassDeclaration AST node} this scope type declaration bases on.
+	 */
+	public get node(): TypeDeclaration | undefined {
+		return this._declaration;
+	}
+
+	/**
+	 * The type of this type.
+	 *
+	 * This is always the custom type of the class declaration.
+	 * @since 0.12.0
+	 */
+	public get type(): ProcessedType {
+		return this._declaration.getTypeSemanticData().valueType;
+	}
+
+	/**
+	 * Returns whether the declaration is defined.
+	 *
+	 * As this is auto-initialized, it will always be defined.
+	 * @since 0.12.0
+	 */
+	public get isDefined(): true {
+		return true;
+	}
+
+	/**
+	 * Returns the scope associated with this {@link ScopeDeclaration}.
+	 * @since 0.12.0
+	 */
+	public get scope() {
+		return this._declaration.scope;
+	}
+
+	/**
+	 * Returns whether the declaration has a value.
+	 *
+	 * As this is auto-initialized, it will always have a value.
+	 * @since 0.12.0
+	 */
+	public get hasValue(): true {
+		return true;
+	}
+
+	/**
+	 * Returns whether the declaration has a callable value (function).
+	 *
+	 * A class is not callable, so this will always be false.
+	 * @since 0.12.0
+	 */
+	public get isCallable(): false {
+		return false;
+	}
+}

--- a/kipper/core/src/compiler/semantics/symbol-table/entry/scope-declaration.ts
+++ b/kipper/core/src/compiler/semantics/symbol-table/entry/scope-declaration.ts
@@ -17,7 +17,6 @@ import type { BuiltInFunction, BuiltInVariable } from "../../runtime-built-ins";
  */
 export abstract class ScopeDeclaration {
 	public abstract get node(): Declaration | undefined;
-
 	public abstract get identifier(): string;
 
 	/**

--- a/kipper/core/src/compiler/semantics/symbol-table/entry/scope-type-declaration.ts
+++ b/kipper/core/src/compiler/semantics/symbol-table/entry/scope-type-declaration.ts
@@ -13,10 +13,10 @@ import { BuiltInTypes } from "../universe-scope";
  * @since 0.11.0
  */
 export class ScopeTypeDeclaration extends ScopeDeclaration {
-	private constructor(
-		private readonly _declaration?: TypeDeclaration,
-		private readonly _builtInType?: BuiltInType,
-		private readonly _universeScope?: UniverseScope,
+	protected constructor(
+		protected readonly _declaration?: TypeDeclaration,
+		protected readonly _builtInType?: BuiltInType,
+		protected readonly _universeScope?: UniverseScope,
 	) {
 		super();
 	}
@@ -32,12 +32,12 @@ export class ScopeTypeDeclaration extends ScopeDeclaration {
 
 	/**
 	 * Creates a new scope type declaration from a built-in type.
-	 * @param identifier The identifier of the built-in type.
+	 * @param builtInType The built-in type.
 	 * @param universeScope The universe scope this type is associated with.
 	 * @since 0.11.0
 	 */
-	public static fromBuiltInType(type: BuiltInType, universeScope: UniverseScope): ScopeTypeDeclaration {
-		return new ScopeTypeDeclaration(undefined, type, universeScope);
+	public static fromBuiltInType(builtInType: BuiltInType, universeScope: UniverseScope): ScopeTypeDeclaration {
+		return new ScopeTypeDeclaration(undefined, builtInType, universeScope);
 	}
 
 	/**
@@ -97,13 +97,13 @@ export class ScopeTypeDeclaration extends ScopeDeclaration {
 	}
 
 	/**
-	 * Returns whether the declaration has a value.
+	 * Returns whether the declaration is defined.
 	 *
-	 * As this is a type, it will always be false.
+	 * As this is a type, it will always be true;
 	 * @since 0.11.0
 	 */
-	public get isDefined(): false {
-		return false;
+	public get isDefined(): true {
+		return true;
 	}
 
 	/**

--- a/kipper/core/src/compiler/semantics/symbol-table/function-scope.ts
+++ b/kipper/core/src/compiler/semantics/symbol-table/function-scope.ts
@@ -46,9 +46,7 @@ export class FunctionScope extends LocalScope {
 	 */
 	public addArgument(declaration: ParameterDeclaration): ScopeParameterDeclaration {
 		const identifier = declaration.getSemanticData().identifier;
-
-		// Ensuring that the declaration does not overwrite other declarations
-		this.ctx.programCtx.semanticCheck(declaration).identifierNotUsed(identifier, this);
+		this.ensureNotUsed(identifier, declaration);
 
 		const scopeDeclaration = ScopeParameterDeclaration.fromParameterDeclaration(declaration);
 		this.arguments.set(scopeDeclaration.identifier, scopeDeclaration);

--- a/kipper/core/src/compiler/semantics/symbol-table/local-scope.ts
+++ b/kipper/core/src/compiler/semantics/symbol-table/local-scope.ts
@@ -11,19 +11,19 @@ import type {
 	VariableDeclaration,
 } from "../../ast/";
 import type { GlobalScope } from "./global-scope";
-import { KipperNotImplementedError } from "../../../errors";
+import type { ClassScope } from "./class-scope";
 import type { ScopeDeclaration, ScopeFunctionDeclaration, ScopeTypeDeclaration } from "./entry";
 import { ScopeVariableDeclaration } from "./entry";
-import { Scope } from "./base/scope";
-import type { ClassScope } from "./class-scope";
+import { KipperNotImplementedError } from "../../../errors";
+import { UserScope } from "./base/user-scope";
 
 /**
  * A scope that is bound to a {@link CompoundStatement} and not the global namespace.
  * @since 0.8.0
  */
-export class LocalScope extends Scope<VariableDeclaration, FunctionDeclaration, TypeDeclaration> {
-	constructor(public ctx: ScopeNode<LocalScope> & CompilableASTNode) {
-		super();
+export class LocalScope extends UserScope<VariableDeclaration, FunctionDeclaration, TypeDeclaration> {
+	constructor(public readonly ctx: ScopeNode<LocalScope> & CompilableASTNode) {
+		super(ctx);
 	}
 
 	/**
@@ -43,9 +43,7 @@ export class LocalScope extends Scope<VariableDeclaration, FunctionDeclaration, 
 
 	public addVariable(declaration: VariableDeclaration): ScopeVariableDeclaration {
 		const identifier = declaration.getSemanticData().identifier;
-
-		// Ensuring that the declaration does not overwrite other declarations
-		this.ctx.programCtx.semanticCheck(declaration).identifierNotUsed(identifier, this);
+		this.ensureNotUsed(identifier, declaration);
 
 		const scopeDeclaration = ScopeVariableDeclaration.fromVariableDeclaration(declaration);
 		this._entries.set(identifier, scopeDeclaration);

--- a/kipper/core/src/compiler/semantics/symbol-table/universe-scope.ts
+++ b/kipper/core/src/compiler/semantics/symbol-table/universe-scope.ts
@@ -18,6 +18,7 @@ import {
 import type { KipperBuiltInTypeLiteral } from "../../const";
 import type { KipperProgramContext } from "../../program-ctx";
 import { BuiltInFunction, BuiltInFunctionArgument, BuiltInVariable } from "../runtime-built-ins";
+import { DuplicateUniverseKeyError } from "../../../errors";
 import { Scope } from "./base";
 
 const any = new BuiltInTypeAny();
@@ -94,12 +95,25 @@ export class UniverseScope extends Scope<never, never, BuiltInType> {
 	}
 
 	/**
+	 * Ensures that the given declaration is not already used in the current scope.
+	 * @param identifier The identifier to check.
+	 * @private
+	 * @since 0.12.0
+	 */
+	protected ensureNotUsed(identifier: string): void {
+		if (this.entries.has(identifier)) {
+			throw new DuplicateUniverseKeyError(identifier);
+		}
+	}
+
+	/**
 	 * Adds a built-in variable to the universal scope.
 	 * @param declaration The built-in variable to add.
 	 * @returns The scope declaration of the added variable.
 	 * @since 0.11.0
 	 */
 	public addVariable(declaration: BuiltInVariable): ScopeVariableDeclaration {
+		this.ensureNotUsed(declaration.identifier);
 		const scopeDeclaration = ScopeVariableDeclaration.fromBuiltInVariable(declaration, this);
 		this.entries.set(scopeDeclaration.identifier, scopeDeclaration);
 		return scopeDeclaration;
@@ -112,6 +126,7 @@ export class UniverseScope extends Scope<never, never, BuiltInType> {
 	 * @since 0.11.0
 	 */
 	public addFunction(declaration: BuiltInFunction): ScopeFunctionDeclaration {
+		this.ensureNotUsed(declaration.identifier);
 		const scopeDeclaration = ScopeFunctionDeclaration.fromBuiltInFunction(declaration, this);
 		this.entries.set(scopeDeclaration.identifier, scopeDeclaration);
 		return scopeDeclaration;
@@ -119,12 +134,13 @@ export class UniverseScope extends Scope<never, never, BuiltInType> {
 
 	/**
 	 * Adds a built-in type to the universal scope.
-	 * @param declarationOrIdentifier The built-in type to add.
+	 * @param declaration The built-in type to add.
 	 * @returns The scope declaration of the added type.
 	 * @since 0.11.0
 	 */
-	public addType(declarationOrIdentifier: BuiltInType): ScopeTypeDeclaration {
-		const scopeDeclaration = ScopeTypeDeclaration.fromBuiltInType(declarationOrIdentifier, this);
+	public addType(declaration: BuiltInType): ScopeTypeDeclaration {
+		this.ensureNotUsed(declaration.identifier);
+		const scopeDeclaration = ScopeTypeDeclaration.fromBuiltInType(declaration, this);
 		this.entries.set(scopeDeclaration.identifier, scopeDeclaration);
 		return scopeDeclaration;
 	}

--- a/kipper/core/src/compiler/semantics/types/custom-type.ts
+++ b/kipper/core/src/compiler/semantics/types/custom-type.ts
@@ -34,17 +34,43 @@ export type CustomTypeFields = Map<string, CustomTypeField>;
  * @since 0.12.0
  */
 export class CustomType extends ProcessedType {
+	private readonly _fields: CustomTypeFields;
+	private readonly _clsStaticFields?: CustomTypeFields;
+
 	/**
 	 * The kind of this type. This is simply used to differentiate between classes and interfaces.
 	 * @since 0.12.0
 	 */
 	public readonly kind: CustomTypeKind;
-	private readonly _fields: CustomTypeFields;
 
-	protected constructor(identifier: string, kind: CustomTypeKind, fields: CustomTypeFields) {
+	/**
+	 * The type that this type extends. This is only applicable to classes.
+	 * @since 0.12.0
+	 */
+	public readonly clsExtends?: CustomType;
+
+	/**
+	 * The types that this type implements. This is only applicable to classes.
+	 * @since 0.12.0
+	 */
+	public readonly clsImplements?: CustomType[];
+
+	/**
+	 * The interface that this type extends. This is only applicable to interfaces.
+	 * @since 0.12.0
+	 */
+	public readonly intfExtends?: CustomType;
+
+	protected constructor(
+		identifier: string,
+		kind: CustomTypeKind,
+		fields: CustomTypeFields,
+		staticFields?: CustomTypeFields,
+	) {
 		super(identifier);
-		this._fields = fields;
 		this.kind = kind;
+		this._fields = fields;
+		this._clsStaticFields = staticFields;
 	}
 
 	/**
@@ -64,6 +90,14 @@ export class CustomType extends ProcessedType {
 	 */
 	public get fields(): CustomTypeFields {
 		return this._fields;
+	}
+
+	/**
+	 * The static fields of this type. This is only applicable to classes.
+	 * @since 0.12.0
+	 */
+	public get clsStaticFields(): CustomTypeFields | undefined {
+		return this._clsStaticFields;
 	}
 
 	/**
@@ -161,5 +195,14 @@ export class CustomType extends ProcessedType {
 		} else {
 			throw new AssignmentTypeError(type.identifier, this.identifier);
 		}
+	}
+
+	/**
+	 * Returns the field type for the passed identifier. May return undefined if the field does not exist.
+	 * @param identifier The identifier of the field to get.
+	 * @since 0.12.0
+	 */
+	getProperty(identifier: string): CustomTypeField | undefined {
+		return this.fields.get(identifier);
 	}
 }

--- a/kipper/core/src/errors.ts
+++ b/kipper/core/src/errors.ts
@@ -330,6 +330,17 @@ export class GenericCanOnlyHaveOneSpreadError extends KipperInternalError {
 }
 
 /**
+ * Error that is thrown whenever a variable, type or function is registered in the universe scope where the identifier
+ * is already in use.
+ * @since 0.12.0
+ */
+export class DuplicateUniverseKeyError extends KipperInternalError {
+	constructor(key: string) {
+		super(`Duplicate key '${key}' in universe scope.`);
+	}
+}
+
+/**
  * An error that is raised whenever a feature is used that has not been implemented yet.
  * @since 0.6.0
  */
@@ -538,6 +549,16 @@ export class IdentifierAlreadyUsedByVariableError extends IdentifierError {
 export class IdentifierAlreadyUsedByFunctionError extends IdentifierError {
 	constructor(identifier: string) {
 		super(`Redeclaration of function '${identifier}'.`);
+	}
+}
+
+/**
+ * Error that is thrown when a new identifier is registered, but the used identifier is already in use by
+ * another member.
+ */
+export class IdentifierAlreadyUsedByMemberError extends IdentifierError {
+	constructor(identifier: string, kind: "interface" | "class") {
+		super(`Redeclaration of ${kind} member '${identifier}'.`);
 	}
 }
 

--- a/kipper/core/src/index.ts
+++ b/kipper/core/src/index.ts
@@ -17,7 +17,7 @@ export * as utils from "./tools";
 // eslint-disable-next-line no-unused-vars
 export const name = "@kipper/core";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.12.0-alpha.3";
+export const version = "0.12.0-alpha.4";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/index.ts
+++ b/kipper/index.ts
@@ -13,7 +13,7 @@ export * from "@kipper/target-ts";
 // eslint-disable-next-line no-unused-vars
 export const name = "kipper";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.12.0-alpha.3";
+export const version = "0.12.0-alpha.4";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/target-js/package.json
+++ b/kipper/target-js/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kipper/target-js",
 	"description": "The JavaScript target for the Kipper compiler 🦊",
-	"version": "0.12.0-alpha.3",
+	"version": "0.12.0-alpha.4",
 	"author": "Luna-Klatzer @Luna-Klatzer",
 	"dependencies": {
 		"@kipper/core": "workspace:~",

--- a/kipper/target-js/src/index.ts
+++ b/kipper/target-js/src/index.ts
@@ -13,7 +13,7 @@ export * from "./tools";
 // eslint-disable-next-line no-unused-vars
 export const name = "@kipper/target-js";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.12.0-alpha.3";
+export const version = "0.12.0-alpha.4";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/target-ts/package.json
+++ b/kipper/target-ts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kipper/target-ts",
 	"description": "The TypeScript target for the Kipper compiler 🦊",
-	"version": "0.12.0-alpha.3",
+	"version": "0.12.0-alpha.4",
 	"author": "Luna-Klatzer @Luna-Klatzer",
 	"dependencies": {
 		"@kipper/target-js": "workspace:~",

--- a/kipper/target-ts/src/code-generator.ts
+++ b/kipper/target-ts/src/code-generator.ts
@@ -200,8 +200,7 @@ export class TypeScriptTargetCodeGenerator extends JavaScriptTargetCodeGenerator
 		const identifier = semanticData.identifier;
 		const params = semanticData.parameters;
 		const body = semanticData.functionBody;
-		const evaluatedType = TargetTS.getTypeScriptType(semanticData.returnType.getTypeSemanticData().storedType);
-		const returnType = evaluatedType;
+		const returnType = TargetTS.getTypeScriptType(semanticData.returnTypeSpecifier.getTypeSemanticData().storedType);
 
 		const translatedParams = (
 			await Promise.all(

--- a/kipper/target-ts/src/index.ts
+++ b/kipper/target-ts/src/index.ts
@@ -13,7 +13,7 @@ export * from "./tools";
 // eslint-disable-next-line no-unused-vars
 export const name = "@kipper/target-ts";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.12.0-alpha.3";
+export const version = "0.12.0-alpha.4";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/web/package.json
+++ b/kipper/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kipper/web",
   "description": "The standalone web-module for the Kipper compiler 🦊",
-  "version": "0.12.0-alpha.3",
+  "version": "0.12.0-alpha.4",
   "author": "Luna-Klatzer @Luna-Klatzer",
   "devDependencies": {
     "@kipper/target-js": "workspace:~",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kipper",
   "description": "The Kipper programming language and compiler 🦊",
-  "version": "0.12.0-alpha.3",
+  "version": "0.12.0-alpha.4",
   "author": "Luna-Klatzer @Luna-Klatzer",
   "dependencies": {
     "@kipper/cli": "workspace:~",

--- a/test/module/core/core-functionality.test.ts
+++ b/test/module/core/core-functionality.test.ts
@@ -1418,63 +1418,44 @@ describe("Core functionality", () => {
 	describe("Lambdas", () => {
 		describe("js", () => {
 			it("parses simple lambda expression without syntax errors", async () => {
-				const code = `var add: Func<num, num, num> = (x: num, y: num): num -> x + y;`;
-				try {
-					const result = await compiler.compile(code, jsConfig);
+				const code = `var add: Func<num, num, num> = (x: num, y: num): num -> x + y; print(add(1, 2));`;
+				const result = await compiler.compile(code, jsConfig);
+				const stringResult = result.write();
 
-					// Evaluate the compiled code
-					let stringResult = result.result!.map((x) => x.join("")).join("\n");
-					stringResult = stringResult.concat("\nadd(1, 2);");
-					const res = eval(stringResult);
-					assert.equal(res, 3, "Lambda expression evaluated correctly");
-				} catch (e) {
-					assert.fail("Failed to analyze lambda expression semantically");
-				}
+				testPrintOutput((message: any) => assert.equal(message, "3", "Expected different output"), stringResult);
 			});
 
 			it("correctly identifies semantic data for a lambda with compound statement", async () => {
-				const code = `var greet: Func<str, str> = (name: str): str -> { return "Hello, " + name; };`;
-				try {
-					const result = await compiler.compile(code, jsConfig);
+				const code = `var greet: Func<str, str> = (name: str): str -> { return "Hello, " + name; }; print(greet('John'));`;
+				const result = await compiler.compile(code, jsConfig);
+				const stringResult = result.write();
 
-					// Evaluate the compiled code
-					let stringResult = result.result!.map((x) => x.join("")).join("\n");
-					stringResult = stringResult.concat("\ngreet('John');");
-					const res = eval(stringResult);
-					assert.equal(res, "Hello, John", "Lambda expression evaluated correctly");
-				} catch (e) {
-					assert.fail("Failed to analyze lambda expression semantically");
-				}
+				testPrintOutput(
+					(message: any) => assert.equal(message, "Hello, John", "Expected different output"),
+					stringResult,
+				);
 			});
 
 			it("correctly identifies semantic data for a lambda with single statement", async () => {
-				const code = `var greet: Func<str, str> = (name: str): str -> "Hello, " + name;`;
-				try {
-					const result = await compiler.compile(code, jsConfig);
+				const code = `var greet: Func<str, str> = (name: str): str -> "Hello, " + name; print(greet('John'));`;
+				const result = await compiler.compile(code, jsConfig);
+				const stringResult = result.write();
 
-					// Evaluate the compiled code
-					let stringResult = result.result!.map((x) => x.join("")).join("\n");
-					stringResult = stringResult.concat("\ngreet('John');");
-					const res = eval(stringResult);
-					assert.equal(res, "Hello, John", "Lambda expression evaluated correctly");
-				} catch (e) {
-					assert.fail("Failed to analyze lambda expression semantically");
-				}
+				testPrintOutput(
+					(message: any) => assert.equal(message, "Hello, John", "Expected different output"),
+					stringResult,
+				);
 			});
 
 			it("correctly identifies semantic data for a lambda with no parameters", async () => {
-				const code = `var greet: Func<str> = (): str -> "Hello, World!";`;
-				try {
-					const result = await compiler.compile(code, jsConfig);
+				const code = `var greet: Func<str> = (): str -> "Hello, World!"; print(greet());`;
+				const result = await compiler.compile(code, jsConfig);
+				const stringResult = result.write();
 
-					// Evaluate the compiled code
-					let stringResult = result.result!.map((x) => x.join("")).join("\n");
-					stringResult = stringResult.concat("\ngreet();");
-					const res = eval(stringResult);
-					assert.equal(res, "Hello, World!", "Lambda expression evaluated correctly");
-				} catch (e) {
-					assert.fail("Failed to analyze lambda expression semantically");
-				}
+				testPrintOutput(
+					(message: any) => assert.equal(message, "Hello, World!", "Expected different output"),
+					stringResult,
+				);
 			});
 		});
 

--- a/test/module/core/core-functionality.test.ts
+++ b/test/module/core/core-functionality.test.ts
@@ -658,7 +658,7 @@ describe("Core functionality", () => {
 
 		// Test for multiple conditional expressions
 		it("Multiple conditional expressions", async () => {
-			const fileContent = "const x: num = true ? 5 : false ? 10 : 15;";
+			const fileContent = "const x: num = true ? 5: false ? 10: 15;";
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
@@ -1416,50 +1416,58 @@ describe("Core functionality", () => {
 	});
 
 	describe("Lambdas", () => {
-		describe("js", () => {
-			it("parses simple lambda expression without syntax errors", async () => {
-				const code = `var add: Func<num, num, num> = (x: num, y: num): num -> x + y; print(add(1, 2));`;
-				const result = await compiler.compile(code, jsConfig);
-				const stringResult = result.write();
+		it("parses simple lambda expression without syntax errors", async () => {
+			const code = `var add: Func<num, num, num> = (x: num, y: num): num -> x + y; print(add(1, 2));`;
+			const result = await compiler.compile(code, jsConfig);
 
-				testPrintOutput((message: any) => assert.equal(message, "3", "Expected different output"), stringResult);
-			});
+			assert.isDefined(result.programCtx);
+			assert.deepEqual(result.programCtx?.errors, [], "Expected no compilation errors");
+			const stringResult = result.write();
 
-			it("correctly identifies semantic data for a lambda with compound statement", async () => {
-				const code = `var greet: Func<str, str> = (name: str): str -> { return "Hello, " + name; }; print(greet('John'));`;
-				const result = await compiler.compile(code, jsConfig);
-				const stringResult = result.write();
-
-				testPrintOutput(
-					(message: any) => assert.equal(message, "Hello, John", "Expected different output"),
-					stringResult,
-				);
-			});
-
-			it("correctly identifies semantic data for a lambda with single statement", async () => {
-				const code = `var greet: Func<str, str> = (name: str): str -> "Hello, " + name; print(greet('John'));`;
-				const result = await compiler.compile(code, jsConfig);
-				const stringResult = result.write();
-
-				testPrintOutput(
-					(message: any) => assert.equal(message, "Hello, John", "Expected different output"),
-					stringResult,
-				);
-			});
-
-			it("correctly identifies semantic data for a lambda with no parameters", async () => {
-				const code = `var greet: Func<str> = (): str -> "Hello, World!"; print(greet());`;
-				const result = await compiler.compile(code, jsConfig);
-				const stringResult = result.write();
-
-				testPrintOutput(
-					(message: any) => assert.equal(message, "Hello, World!", "Expected different output"),
-					stringResult,
-				);
-			});
+			testPrintOutput((message: any) => assert.equal(message, "3", "Expected different output"), stringResult);
 		});
 
-		describe("ts", () => {});
+		it("correctly identifies semantic data for a lambda with compound statement", async () => {
+			const code = `var greet: Func<str, str> = (name: str): str -> { return "Hello, " + name; }; print(greet('John'));`;
+			const result = await compiler.compile(code, jsConfig);
+
+			assert.isDefined(result.programCtx);
+			assert.deepEqual(result.programCtx?.errors, [], "Expected no compilation errors");
+			const stringResult = result.write();
+
+			testPrintOutput(
+				(message: any) => assert.equal(message, "Hello, John", "Expected different output"),
+				stringResult,
+			);
+		});
+
+		it("correctly identifies semantic data for a lambda with single statement", async () => {
+			const code = `var greet: Func<str, str> = (name: str): str -> "Hello, " + name; print(greet('John'));`;
+			const result = await compiler.compile(code, jsConfig);
+
+			assert.isDefined(result.programCtx);
+			assert.deepEqual(result.programCtx?.errors, [], "Expected no compilation errors");
+			const stringResult = result.write();
+
+			testPrintOutput(
+				(message: any) => assert.equal(message, "Hello, John", "Expected different output"),
+				stringResult,
+			);
+		});
+
+		it("correctly identifies semantic data for a lambda with no parameters", async () => {
+			const code = `var greet: Func<str> = (): str -> "Hello, World!"; print(greet());`;
+			const result = await compiler.compile(code, jsConfig);
+
+			assert.isDefined(result.programCtx);
+			assert.deepEqual(result.programCtx?.errors, [], "Expected no compilation errors");
+			const stringResult = result.write();
+
+			testPrintOutput(
+				(message: any) => assert.equal(message, "Hello, World!", "Expected different output"),
+				stringResult,
+			);
+		});
 	});
 
 	describe("Functions", () => {
@@ -1529,6 +1537,66 @@ describe("Core functionality", () => {
 		});
 	});
 
+	describe("Object literals", () => {
+		it("should be able to create an object literal", async () => {
+			const fileContent = "{ x: 1, y: '2' };";
+			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
+
+			assert.isDefined(instance.programCtx);
+			assert.equal(instance.programCtx!!.errors.length, 0, "Expected no compilation errors");
+			let written = instance.write();
+			assert.include(written, "{\n  x: 1,\n  y: '2',\n};", "Invalid TypeScript code (Expected different output)");
+		});
+
+		it("should create an object with different types of properties", async () => {
+			const fileContent = "{ numProp: 1, strProp: '2', boolProp: true };";
+			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
+
+			assert.isDefined(instance.programCtx);
+			assert.deepEqual(instance.programCtx?.errors, [], "Expected no compilation errors");
+			const written = instance.write();
+			assert.include(written, "{\n  numProp: 1,\n  strProp: '2',\n  boolProp: true,\n};", "Invalid TypeScript code (Expected different output)");
+		});
+
+		it("should create an object with nested objects", async () => {
+			const fileContent = "{ outerProp: { innerProp: 1 } };";
+			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
+
+			assert.isDefined(instance.programCtx);
+			assert.deepEqual(instance.programCtx?.errors, [], "Expected no compilation errors");
+			const written = instance.write();
+			assert.include(written, "{\n  outerProp: {\n  innerProp: 1,\n},\n};", "Invalid TypeScript code (Expected different output)");
+		});
+
+		it("should create an object with array properties", async () => {
+			const fileContent = "{ arrProp: [1, 2, 3] };";
+			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
+
+			assert.isDefined(instance.programCtx);
+			assert.deepEqual(instance.programCtx?.errors, [], "Expected no compilation errors");
+			const written = instance.write();
+			assert.include(
+				written,
+				"{\n  arrProp: __kipper.assignTypeMeta([1, 2, 3],",
+				"Invalid TypeScript code (Expected different output)",
+			);
+		});
+
+		it("should create an object with method properties", async () => {
+			const fileContent = "{ methodProp: (): num -> 1 };";
+			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
+
+			assert.isDefined(instance.programCtx);
+			assert.deepEqual(instance.programCtx?.errors, [], "Expected no compilation errors");
+			const written = instance.write();
+			assert.include(
+				written,
+				"{\n  methodProp: __kipper.assignTypeMeta((): number => 1,",
+				"Invalid TypeScript code (Expected different output)",
+			);
+		});
+	});
+
 	describe("Interfaces", async () => {
 		it("Can initialize empty interface", async () => {
 			const fileContent = "interface Test { }";
@@ -1540,7 +1608,27 @@ describe("Core functionality", () => {
 			assert.include(written, "interface Test {\n}", "Invalid TypeScript code (Expected different output)");
 		});
 
-		/* TODO Implement runtime code generation for functions in interfaces (Fabos task I guess)
+		it("should be able to to create object with interface blueprint", async () => {
+			const fileContent = `interface Test {a: str;}; var x: Test = {a: "3"}; print(x.a);`;
+			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
+
+			assert.isDefined(instance.programCtx);
+			assert.equal(instance.programCtx!!.errors.length, 0, "Expected no compilation errors");
+			let written = instance.write();
+			assert.include(
+				written,
+				`interface Test {\n` +
+				`  a: string;\n` +
+				`}\n` +
+				`const __intf_Test = new __kipper.Type("Test", [new __kipper.Property("a", __kipper.builtIn.str),], [])\n` +
+				"let x: Test = {\n" +
+				'  a: "3",\n' +
+				"};\n" +
+				"__kipper.print(x.a);",
+				"Invalid TypeScript code (Expected different output)",
+			);
+		});
+
 		it("can initialize interface with members", async () => {
 			const fileContent = "interface Test {\n x: num;\n y: str;\n greet(name: str): str;}";
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
@@ -1550,13 +1638,13 @@ describe("Core functionality", () => {
 			let written = instance.write();
 			assert.include(
 				written,
-				"interface Test {\n x: number;\n y: string;\n greet(name: string): string;\n}",
+				"interface Test {\n  x: number;\n  y: string;\n  greet(name: string): string;\n}",
 				"Invalid TypeScript code (Expected different output)",
 			);
 		});
 
 		it("should can initialize with mixed members", async () => {
-			const fileContent = "interface Test {\n x: num;\n isTrue(f: bool): str;\n y: str;\n greet(name: str) : str;}";
+			const fileContent = "interface Test {\n x: num;\n isTrue(f: bool): str;\n y: str;\n greet(name: str): str;}";
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
@@ -1564,22 +1652,10 @@ describe("Core functionality", () => {
 			let written = instance.write();
 			assert.include(
 				written,
-				"interface Test {\n x: number;\n isTrue(f: boolean): string;\n y: string;\n greet(name: string): string;\n}",
+				"interface Test {\n  x: number;\n  isTrue(f: boolean): string;\n  y: string;\n  greet(name: string):" +
+				" string;\n}",
 				"Invalid TypeScript code (Expected different output)",
 			);
-		});
-		*/
-	});
-
-	describe("Object literals", () => {
-		it("should be able to create an Object literal", async () => {
-			const fileContent = "{ x: 1, y: '2' };";
-			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
-
-			assert.isDefined(instance.programCtx);
-			assert.equal(instance.programCtx!!.errors.length, 0, "Expected no compilation errors");
-			let written = instance.write();
-			assert.include(written, "{\n  x: 1,\n  y: '2',\n};", "Invalid TypeScript code (Expected different output)");
 		});
 	});
 
@@ -1631,29 +1707,8 @@ describe("Core functionality", () => {
 			);
 		});
 
-		it("should be able to to create object with interface blueprint", async () => {
-			const fileContent = `interface Test {a: str;}; var x : Test = {a: "3"}; print(x.a);`;
-			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
-
-			assert.isDefined(instance.programCtx);
-			assert.equal(instance.programCtx!!.errors.length, 0, "Expected no compilation errors");
-			let written = instance.write();
-			assert.include(
-				written,
-				`interface Test {\n` +
-					`  a: string;\n` +
-					`}\n` +
-					`const __intf_Test = new __kipper.Type("Test", [new __kipper.Property("a", __kipper.builtIn.str),], [])\n` +
-					"let x: Test = {\n" +
-					'  a: "3",\n' +
-					"};\n" +
-					"__kipper.print(x.a);",
-				"Invalid TypeScript code (Expected different output)",
-			);
-		});
-
-		it("it should be able to instantiate a class with new", async () => {
-			const fileContent = `class Test {a: str; constructor (b: str) {a = b;}}; var x : Test = new Test("3"); print(x.a);`;
+		it("should be able to instantiate a class with new", async () => {
+			const fileContent = `class Test {a: str; constructor (b: str) {this.a = b;}}; var x: Test = new Test("3"); print(x.a);`;
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
@@ -1665,7 +1720,7 @@ describe("Core functionality", () => {
 					"  a: string;\n" +
 					"  constructor(b: string)\n" +
 					"  {\n" +
-					"    a = b;\n" +
+					"    this.a = b;\n" +
 					"  }\n" +
 					"}\n" +
 					'let x: Test = new Test("3");\n' +
@@ -1674,8 +1729,8 @@ describe("Core functionality", () => {
 			);
 		});
 
-		it("it should be able to instantiate a class with new and two properties", async () => {
-			const fileContent = `class Test {x: str; y: num; constructor (a: str, b: num) {x = a; y = b;}}; var x : Test = new Test("hello", 42); print(x.x);`;
+		it("should be able to instantiate a class with new and two properties", async () => {
+			const fileContent = `class Test {x: str; y: num; constructor (a: str, b: num) {this.x = a; this.y = b;}}; var x: Test = new Test("hello", 42); print(x.x);`;
 			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
 
 			assert.isDefined(instance.programCtx);
@@ -1688,14 +1743,43 @@ describe("Core functionality", () => {
 					"  y: number;\n" +
 					"  constructor(a: string, b: number)\n" +
 					"  {\n" +
-					"    x = a;\n" +
-					"    y = b;\n" +
+					"    this.x = a;\n" +
+					"    this.y = b;\n" +
 					"  }\n" +
 					"}\n" +
 					'let x: Test = new Test("hello", 42);\n' +
 					"__kipper.print(x.x);",
 				"Invalid TypeScript code (Expected different output)",
 			);
+		});
+
+		it("should be able to access 'this' inside a class method", async () => {
+			const fileContent = `class Test {x: str; constructor (a: str) {this.x = a;} greet(): void {print(this.x);}}; var x: Test = new Test("hello"); x.greet();`;
+			const instance: KipperCompileResult = await compiler.compile(fileContent, { target: defaultTarget });
+
+			assert.isDefined(instance.programCtx);
+			assert.equal(instance.programCtx!!.errors.length, 0, "Expected no compilation errors");
+			let written = instance.write();
+			assert.include(
+				written,
+				"class Test {\n" +
+					"  x: string;\n" +
+					"  greet(): void\n" +
+					"  {\n" +
+					"    __kipper.print(this.x);\n" +
+					"  }\n" +
+					"  constructor(a: string)\n" +
+					"  {\n" +
+					"    this.x = a;\n" +
+					"  }\n" +
+					"}\n" +
+					'let x: Test = new Test("hello");\n' +
+					"x.greet();",
+				"Invalid TypeScript code (Expected different output)",
+			);
+
+			const jsCode = ts.transpile(written);
+			testPrintOutput((message: any) => assert.equal(message, "hello", "Expected different output"), jsCode);
 		});
 	});
 });

--- a/test/module/core/core-functionality.test.ts
+++ b/test/module/core/core-functionality.test.ts
@@ -1555,7 +1555,11 @@ describe("Core functionality", () => {
 			assert.isDefined(instance.programCtx);
 			assert.deepEqual(instance.programCtx?.errors, [], "Expected no compilation errors");
 			const written = instance.write();
-			assert.include(written, "{\n  numProp: 1,\n  strProp: '2',\n  boolProp: true,\n};", "Invalid TypeScript code (Expected different output)");
+			assert.include(
+				written,
+				"{\n  numProp: 1,\n  strProp: '2',\n  boolProp: true,\n};",
+				"Invalid TypeScript code (Expected different output)",
+			);
 		});
 
 		it("should create an object with nested objects", async () => {
@@ -1565,7 +1569,11 @@ describe("Core functionality", () => {
 			assert.isDefined(instance.programCtx);
 			assert.deepEqual(instance.programCtx?.errors, [], "Expected no compilation errors");
 			const written = instance.write();
-			assert.include(written, "{\n  outerProp: {\n  innerProp: 1,\n},\n};", "Invalid TypeScript code (Expected different output)");
+			assert.include(
+				written,
+				"{\n  outerProp: {\n  innerProp: 1,\n},\n};",
+				"Invalid TypeScript code (Expected different output)",
+			);
 		});
 
 		it("should create an object with array properties", async () => {
@@ -1618,13 +1626,13 @@ describe("Core functionality", () => {
 			assert.include(
 				written,
 				`interface Test {\n` +
-				`  a: string;\n` +
-				`}\n` +
-				`const __intf_Test = new __kipper.Type("Test", [new __kipper.Property("a", __kipper.builtIn.str),], [])\n` +
-				"let x: Test = {\n" +
-				'  a: "3",\n' +
-				"};\n" +
-				"__kipper.print(x.a);",
+					`  a: string;\n` +
+					`}\n` +
+					`const __intf_Test = new __kipper.Type("Test", [new __kipper.Property("a", __kipper.builtIn.str),], [])\n` +
+					"let x: Test = {\n" +
+					'  a: "3",\n' +
+					"};\n" +
+					"__kipper.print(x.a);",
 				"Invalid TypeScript code (Expected different output)",
 			);
 		});
@@ -1653,7 +1661,7 @@ describe("Core functionality", () => {
 			assert.include(
 				written,
 				"interface Test {\n  x: number;\n  isTrue(f: boolean): string;\n  y: string;\n  greet(name: string):" +
-				" string;\n}",
+					" string;\n}",
 				"Invalid TypeScript code (Expected different output)",
 			);
 		});


### PR DESCRIPTION
<!--
Please read through the given types of changes and select the correct one using an 'x' instead of the ' ' (space) in the brackets.

Note: Comments are marked by arrows, like here. They will not be visible in the final pull request!
-->

## What type of change does this PR perform?

<!-- Please put an X in the box of the line that applies -->
<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

- [ ] Info or documentation change (Non-breaking change that updates repo info files (e.g. README.md, CONTRIBUTING.md, etc.) or online documentation)
- [ ] Website (Change that changes the design or functionality of the websites or docs)
- [ ] Development or internal changes (These changes do not add new features or fix bugs, but update the code in other ways)
- [x] Bug fix (Non-breaking change which fixes an issue)
- [x] New feature (Non-breaking change which adds functionality)
- [x] Breaking change (Major bug fix or feature that would cause existing functionality not to work as expected.)
- [x] Requires a documentation update, as it changes language or compiler behaviour

## Summary

<!-- Explain the reason for this pr, changes, and solution briefly. -->

New development release `0.12.0-alpha.4`, which implements the `this` keyword for accessing internal class members and "ahead of time" type evaluation for recursive types. 

## Detailed Changelog

_Not present for website/docs changes_

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added and remove any header with no item.). -->


### Added

- Implemented internal preliminary type checking and "ahead of time" type evaluation to allow for self-referential types and type checking of recursive types.
- Support for the `this` keyword inside a class method to access the current instance of the class. ([#697](https://github.com/Kipper-Lang/Kipper/issues/697))
- New classes:
  - `CustomType`, which is a class extending from `ProcessedType` and implementing the functionality for a custom type such as an interface or class.
  - `UserScope`, which represents a user scope i.e. any scope except the universe scope.
  - `ClassScopeThisDeclaration`, which represents the `this` declaration of a class.
- New errors:
  - `DuplicateUniverseKeyError`, which is thrown when a key is duplicated in the universe scope.
  - `IdentifierAlreadyUsedByMemberError`, which is thrown when an identifier is already used by another property.
- New interfaces and types:
  - `KipperCallable`, which is an alias for `FunctionDeclaration`, `LambdaPrimaryExpression` and `ClassMethodDeclaration`.
  - `TypeDeclarationPropertyTypeSemantics`, which represents the type semantics of a type declaration property.
- New functions:
  - `ClassDeclaration.getThis()`, which returns the `this` type of the class.
  - `ClassScope.getThis()`, which returns the `this` type of the class. This is a simple alias for the method in the `ClassDeclaration` class.
- New properties:
  - `CustomType.clsExtends`, which returns the class that the custom type extends. This is only applicable for classes.
  - `CustomType.clsImplements`, which returns the interfaces that the custom type implements. This is only applicable for classes.
  - `CustomType.intfExtends`, which returns the interfaces that the custom type extends. This is only applicable for interfaces.
  - `CustomType._clsStaticFields`, which returns the static fields of the custom type. This is only applicable for classes.
  - `ASTNode.preliminaryTypeSemantics`, which runs the preliminary type semantics of the node as well as the preliminary type semantics of all its children. This is a recursive function.
  - `ASTNode.primaryPreliminaryTypeSemantics`, which returns the primary preliminary type semantics of the node. May be undefined if there is no primary preliminary type semantics for the given node.

### Changed

- Renamed method `KipperProgramContext._initUniversalReferencables()` to `_initUniversalReferenceables()`.

### Fixed

- Previously invalid parent type checking and evaluation performed in `ReturnStatement`. This was now made absolute by the introduction of the preliminary type checking and "ahead of time" type evaluation, as that now allows for self-referential types and type checking of recursive types i.e. the return statement now knows the type of its function even though it is not yet fully processed.
- Duplicate universe entry registration in the `KipperProgramContext` for built-in types, functions and variables.

### Removed

- Function `KipperProgramContext.setUpBuiltInsInGlobalScope()`, which is no longer needed as the universe scope now handles all built-in types, functions and variables.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

None.

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [x] #697 
- [x] #698 
