### PR TITLE
v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,24 @@ To use development versions of Kipper download the
 
 </details>
 
+## [0.12.1] - 2025-02-17
+
+### Changed
+
+- Renamed:
+  - Error `MismatchingArgCountBetweenFuncTypesError` to `MismatchingArgCountBetweenFuncTypesTypeError`.
+  - Error `UnknownTypeError` to `UnknownTypeTypeError`.
+  - Error `PropertyNotFoundError` to `PropertyNotFoundTypeError`.
+
+### Fixed
+
+- `PropertyNotFoundTypeError` being thrown as a stand-alone error instead of being set as the cause for any parent
+  assignment operation failure.
+- `PropertyNotFoundTypeError` being checked for in the wrong direction i.e. that `otherT` had to have all the properties
+  of `thisT` instead of the other way around (which is the correct way).
+- Indexable checks for `str` and `Array<T>` being accidentally turned off by incorrect logic. This caused
+  `ValueTypeNotIndexableWithGivenAccessorTypeError` to be only thrown for objects and not for arrays and strings.
+
 ## [0.12.0] - 2024-09-25
 
 ### Added
@@ -1606,7 +1624,8 @@ To use development versions of Kipper download the
 
 - Updated file structure to separate `commands` (for `oclif`) and `compiler` (for the compiler source-code)
 
-[unreleased]: https://github.com/Kipper-Lang/Kipper/compare/v0.12.0...HEAD
+[unreleased]: https://github.com/Kipper-Lang/Kipper/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/Kipper-Lang/Kipper/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/Kipper-Lang/Kipper/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/Kipper-Lang/Kipper/compare/v0.10.4...v0.11.0
 [0.10.4]: https://github.com/Kipper-Lang/Kipper/compare/v0.10.3...v0.10.4

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,8 +21,8 @@ authors:
 identifiers:
   - type: url
     value: >-
-      https://github.com/Kipper-Lang/Kipper/releases/tag/v0.12.0
-    description: The GitHub release URL of tag 0.12.0
+      https://github.com/Kipper-Lang/Kipper/releases/tag/v0.12.1
+    description: The GitHub release URL of tag 0.12.1
 repository-code: 'https://github.com/Kipper-Lang/Kipper/'
 url: 'https://kipper-lang.org'
 abstract: >-
@@ -39,6 +39,6 @@ keywords:
   - oop-programming
   - type-safety
 license: GPL-3.0-or-later
-license-url: 'https://github.com/Kipper-Lang/Kipper/blob/v0.12.0/LICENSE'
-version: 0.12.0
-date-released: '2024-09-25'
+license-url: 'https://github.com/Kipper-Lang/Kipper/blob/v0.12.1/LICENSE'
+version: 0.12.1
+date-released: '2025-02-17'

--- a/kipper/cli/README.md
+++ b/kipper/cli/README.md
@@ -22,10 +22,9 @@ and the [Kipper website](https://kipper-lang.org)._
 [![DOI](https://zenodo.org/badge/411260595.svg)](https://zenodo.org/badge/latestdoi/411260595)
 
 <!-- toc -->
-
-- [Kipper CLI - `@kipper/cli` 🦊✨](#kipper-cli---kippercli-)
-- [Usage](#usage)
-- [Commands](#commands)
+* [Kipper CLI - `@kipper/cli` 🦊✨](#kipper-cli---kippercli-)
+* [Usage](#usage)
+* [Commands](#commands)
 <!-- tocstop -->
 
 ## General Information
@@ -40,30 +39,27 @@ and the [Kipper website](https://kipper-lang.org)._
 # Usage
 
 <!-- usage -->
-
 ```sh-session
 $ npm install -g @kipper/cli
 $ kipper COMMAND
 running command...
 $ kipper (--version)
-@kipper/cli/0.12.0 linux-x64 node-v20.15.0
+@kipper/cli/0.12.1 linux-x64 node-v23.4.0
 $ kipper --help [COMMAND]
 USAGE
   $ kipper COMMAND
 ...
 ```
-
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-
-- [`kipper compile [FILE]`](#kipper-compile-file)
-- [`kipper help [COMMAND]`](#kipper-help-command)
-- [`kipper new [LOCATION]`](#kipper-new-location)
-- [`kipper run [FILE]`](#kipper-run-file)
-- [`kipper version`](#kipper-version)
+* [`kipper compile [FILE]`](#kipper-compile-file)
+* [`kipper help [COMMAND]`](#kipper-help-command)
+* [`kipper new [LOCATION]`](#kipper-new-location)
+* [`kipper run [FILE]`](#kipper-run-file)
+* [`kipper version`](#kipper-version)
 
 ## `kipper compile [FILE]`
 
@@ -115,7 +111,7 @@ EXAMPLES
   kipper compile -t ts ./path/to/file.kip -o build/ -e utf16le --warnings --log-timestamp
 ```
 
-_See code: [src/commands/compile.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.0/kipper/cli/src/commands/compile.ts)_
+_See code: [src/commands/compile.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.1/kipper/cli/src/commands/compile.ts)_
 
 ## `kipper help [COMMAND]`
 
@@ -132,7 +128,7 @@ OPTIONS
   --all  see all commands in CLI
 ```
 
-_See code: [src/commands/help.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.0/kipper/cli/src/commands/help.ts)_
+_See code: [src/commands/help.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.1/kipper/cli/src/commands/help.ts)_
 
 ## `kipper new [LOCATION]`
 
@@ -149,7 +145,7 @@ OPTIONS
   -d, --default  Use the default settings for the new project. Skips the setup wizard.
 ```
 
-_See code: [src/commands/new.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.0/kipper/cli/src/commands/new.ts)_
+_See code: [src/commands/new.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.1/kipper/cli/src/commands/new.ts)_
 
 ## `kipper run [FILE]`
 
@@ -194,7 +190,7 @@ EXAMPLES
   kipper run -t ts -o build/ -e utf8 -s "print('Hello, World!');" --warnings --log-timestamp
 ```
 
-_See code: [src/commands/run.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.0/kipper/cli/src/commands/run.ts)_
+_See code: [src/commands/run.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.1/kipper/cli/src/commands/run.ts)_
 
 ## `kipper version`
 
@@ -205,8 +201,7 @@ USAGE
   $ kipper version
 ```
 
-_See code: [src/commands/version.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.0/kipper/cli/src/commands/version.ts)_
-
+_See code: [src/commands/version.ts](https://github.com/Kipper-Lang/Kipper/blob/v0.12.1/kipper/cli/src/commands/version.ts)_
 <!-- commandsstop -->
 
 ## Contributing to Kipper

--- a/kipper/cli/package.json
+++ b/kipper/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kipper/cli",
   "description": "The Kipper Command Line Interface (CLI).",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "author": "Luna-Klatzer @Luna-Klatzer",
   "bin": {
     "kipper": "./bin/run",

--- a/kipper/cli/src/index.ts
+++ b/kipper/cli/src/index.ts
@@ -13,7 +13,7 @@ export * from "./output/compile";
 // eslint-disable-next-line no-unused-vars
 export const name = "@kipper/cli";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.12.0";
+export const version = "0.12.1";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/config/package.json
+++ b/kipper/config/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kipper/config",
 	"description": "The config file support package adding support for kip-config.json/kipper-config.json 🦊",
-	"version": "0.12.0",
+	"version": "0.12.1",
 	"author": "Luna-Klatzer @Luna-Klatzer",
 	"dependencies": {
 		"is-plain-object": "5.0.0",

--- a/kipper/config/src/index.ts
+++ b/kipper/config/src/index.ts
@@ -12,7 +12,7 @@ export * from "./evaluated-kipper-config-file";
 // eslint-disable-next-line no-unused-vars
 export const name = "@kipper/config";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.12.0";
+export const version = "0.12.1";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/core/package.json
+++ b/kipper/core/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kipper/core",
 	"description": "The core implementation of the Kipper compiler 🦊",
-	"version": "0.12.0",
+	"version": "0.12.1",
 	"author": "Luna-Klatzer @Luna-Klatzer",
 	"dependencies": {
 		"antlr4ts": "^0.5.0-alpha.4",

--- a/kipper/core/src/compiler/semantics/analyser/type-checker.ts
+++ b/kipper/core/src/compiler/semantics/analyser/type-checker.ts
@@ -665,18 +665,12 @@ export class KipperTypeChecker extends KipperSemanticsAsserter {
 			return;
 		}
 
-		if (
-			!objType.isAssignableTo(BuiltInTypes.str) &&
-			!objType.isAssignableTo(BuiltInTypes.Array) &&
-			!objType.isAssignableTo(BuiltInTypes.obj)
-		) {
+		const isStrOrArr = objType.isAssignableTo(BuiltInTypes.str)
+			|| objType.isAssignableTo(BuiltInTypes.Array);
+		const isObj = objType.isAssignableTo(BuiltInTypes.obj);
+		if (!isStrOrArr && !isObj) {
 			throw this.assertError(new ValueNotIndexableTypeError(objType.toString()));
-		} else if (
-			(objType.isAssignableTo(BuiltInTypes.str) &&
-				objType.isAssignableTo(BuiltInTypes.Array) &&
-				accessType === "dot") ||
-			(objType.isAssignableTo(BuiltInTypes.obj) && accessType !== "dot")
-		) {
+		} else if (isStrOrArr && accessType === "dot" || isObj && accessType !== "dot") {
 			throw this.assertError(new ValueTypeNotIndexableWithGivenAccessor(objType.toString(), accessType));
 		}
 	}

--- a/kipper/core/src/compiler/semantics/analyser/type-checker.ts
+++ b/kipper/core/src/compiler/semantics/analyser/type-checker.ts
@@ -67,7 +67,7 @@ import {
 	PropertyDoesNotExistError,
 	ReadOnlyWriteTypeError,
 	ReferenceCanNotBeUsedAsTypeError,
-	UnknownTypeError,
+	UnknownTypeTypeError,
 	ValueNotIndexableTypeError,
 	ValueTypeNotIndexableWithGivenAccessor,
 } from "../../../errors";
@@ -93,7 +93,7 @@ export class KipperTypeChecker extends KipperSemanticsAsserter {
 	public getTypeFromIdentifier(type: string, scope: Scope): ScopeTypeDeclaration {
 		const scopeEntry = scope.getEntryRecursively(type);
 		if (scopeEntry === undefined) {
-			throw this.assertError(new UnknownTypeError(type));
+			throw this.assertError(new UnknownTypeTypeError(type));
 		} else if (!(scopeEntry instanceof ScopeTypeDeclaration)) {
 			throw this.assertError(new ReferenceCanNotBeUsedAsTypeError(type));
 		}
@@ -665,12 +665,11 @@ export class KipperTypeChecker extends KipperSemanticsAsserter {
 			return;
 		}
 
-		const isStrOrArr = objType.isAssignableTo(BuiltInTypes.str)
-			|| objType.isAssignableTo(BuiltInTypes.Array);
+		const isStrOrArr = objType.isAssignableTo(BuiltInTypes.str) || objType.isAssignableTo(BuiltInTypes.Array);
 		const isObj = objType.isAssignableTo(BuiltInTypes.obj);
 		if (!isStrOrArr && !isObj) {
 			throw this.assertError(new ValueNotIndexableTypeError(objType.toString()));
-		} else if (isStrOrArr && accessType === "dot" || isObj && accessType !== "dot") {
+		} else if ((isStrOrArr && accessType === "dot") || (isObj && accessType !== "dot")) {
 			throw this.assertError(new ValueTypeNotIndexableWithGivenAccessor(objType.toString(), accessType));
 		}
 	}

--- a/kipper/core/src/compiler/semantics/types/built-in/func.ts
+++ b/kipper/core/src/compiler/semantics/types/built-in/func.ts
@@ -5,7 +5,7 @@ import {
 	ArgumentAssignmentTypeError,
 	AssignmentTypeError,
 	GenericArgumentTypeError,
-	MismatchingArgCountBetweenFuncTypesError,
+	MismatchingArgCountBetweenFuncTypesTypeError,
 	PropertyAssignmentTypeError,
 	type TypeError,
 } from "../../../../errors";
@@ -86,7 +86,7 @@ export class BuiltInTypeFunc extends GenericBuiltInType<BuiltInTypeFuncGenericAr
 			const [otherParamTypes, otherReturnType] = (<typeof this>type).genericTypeArguments;
 
 			if (paramTypes.type.length !== otherParamTypes.type.length) {
-				throw new MismatchingArgCountBetweenFuncTypesError(otherParamTypes.type.length, paramTypes.type.length);
+				throw new MismatchingArgCountBetweenFuncTypesTypeError(otherParamTypes.type.length, paramTypes.type.length);
 			}
 
 			try {

--- a/kipper/core/src/compiler/semantics/types/custom-type.ts
+++ b/kipper/core/src/compiler/semantics/types/custom-type.ts
@@ -162,21 +162,21 @@ export class CustomType extends ProcessedType {
 	 * @throws AssignmentTypeError If the types are not assignable.
 	 * @throws PropertyAssignmentTypeError If a property is not assignable.
 	 * @throws ArgumentAssignmentTypeError If an argument is not assignable.
-	 * @throws PropertyNotFoundError If a property is not found.
+	 * @throws PropertyNotFoundError If a property is not found in this type.
 	 * @since 0.12.0
 	 */
 	assertAssignableTo(type: ProcessedType, propertyName?: string, argumentName?: string): void {
 		if (this === type || type === BuiltInTypes.any || type === BuiltInTypes.obj) {
 			return;
 		} else if (type instanceof CustomType && type.kind === "interface") {
-			for (const [fieldName, fieldType] of this.fields) {
-				const targetTypeField = type.fields.get(fieldName);
-				if (!targetTypeField) {
-					throw new PropertyNotFoundError(type.identifier, fieldName);
+			for (const [fieldName, otherFieldType] of type.fields) {
+				const thisFieldType = this.fields.get(fieldName);
+				if (!thisFieldType) {
+					throw new PropertyNotFoundError(this.identifier, type.identifier, fieldName);
 				}
 
 				try {
-					fieldType.assertAssignableTo(targetTypeField, fieldName);
+					thisFieldType.assertAssignableTo(otherFieldType, fieldName);
 				} catch (error) {
 					if (propertyName) {
 						throw new PropertyAssignmentTypeError(propertyName, type.identifier, this.identifier, <TypeError>error);

--- a/kipper/core/src/compiler/semantics/types/custom-type.ts
+++ b/kipper/core/src/compiler/semantics/types/custom-type.ts
@@ -185,9 +185,19 @@ export class CustomType extends ProcessedType {
 
 				if (caughtError) {
 					if (propertyName) {
-						throw new PropertyAssignmentTypeError(propertyName, type.identifier, this.identifier, <TypeError>caughtError);
+						throw new PropertyAssignmentTypeError(
+							propertyName,
+							type.identifier,
+							this.identifier,
+							<TypeError>caughtError,
+						);
 					} else if (argumentName) {
-						throw new ArgumentAssignmentTypeError(argumentName, type.identifier, this.identifier, <TypeError>caughtError);
+						throw new ArgumentAssignmentTypeError(
+							argumentName,
+							type.identifier,
+							this.identifier,
+							<TypeError>caughtError,
+						);
 					} else {
 						throw new AssignmentTypeError(type.identifier, this.identifier, <TypeError>caughtError);
 					}

--- a/kipper/core/src/compiler/semantics/types/custom-type.ts
+++ b/kipper/core/src/compiler/semantics/types/custom-type.ts
@@ -4,7 +4,7 @@ import {
 	ArgumentAssignmentTypeError,
 	AssignmentTypeError,
 	PropertyAssignmentTypeError,
-	PropertyNotFoundError,
+	PropertyNotFoundTypeError,
 } from "../../../errors";
 import type { ClassDeclaration, InterfaceDeclaration, ObjectPrimaryExpression } from "../../ast";
 import { BuiltInTypes } from "../symbol-table";
@@ -162,7 +162,7 @@ export class CustomType extends ProcessedType {
 	 * @throws AssignmentTypeError If the types are not assignable.
 	 * @throws PropertyAssignmentTypeError If a property is not assignable.
 	 * @throws ArgumentAssignmentTypeError If an argument is not assignable.
-	 * @throws PropertyNotFoundError If a property is not found in this type.
+	 * @throws PropertyNotFoundTypeError If a property is not found in this type.
 	 * @since 0.12.0
 	 */
 	assertAssignableTo(type: ProcessedType, propertyName?: string, argumentName?: string): void {
@@ -170,20 +170,26 @@ export class CustomType extends ProcessedType {
 			return;
 		} else if (type instanceof CustomType && type.kind === "interface") {
 			for (const [fieldName, otherFieldType] of type.fields) {
+				let caughtError: TypeError | undefined;
+
 				const thisFieldType = this.fields.get(fieldName);
 				if (!thisFieldType) {
-					throw new PropertyNotFoundError(this.identifier, type.identifier, fieldName);
+					caughtError = new PropertyNotFoundTypeError(this.identifier, type.identifier, fieldName);
+				} else {
+					try {
+						thisFieldType.assertAssignableTo(otherFieldType, fieldName);
+					} catch (error) {
+						caughtError = <TypeError>error;
+					}
 				}
 
-				try {
-					thisFieldType.assertAssignableTo(otherFieldType, fieldName);
-				} catch (error) {
+				if (caughtError) {
 					if (propertyName) {
-						throw new PropertyAssignmentTypeError(propertyName, type.identifier, this.identifier, <TypeError>error);
+						throw new PropertyAssignmentTypeError(propertyName, type.identifier, this.identifier, <TypeError>caughtError);
 					} else if (argumentName) {
-						throw new ArgumentAssignmentTypeError(argumentName, type.identifier, this.identifier, <TypeError>error);
+						throw new ArgumentAssignmentTypeError(argumentName, type.identifier, this.identifier, <TypeError>caughtError);
 					} else {
-						throw new AssignmentTypeError(type.identifier, this.identifier, <TypeError>error);
+						throw new AssignmentTypeError(type.identifier, this.identifier, <TypeError>caughtError);
 					}
 				}
 			}

--- a/kipper/core/src/errors.ts
+++ b/kipper/core/src/errors.ts
@@ -673,7 +673,7 @@ export class PropertyAssignmentTypeError extends TypeError {
  * Error that is thrown whenever a property is missing in this type but is required in another type.
  * @since 0.11.0
  */
-export class PropertyNotFoundError extends TypeError {
+export class PropertyNotFoundTypeError extends TypeError {
 	constructor(thisType: string, objType: string, identifier: string) {
 		super(`Property '${identifier}' not found in '${thisType}' but required in object of type '${objType}'.`);
 	}
@@ -693,7 +693,7 @@ export class GenericArgumentTypeError extends TypeError {
  * Error that is thrown whenever a function type is casted to a function with a different amount of arguments.
  * @since 0.12.0
  */
-export class MismatchingArgCountBetweenFuncTypesError extends TypeError {
+export class MismatchingArgCountBetweenFuncTypesTypeError extends TypeError {
 	constructor(expected: number, received: number) {
 		super(`Function type expects ${expected} arguments, received ${received}.`);
 	}
@@ -755,7 +755,7 @@ export class InvalidConversionTypeError extends TypeError {
 /**
  * Error that is thrown whenever a declaration type is used that is unknown to the program.
  */
-export class UnknownTypeError extends TypeError {
+export class UnknownTypeTypeError extends TypeError {
 	constructor(type: string) {
 		super(`Unknown type '${type}'.`);
 	}

--- a/kipper/core/src/errors.ts
+++ b/kipper/core/src/errors.ts
@@ -670,12 +670,12 @@ export class PropertyAssignmentTypeError extends TypeError {
 }
 
 /**
- * Error that is thrown whenever a property can not be found in the object.
+ * Error that is thrown whenever a property is missing in this type but is required in another type.
  * @since 0.11.0
  */
 export class PropertyNotFoundError extends TypeError {
-	constructor(objType: string, identifier: string) {
-		super(`Property '${identifier}' not found in object of type '${objType}'.`);
+	constructor(thisType: string, objType: string, identifier: string) {
+		super(`Property '${identifier}' not found in '${thisType}' but required in object of type '${objType}'.`);
 	}
 }
 

--- a/kipper/core/src/index.ts
+++ b/kipper/core/src/index.ts
@@ -17,7 +17,7 @@ export * as utils from "./tools";
 // eslint-disable-next-line no-unused-vars
 export const name = "@kipper/core";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.12.0";
+export const version = "0.12.1";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/index.ts
+++ b/kipper/index.ts
@@ -13,7 +13,7 @@ export * from "@kipper/target-ts";
 // eslint-disable-next-line no-unused-vars
 export const name = "kipper";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.12.0";
+export const version = "0.12.1";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/target-js/package.json
+++ b/kipper/target-js/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kipper/target-js",
 	"description": "The JavaScript target for the Kipper compiler 🦊",
-	"version": "0.12.0",
+	"version": "0.12.1",
 	"author": "Luna-Klatzer @Luna-Klatzer",
 	"dependencies": {
 		"@kipper/core": "workspace:~",

--- a/kipper/target-js/src/index.ts
+++ b/kipper/target-js/src/index.ts
@@ -14,7 +14,7 @@ export * from "./tools";
 // eslint-disable-next-line no-unused-vars
 export const name = "@kipper/target-js";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.12.0";
+export const version = "0.12.1";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/target-ts/package.json
+++ b/kipper/target-ts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kipper/target-ts",
 	"description": "The TypeScript target for the Kipper compiler 🦊",
-	"version": "0.12.0",
+	"version": "0.12.1",
 	"author": "Luna-Klatzer @Luna-Klatzer",
 	"dependencies": {
 		"@kipper/target-js": "workspace:~",

--- a/kipper/target-ts/src/index.ts
+++ b/kipper/target-ts/src/index.ts
@@ -13,7 +13,7 @@ export * from "./tools";
 // eslint-disable-next-line no-unused-vars
 export const name = "@kipper/target-ts";
 // eslint-disable-next-line no-unused-vars
-export const version = "0.12.0";
+export const version = "0.12.1";
 // eslint-disable-next-line no-unused-vars
 export const author = "Luna Klatzer";
 // eslint-disable-next-line no-unused-vars

--- a/kipper/web/package.json
+++ b/kipper/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kipper/web",
   "description": "The standalone web-module for the Kipper compiler 🦊",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "author": "Luna-Klatzer @Luna-Klatzer",
   "devDependencies": {
     "@kipper/target-js": "workspace:~",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kipper",
   "description": "The Kipper programming language and compiler 🦊",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "author": "Luna-Klatzer @Luna-Klatzer",
   "dependencies": {
     "@kipper/cli": "workspace:~",

--- a/test/module/core/errors/type-errors/mismatching-arg-count-between-func-types.ts
+++ b/test/module/core/errors/type-errors/mismatching-arg-count-between-func-types.ts
@@ -2,30 +2,30 @@ import { KipperCompiler, type KipperCompileResult, type KipperError } from "@kip
 import { defaultConfig, ensureTracebackDataExists } from "../index";
 import { assert } from "chai";
 
-describe("MismatchingArgCountBetweenFuncTypesError", () => {
+describe("MismatchingArgCountBetweenFuncTypesTypeError", () => {
 	describe("Error", () => {
 		it("Too many", async () => {
 			try {
 				await new KipperCompiler().compile("var x: Func<str> = (x: num): str -> '';", defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "MismatchingArgCountBetweenFuncTypesError");
+				assert.equal((<KipperError>e).constructor.name, "MismatchingArgCountBetweenFuncTypesTypeError");
 				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureTracebackDataExists(<KipperError>e);
 				return;
 			}
-			assert.fail("Expected 'MismatchingArgCountBetweenFuncTypesError'");
+			assert.fail("Expected 'MismatchingArgCountBetweenFuncTypesTypeError'");
 		});
 
 		it("Too few", async () => {
 			try {
 				await new KipperCompiler().compile("var x: Func<num, str> = (): str -> '';", defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "MismatchingArgCountBetweenFuncTypesError");
+				assert.equal((<KipperError>e).constructor.name, "MismatchingArgCountBetweenFuncTypesTypeError");
 				assert((<KipperError>e).name === "TypeError", "Expected different error");
 				ensureTracebackDataExists(<KipperError>e);
 				return;
 			}
-			assert.fail("Expected 'MismatchingArgCountBetweenFuncTypesError'");
+			assert.fail("Expected 'MismatchingArgCountBetweenFuncTypesTypeError'");
 		});
 	});
 

--- a/test/module/core/errors/type-errors/unknown-type.ts
+++ b/test/module/core/errors/type-errors/unknown-type.ts
@@ -3,17 +3,17 @@ import { KipperCompiler } from "@kipper/core";
 import { defaultConfig, ensureTracebackDataExists } from "../index";
 import { assert } from "chai";
 
-describe("UnknownTypeError", () => {
+describe("UnknownTypeTypeError", () => {
 	["x", "number", "UNKNOWN"].forEach((typeName) => {
 		it(typeName, async () => {
 			try {
 				await new KipperCompiler().compile(`var invalid: ${typeName} = 4;`, defaultConfig);
 			} catch (e) {
-				assert.equal((<KipperError>e).constructor.name, "UnknownTypeError", "Expected different error");
+				assert.equal((<KipperError>e).constructor.name, "UnknownTypeTypeError", "Expected different error");
 				ensureTracebackDataExists(<KipperError>e);
 				return;
 			}
-			assert.fail("Expected 'UnknownTypeError'");
+			assert.fail("Expected 'UnknownTypeTypeError'");
 		});
 	});
 });


### PR DESCRIPTION
<!--
Please read through the given types of changes and select the correct one using an 'x' instead of the ' ' (space) in the brackets.

Note: Comments are marked by arrows, like here. They will not be visible in the final pull request!
-->

## What type of change does this PR perform?

<!-- Please put an X in the box of the line that applies -->
<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

- [ ] Info or documentation change (Non-breaking change that updates repo info files (e.g. README.md, CONTRIBUTING.md, etc.) or online documentation)
- [ ] Website (Change that changes the design or functionality of the websites or docs)
- [ ] Development or internal changes (These changes do not add new features or fix bugs, but update the code in other ways)
- [x] Bug fix (Non-breaking change which fixes an issue)
- [ ] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Major bug fix or feature that would cause existing functionality not to work as expected.)
- [ ] Requires a documentation update, as it changes language or compiler behaviour

## Summary

<!-- Explain the reason for this pr, changes, and solution briefly. -->

New bug fix release `0.12.1`, which fixes a bug in the duck-typing type check logic and a bug causing the `PropertyNotFoundTypeError` error to be thrown as a stand-alone error although it is an error indicating the failure of a parent type check operation.

## Detailed Changelog

_Not present for website/docs changes_

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added and remove any header with no item.). -->

### Changed

- Renamed:
  - Error `MismatchingArgCountBetweenFuncTypesError` to `MismatchingArgCountBetweenFuncTypesTypeError`.
  - Error `UnknownTypeError` to `UnknownTypeTypeError`.
  - Error `PropertyNotFoundError` to `PropertyNotFoundTypeError`.

### Fixed

- `PropertyNotFoundTypeError` being thrown as a stand-alone error instead of being set as the cause for any parent
  assignment operation failure.
- `PropertyNotFoundTypeError` being checked for in the wrong direction i.e. that `otherT` had to have all the properties
  of `thisT` instead of the other way around (which is the correct way).
- Indexable checks for `str` and `Array<T>` being accidentally turned off by incorrect logic. This caused
  `ValueTypeNotIndexableWithGivenAccessorTypeError` to be only thrown for objects and not for arrays and strings.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

None.

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

No linked issues.
