### PR TITLE
Fixed internal references to class properties without `this` being allowed and throwing runtime errors

### DIFF
--- a/.github/workflows/cov-badge.yml
+++ b/.github/workflows/cov-badge.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [22.19.x]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/nodejs-cli-run.yml
+++ b/.github/workflows/nodejs-cli-run.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [16.x, 18.x, 20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [16.x, 18.x, 20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [16.x, 18.x, 20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nodejs-test.yml
+++ b/.github/workflows/nodejs-test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [16.x, 18.x, 20.x, 22.19.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -22,6 +22,11 @@ jobs:
           version: 8.x.x
           run_install: false
       - run: pnpm install --frozen-lockfile
+      # Restore old config for Node 16, 18 & 20
+      - run: |
+          if [[ $(node -v | grep -E '^v(16|18|20)\.') ]]; then
+            cp .mocharc.old.json .mocharc.json
+          fi
       - run: pnpm test
 
   # Run tests with 'pnpm i' dependencies
@@ -30,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [16.x, 18.x, 20.x, 22.19.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -43,4 +48,9 @@ jobs:
           version: 8.x.x
           run_install: false
       - run: pnpm i
+      # Restore old config for Node 16, 18 & 20
+      - run: |
+          if [[ $(node -v | grep -E '^v(16|18|20)\.') ]]; then
+            cp .mocharc.old.json .mocharc.json
+          fi
       - run: pnpm test

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -15,5 +15,8 @@
 	],
 	"spec": [
 		"**/*.test.ts"
+	],
+	"node-option": [
+		"no-experimental-strip-types"
 	]
 }

--- a/.mocharc.old.json
+++ b/.mocharc.old.json
@@ -1,0 +1,19 @@
+{
+  "extension": ["ts"],
+  "timeout": 15000,
+  "exit": true,
+  "recursive": true,
+	"watch": false,
+	"watch-files": [
+		"./kipper/core/src/",
+		"./kipper/cli/src/",
+		"./node_modules/@kipper/"
+	],
+  "reporter": "spec",
+  "require": [
+		"ts-node/register"
+	],
+	"spec": [
+		"**/*.test.ts"
+	]
+}

--- a/.run/kipper compile (DEBUG).run.xml
+++ b/.run/kipper compile (DEBUG).run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="kipper compile (DEBUG)" type="NodeJSConfigurationType" application-parameters="compile -s &quot;&quot;" path-to-js-file="./kipper/cli/bin/run" working-dir="$PROJECT_DIR$/">
+  <configuration default="false" name="kipper compile (DEBUG)" type="NodeJSConfigurationType" application-parameters="compile -s &quot;&quot;" node-parameters="--no-experimental-strip-types" path-to-js-file="./kipper/cli/bin/run" working-dir="$PROJECT_DIR$/">
     <envs>
       <env name="DEBUG" value="*" />
     </envs>

--- a/.run/kipper compile (js).run.xml
+++ b/.run/kipper compile (js).run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="kipper compile (js)" type="NodeJSConfigurationType" application-parameters="compile -s &quot;&quot; -t js" path-to-js-file="./kipper/cli/bin/run" working-dir="$PROJECT_DIR$/">
+  <configuration default="false" name="kipper compile (js)" type="NodeJSConfigurationType" application-parameters="compile -s &quot;&quot; -t js" node-parameters="--no-experimental-strip-types" path-to-js-file="./kipper/cli/bin/run" working-dir="$PROJECT_DIR$/">
     <method v="2" />
   </configuration>
 </component>

--- a/.run/kipper compile (ts).run.xml
+++ b/.run/kipper compile (ts).run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="kipper compile (ts)" type="NodeJSConfigurationType" application-parameters="compile -s &quot;&quot; -t ts" path-to-js-file="./kipper/cli/bin/run" working-dir="$PROJECT_DIR$/">
+  <configuration default="false" name="kipper compile (ts)" type="NodeJSConfigurationType" application-parameters="compile -s &quot;&quot; -t ts" node-parameters="--no-experimental-strip-types" path-to-js-file="./kipper/cli/bin/run" working-dir="$PROJECT_DIR$/">
     <method v="2" />
   </configuration>
 </component>

--- a/.run/kipper help (DEBUG).run.xml
+++ b/.run/kipper help (DEBUG).run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="kipper help (DEBUG)" type="NodeJSConfigurationType" application-parameters="help" path-to-js-file="./kipper/cli/bin/run" working-dir="$PROJECT_DIR$/">
+  <configuration default="false" name="kipper help (DEBUG)" type="NodeJSConfigurationType" application-parameters="help" node-parameters="--no-experimental-strip-types" path-to-js-file="./kipper/cli/bin/run" working-dir="$PROJECT_DIR$/">
     <envs>
       <env name="DEBUG" value="*" />
     </envs>

--- a/.run/kipper help.run.xml
+++ b/.run/kipper help.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="kipper help" type="NodeJSConfigurationType" application-parameters="help" path-to-js-file="./kipper/cli/bin/run" working-dir="$PROJECT_DIR$/">
+  <configuration default="false" name="kipper help" type="NodeJSConfigurationType" application-parameters="help" node-parameters="--no-experimental-strip-types" path-to-js-file="./kipper/cli/bin/run" working-dir="$PROJECT_DIR$/">
     <method v="2" />
   </configuration>
 </component>

--- a/.run/kipper run (DEBUG).run.xml
+++ b/.run/kipper run (DEBUG).run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="kipper run (DEBUG)" type="NodeJSConfigurationType" application-parameters="run -s &quot;&quot;" path-to-js-file="./kipper/cli/bin/run" working-dir="$PROJECT_DIR$/">
+  <configuration default="false" name="kipper run (DEBUG)" type="NodeJSConfigurationType" application-parameters="run -s &quot;&quot;" node-parameters="--no-experimental-strip-types" path-to-js-file="./kipper/cli/bin/run" working-dir="$PROJECT_DIR$/">
     <envs>
       <env name="DEBUG" value="*" />
     </envs>

--- a/.run/kipper run (js).run.xml
+++ b/.run/kipper run (js).run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="kipper run (js)" type="NodeJSConfigurationType" application-parameters="run -s &quot;&quot; -t js" path-to-js-file="./kipper/cli/bin/run" working-dir="$PROJECT_DIR$/">
+  <configuration default="false" name="kipper run (js)" type="NodeJSConfigurationType" application-parameters="run -s &quot;&quot; -t js" node-parameters="--no-experimental-strip-types" path-to-js-file="./kipper/cli/bin/run" working-dir="$PROJECT_DIR$/">
     <method v="2" />
   </configuration>
 </component>

--- a/.run/kipper run (ts).run.xml
+++ b/.run/kipper run (ts).run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="kipper run (ts)" type="NodeJSConfigurationType" application-parameters="run -s &quot;&quot; -t ts" path-to-js-file="./kipper/cli/bin/run" working-dir="$PROJECT_DIR$/">
+  <configuration default="false" name="kipper run (ts)" type="NodeJSConfigurationType" application-parameters="run -s &quot;&quot; -t ts" node-parameters="--no-experimental-strip-types" path-to-js-file="./kipper/cli/bin/run" working-dir="$PROJECT_DIR$/">
     <method v="2" />
   </configuration>
 </component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ To use development versions of Kipper download the
 - Empty arrays not being assignable to `Array<T>` types, due to a strict type checking error. This was fixed by adding
   a special case for empty arrays in the type checking logic and code generation to ensure the type of the empty array
   matches the required type set by the declaration or parameter. ([#696](https://github.com/Kipper-Lang/Kipper/issues/696))
+- Fixed class members being accessible without the use of 'this' causing a runtime error. ([#721](https://github.com/Kipper-Lang/Kipper/issues/721))
+- Fixed class members not being allowed to use names already used in a parent scope.
 
 ### Deprecated
 

--- a/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/class-declaration/class-member-declaration/class-property-declaration/class-property-declaration.ts
+++ b/kipper/core/src/compiler/ast/nodes/declarations/type-declaration/class-declaration/class-member-declaration/class-property-declaration/class-property-declaration.ts
@@ -124,7 +124,7 @@ export class ClassPropertyDeclaration extends ClassMemberDeclaration<
 			typeSpecifier: typeSpecifier,
 			valueType: typeSpecifier.getSemanticData().rawType,
 		};
-		this.scopeDeclaration = this.scope.addVariable(this);
+		this.scopeDeclaration = this.scope.addProperty(this);
 	}
 
 	/**

--- a/kipper/core/src/compiler/semantics/analyser/semantic-checker.ts
+++ b/kipper/core/src/compiler/semantics/analyser/semantic-checker.ts
@@ -95,6 +95,8 @@ export class KipperSemanticChecker extends KipperSemanticsAsserter {
 	 * Recursively ensures that the identifier does not overwrite any declarations in this scope or parent scopes.
 	 * @param declaration The declaration to check.
 	 * @param identifier The identifier to search for in this scope and its parent scopes.
+	 * @param isClass Whether this is a class scope. If true, the check will only check for class members as they do not
+	 * clash with other scopes.
 	 * @param scopeCtx The context instance of the scope.
 	 * @throws {IdentifierAlreadyUsedByVariableError} If the identifier is already used by a variable.
 	 * @throws {IdentifierAlreadyUsedByFunctionError} If the identifier is already used by a function.
@@ -102,11 +104,11 @@ export class KipperSemanticChecker extends KipperSemanticsAsserter {
 	 * @throws {BuiltInOverwriteError} If the identifier is already in use by a built-in function.
 	 * @since 0.10.0
 	 */
-	public identifierNotUsed(declaration: Declaration, identifier: string, scopeCtx: Scope): void {
+	public identifierNotUsed(declaration: Declaration, identifier: string, isClass: boolean, scopeCtx: Scope): void {
 		// Ensure beforehand that also no built-in has the same identifier
 		this.builtInNotDefined(identifier);
 
-		const ref = scopeCtx.getEntryRecursively(identifier);
+		const ref = isClass ? scopeCtx.getEntry(identifier) : this.getReference(identifier, scopeCtx);
 		if (ref) {
 			if (ref instanceof ScopeVariableDeclaration) {
 				if (ref.node instanceof ClassPropertyDeclaration) {

--- a/kipper/core/src/compiler/semantics/symbol-table/base/user-scope.ts
+++ b/kipper/core/src/compiler/semantics/symbol-table/base/user-scope.ts
@@ -16,10 +16,12 @@ export abstract class UserScope<VarT = any, FuncT = any, TypeT = any> extends Sc
 	 * Ensures that the given declaration is not already used in the current scope.
 	 * @param identifier The identifier to check.
 	 * @param declaration The declaration to check.
+	 * @param isClass Whether this is a class scope. If true, the check will only check for class members as they do not
+	 * clash with other scopes.
 	 * @private
 	 * @since 0.12.0
 	 */
-	protected ensureNotUsed(identifier: string, declaration: Declaration): void {
-		this.ctx.programCtx.semanticCheck(declaration).identifierNotUsed(declaration, identifier, this);
+	protected ensureNotUsed(identifier: string, declaration: Declaration, isClass: boolean = false): void {
+		this.ctx.programCtx.semanticCheck(declaration).identifierNotUsed(declaration, identifier, isClass, this);
 	}
 }

--- a/kipper/core/src/compiler/semantics/symbol-table/class-scope.ts
+++ b/kipper/core/src/compiler/semantics/symbol-table/class-scope.ts
@@ -88,13 +88,14 @@ export class ClassScope extends UserScope {
 
 	/**
 	 * Gets the searched entry if it exists in any scope excluding the class scope itself, which requires explicit an
-	 * explicit `this` keyword to be used.
+	 * explicit `this` keyword to be used (internally we will handle 'this' references as a member access of the 'this'
+	 * type of the class).
 	 *
 	 * This is essential to allow the class to use common identifiers like `length` or `name` for properties and methods
 	 * without having to conform to naming conflicts with parent scopes.
 	 */
 	public getEntry(identifier: string): ScopeDeclaration | undefined {
-		return identifier === "this" ? this.getThis() : undefined;
+		return identifier === "this" ? this.getThis() : undefined; // returns 'undefined' for direct references
 	}
 
 	public getEntryRecursively(identifier: string): ScopeDeclaration | undefined {

--- a/kipper/core/src/compiler/semantics/symbol-table/class-scope.ts
+++ b/kipper/core/src/compiler/semantics/symbol-table/class-scope.ts
@@ -3,9 +3,9 @@
  * the global namespace.
  * @since 0.11.0
  */
-import type {
+import {
 	ClassConstructorDeclaration,
-	ClassDeclaration,
+	ClassDeclaration, ClassMemberDeclaration,
 	ClassMethodDeclaration,
 	ClassPropertyDeclaration,
 } from "../../ast";
@@ -37,7 +37,7 @@ export class ClassScope extends UserScope {
 
 	public addConstructor(declaration: ClassConstructorDeclaration): ScopeFunctionDeclaration {
 		const identifier = declaration.getSemanticData().identifier;
-		this.ensureNotUsed(identifier, declaration);
+		this.clsEnsureNotUsed(declaration);
 
 		const scopeDeclaration = ScopeFunctionDeclaration.fromClassConstructorDeclaration(declaration);
 		this.entries.set(identifier, scopeDeclaration);
@@ -46,7 +46,7 @@ export class ClassScope extends UserScope {
 
 	public override addFunction(declaration: ClassMethodDeclaration): ScopeFunctionDeclaration {
 		const identifier = declaration.getSemanticData().identifier;
-		this.ensureNotUsed(identifier, declaration);
+		this.clsEnsureNotUsed(declaration);
 
 		const scopeDeclaration = ScopeFunctionDeclaration.fromClassMethodDeclaration(declaration);
 		this.entries.set(identifier, scopeDeclaration);
@@ -54,8 +54,12 @@ export class ClassScope extends UserScope {
 	}
 
 	public addVariable(declaration: ClassPropertyDeclaration): ScopeVariableDeclaration {
+		return this.addProperty(declaration);
+	}
+
+	public addProperty(declaration: ClassPropertyDeclaration): ScopeVariableDeclaration {
 		const identifier = declaration.getSemanticData().identifier;
-		this.ensureNotUsed(identifier, declaration);
+		this.clsEnsureNotUsed(declaration);
 
 		const scopeDeclaration = ScopeVariableDeclaration.fromClassPropertyDeclaration(declaration);
 		this._entries.set(identifier, scopeDeclaration);
@@ -68,6 +72,12 @@ export class ClassScope extends UserScope {
 			.notImplementedError(new KipperNotImplementedError("Local types have not been implemented yet."));
 	}
 
+	public clsEnsureNotUsed(declaration: ClassMemberDeclaration): void {
+		// Only checks for other members, as they do not shadow parent scope members
+		const identifier = declaration.getSemanticData().identifier;
+		super.ensureNotUsed(identifier, declaration, true);
+	}
+
 	/**
 	 * Gets the "this" keyword which is simply a reference to the class.
 	 * @since 0.12.0
@@ -76,15 +86,22 @@ export class ClassScope extends UserScope {
 		return this.ctx.thisAliasDeclaration;
 	}
 
+	/**
+	 * Gets the searched entry if it exists in any scope excluding the class scope itself, which requires explicit an
+	 * explicit `this` keyword to be used.
+	 *
+	 * This is essential to allow the class to use common identifiers like `length` or `name` for properties and methods
+	 * without having to conform to naming conflicts with parent scopes.
+	 */
 	public getEntry(identifier: string): ScopeDeclaration | undefined {
-		return identifier === "this" ? this.getThis() : this.entries.get(identifier);
+		return identifier === "this" ? this.getThis() : undefined;
 	}
 
 	public getEntryRecursively(identifier: string): ScopeDeclaration | undefined {
-		const localRef = this.getEntry(identifier);
-		if (!localRef) {
+		const ref = this.getEntry(identifier);
+		if (!ref) {
 			return this.parent.getEntryRecursively(identifier);
 		}
-		return localRef;
+		return ref;
 	}
 }

--- a/kipper/core/src/compiler/semantics/symbol-table/local-scope.ts
+++ b/kipper/core/src/compiler/semantics/symbol-table/local-scope.ts
@@ -61,10 +61,10 @@ export class LocalScope extends UserScope<VariableDeclaration, FunctionDeclarati
 	}
 
 	public getEntryRecursively(identifier: string): ScopeDeclaration | undefined {
-		const localRef = this.getEntry(identifier);
-		if (!localRef) {
+		const ref = this.getEntry(identifier);
+		if (!ref) {
 			return this.parent.getEntryRecursively(identifier);
 		}
-		return localRef;
+		return ref;
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2540,6 +2540,7 @@ packages:
 
   /mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
     dependencies:
       minimist: 1.2.8
     dev: true
@@ -3466,6 +3467,7 @@ packages:
   /ts-node@7.0.1:
     resolution: {integrity: sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==}
     engines: {node: '>=4.2.0'}
+    hasBin: true
     dependencies:
       arrify: 1.0.1
       buffer-from: 1.1.2

--- a/test/module/cli/compile.test.ts
+++ b/test/module/cli/compile.test.ts
@@ -20,7 +20,7 @@ describe("Kipper CLI 'compile'", async () => {
 			test
 				.stdout()
 				.command(["compile", filePath])
-				.it("Compile file 'hello-world.kip' with file argument", async (ctx) => {
+				.it("Compile file 'hello-world.kip' with file argument", async (ctx: any) => {
 					expect(ctx.stdout).to.length.greaterThan(0);
 					expect(ctx.stdout).to.contain("Starting compilation for 'hello-world.kip'.");
 					expect(ctx.stdout).to.contain("Parsing file content.");
@@ -36,7 +36,7 @@ describe("Kipper CLI 'compile'", async () => {
 			test
 				.stdout()
 				.command(["compile", filePath])
-				.it("Run file 'hello-world.kip' with file argument", async (ctx) => {
+				.it("Run file 'hello-world.kip' with file argument", async (ctx: any) => {
 					expect(ctx.stdout).to.length.greaterThan(0);
 
 					// Read the created file
@@ -73,7 +73,7 @@ describe("Kipper CLI 'compile'", async () => {
 			test
 				.stdout()
 				.command(["compile", "-s", `call print("Hello world!");`])
-				.it("Compile Hello world with --stringCode flag", async (ctx) => {
+				.it("Compile Hello world with --stringCode flag", async (ctx: any) => {
 					expect(ctx.stdout).to.length.greaterThan(0);
 					expect(ctx.stdout).to.contain("Starting compilation for 'anonymous-script'.");
 					expect(ctx.stdout).to.contain("Parsing file content.");
@@ -89,7 +89,7 @@ describe("Kipper CLI 'compile'", async () => {
 			test
 				.stdout()
 				.command(["compile", "-s", `call print("Hello world!");`])
-				.it("Run Hello world with --stringCode flag", async (ctx) => {
+				.it("Run Hello world with --stringCode flag", async (ctx: any) => {
 					expect(ctx.stdout).to.length.greaterThan(0);
 
 					// Read the created file
@@ -132,7 +132,7 @@ describe("Kipper CLI 'compile'", async () => {
 			test
 				.stdout()
 				.command(["compile", filePath, "-e", "ascii"])
-				.it("Compile using encoding 'ascii'", async (ctx) => {
+				.it("Compile using encoding 'ascii'", async (ctx: any) => {
 					expect(ctx.stdout).to.length.greaterThan(0);
 					expect(ctx.stdout).to.contain("Starting compilation for 'hello-world.kip'.");
 					expect(ctx.stdout).to.contain("Parsing file content.");
@@ -148,7 +148,7 @@ describe("Kipper CLI 'compile'", async () => {
 			test
 				.stdout()
 				.command(["compile", filePath, "-e", "utf8"])
-				.it("Compile using encoding 'utf8'", async (ctx) => {
+				.it("Compile using encoding 'utf8'", async (ctx: any) => {
 					expect(ctx.stdout).to.length.greaterThan(0);
 					expect(ctx.stdout).to.contain("Starting compilation for 'hello-world.kip'.");
 					expect(ctx.stdout).to.contain("Parsing file content.");
@@ -164,7 +164,7 @@ describe("Kipper CLI 'compile'", async () => {
 			test
 				.stdout()
 				.command(["compile", utf16filePath, "-e", "utf16le"])
-				.it("Compile using encoding 'utf16le'", async (ctx) => {
+				.it("Compile using encoding 'utf16le'", async (ctx: any) => {
 					expect(ctx.stdout).to.length.greaterThan(0);
 					expect(ctx.stdout).to.contain("Starting compilation for 'hello-world-utf16.kip'.");
 					expect(ctx.stdout).to.contain("Parsing file content.");
@@ -184,7 +184,7 @@ describe("Kipper CLI 'compile'", async () => {
 				test
 					.stdout()
 					.command(["compile", "-s", `call print("Hello world!");`, "-e", "ascii"])
-					.it("Compile using encoding 'ascii'", async (ctx) => {
+					.it("Compile using encoding 'ascii'", async (ctx: any) => {
 						expect(ctx.stdout).to.length.greaterThan(0);
 						expect(ctx.stdout).to.contain("Starting compilation for 'anonymous-script'.");
 						expect(ctx.stdout).to.contain("Parsing file content.");
@@ -200,7 +200,7 @@ describe("Kipper CLI 'compile'", async () => {
 				test
 					.stdout()
 					.command(["compile", "-s", `call print("Hello world!");`, "-e", "utf8"])
-					.it("Compile using encoding 'utf8'", async (ctx) => {
+					.it("Compile using encoding 'utf8'", async (ctx: any) => {
 						expect(ctx.stdout).to.length.greaterThan(0);
 						expect(ctx.stdout).to.contain("Starting compilation for 'anonymous-script'.");
 						expect(ctx.stdout).to.contain("Parsing file content.");
@@ -216,7 +216,7 @@ describe("Kipper CLI 'compile'", async () => {
 				test
 					.stdout()
 					.command(["compile", "-s", `call print("Hello world!");`, "-e", "utf16le"])
-					.it("Compile using encoding 'utf16le'", async (ctx) => {
+					.it("Compile using encoding 'utf16le'", async (ctx: any) => {
 						expect(ctx.stdout).to.length.greaterThan(0);
 						expect(ctx.stdout).to.contain("Starting compilation for 'anonymous-script'.");
 						expect(ctx.stdout).to.contain("Parsing file content.");
@@ -234,7 +234,7 @@ describe("Kipper CLI 'compile'", async () => {
 				test
 					.stdout()
 					.command(["compile", "-s", `call print("Hello world!");`, "-e", "ascii", "-t", "ts"])
-					.it("Compile using encoding 'ascii'", async (ctx) => {
+					.it("Compile using encoding 'ascii'", async (ctx: any) => {
 						expect(ctx.stdout).to.length.greaterThan(0);
 						expect(ctx.stdout).to.contain("Starting compilation for 'anonymous-script'.");
 						expect(ctx.stdout).to.contain("Parsing file content.");
@@ -250,7 +250,7 @@ describe("Kipper CLI 'compile'", async () => {
 				test
 					.stdout()
 					.command(["compile", "-s", `call print("Hello world!");`, "-e", "utf8", "-t", "ts"])
-					.it("Compile using encoding 'utf8'", async (ctx) => {
+					.it("Compile using encoding 'utf8'", async (ctx: any) => {
 						expect(ctx.stdout).to.length.greaterThan(0);
 						expect(ctx.stdout).to.contain("Starting compilation for 'anonymous-script'.");
 						expect(ctx.stdout).to.contain("Parsing file content.");
@@ -266,7 +266,7 @@ describe("Kipper CLI 'compile'", async () => {
 				test
 					.stdout()
 					.command(["compile", "-s", `call print("Hello world!");`, "-e", "utf16le", "-t", "ts"])
-					.it("Compile using encoding 'utf16le'", async (ctx) => {
+					.it("Compile using encoding 'utf16le'", async (ctx: any) => {
 						expect(ctx.stdout).to.length.greaterThan(0);
 						expect(ctx.stdout).to.contain("Starting compilation for 'anonymous-script'.");
 						expect(ctx.stdout).to.contain("Parsing file content.");

--- a/test/module/cli/new.test.ts
+++ b/test/module/cli/new.test.ts
@@ -27,7 +27,7 @@ describe("Kipper CLI 'new'", () => {
 	test
 		.stdout()
 		.command(["new", tempFolder, "-d"])
-		.it("using '-d' (Default Config)", async (ctx) => {
+		.it("using '-d' (Default Config)", async (ctx: any) => {
 			assert.isNotEmpty(ctx.stdout);
 			assert.include(ctx.stdout, "Using default settings. Skipping setup wizard.");
 			assert.include(ctx.stdout, "Project 'new-kipper-project' created successfully!");

--- a/test/module/core/errors/semantic-errors/identifier-already-used-by-variable.ts
+++ b/test/module/core/errors/semantic-errors/identifier-already-used-by-variable.ts
@@ -4,101 +4,116 @@ import { defaultConfig, ensureTracebackDataExists } from "../index";
 import { assert } from "chai";
 
 describe("IdentifierAlreadyUsedByVariableError", () => {
-	describe("Same Global Scope", () => {
-		it("Redeclaration by variable", async () => {
-			try {
-				await new KipperCompiler().compile("var x: num = 5; var x: num = 5;", defaultConfig);
-			} catch (e) {
-				assert(
-					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError",
-					"Expected different error",
-				);
-				ensureTracebackDataExists(<KipperError>e);
-				return;
-			}
-			assert.fail("Expected 'IdentifierAlreadyUsedByVariableError'");
+	describe("Error", () => {
+		describe("Same Global Scope", () => {
+			it("Redeclaration by variable", async () => {
+				try {
+					await new KipperCompiler().compile("var x: num = 5; var x: num = 5;", defaultConfig);
+				} catch (e) {
+					assert(
+						(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError",
+						"Expected different error",
+					);
+					ensureTracebackDataExists(<KipperError>e);
+					return;
+				}
+				assert.fail("Expected 'IdentifierAlreadyUsedByVariableError'");
+			});
+
+			it("Redeclaration by function", async () => {
+				try {
+					await new KipperCompiler().compile("var x: num; def x() -> void {};", defaultConfig);
+				} catch (e) {
+					assert(
+						(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError",
+						"Expected different error",
+					);
+					ensureTracebackDataExists(<KipperError>e);
+					return;
+				}
+				assert.fail("Expected 'IdentifierAlreadyUsedByVariableError'");
+			});
+
+			it("Redeclaration by parameter", async () => {
+				try {
+					await new KipperCompiler().compile("var x: num; def f(x: num) -> void {};", defaultConfig);
+				} catch (e) {
+					assert(
+						(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError",
+						"Expected different error",
+					);
+					ensureTracebackDataExists(<KipperError>e);
+					return;
+				}
+				assert.fail("Expected 'IdentifierAlreadyUsedByVariableError'");
+			});
 		});
 
-		it("Redeclaration by function", async () => {
-			try {
-				await new KipperCompiler().compile("var x: num; def x() -> void {};", defaultConfig);
-			} catch (e) {
-				assert(
-					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError",
-					"Expected different error",
-				);
-				ensureTracebackDataExists(<KipperError>e);
-				return;
-			}
-			assert.fail("Expected 'IdentifierAlreadyUsedByVariableError'");
+		describe("Same Nested Scope", async () => {
+			it("Redeclaration by variable", async () => {
+				try {
+					await new KipperCompiler().compile("{ var x: num = 5; var x: num = 5; }", defaultConfig);
+				} catch (e) {
+					assert(
+						(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError",
+						"Expected different error",
+					);
+					ensureTracebackDataExists(<KipperError>e);
+					return;
+				}
+				assert.fail("Expected 'IdentifierAlreadyUsedByVariableError'");
+			});
+
+			// Functions and parameters are not allowed to be nested (Local functions are not implemented yet)
 		});
 
-		it("Redeclaration by parameter", async () => {
-			try {
-				await new KipperCompiler().compile("var x: num; def f(x: num) -> void {};", defaultConfig);
-			} catch (e) {
-				assert(
-					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError",
-					"Expected different error",
-				);
-				ensureTracebackDataExists(<KipperError>e);
-				return;
-			}
-			assert.fail("Expected 'IdentifierAlreadyUsedByVariableError'");
+		describe("Global Override from Nested Scope", () => {
+			it("Redeclaration by variable", async () => {
+				try {
+					await new KipperCompiler().compile("var x: num = 5; { var x: num = 5; }", defaultConfig);
+				} catch (e) {
+					assert(
+						(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError",
+						"Expected different error",
+					);
+					ensureTracebackDataExists(<KipperError>e);
+					return;
+				}
+				assert.fail("Expected 'IdentifierAlreadyUsedByVariableError'");
+			});
+
+			// Functions and parameters are not allowed to be nested (Local functions are not implemented yet)
+		});
+
+		describe("Nested Override from Deeper Nested Scope", () => {
+			it("Redeclaration by variable", async () => {
+				try {
+					await new KipperCompiler().compile("var x: num = 5; { { var x: num = 5; } }", defaultConfig);
+				} catch (e) {
+					assert(
+						(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError",
+						"Expected different error",
+					);
+					ensureTracebackDataExists(<KipperError>e);
+					return;
+				}
+				assert.fail("Expected 'IdentifierAlreadyUsedByVariableError'");
+			});
+
+			// Functions and parameters are not allowed to be nested (Local functions are not implemented yet)
 		});
 	});
 
-	describe("Same Nested Scope", async () => {
-		it("Redeclaration by variable", async () => {
+	describe("NoError", () => {
+		it("Class Member with used name", async () => {
 			try {
-				await new KipperCompiler().compile("{ var x: num = 5; var x: num = 5; }", defaultConfig);
-			} catch (e) {
-				assert(
-					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError",
-					"Expected different error",
+				await new KipperCompiler().compile(
+					"var x: num = 5; class A { x: num; constructor() { this.x = 0; } }",
+					defaultConfig,
 				);
-				ensureTracebackDataExists(<KipperError>e);
-				return;
-			}
-			assert.fail("Expected 'IdentifierAlreadyUsedByVariableError'");
-		});
-
-		// Functions and parameters are not allowed to be nested (Local functions are not implemented yet)
-	});
-
-	describe("Global Override from Nested Scope", () => {
-		it("Redeclaration by variable", async () => {
-			try {
-				await new KipperCompiler().compile("var x: num = 5; { var x: num = 5; }", defaultConfig);
 			} catch (e) {
-				assert(
-					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError",
-					"Expected different error",
-				);
-				ensureTracebackDataExists(<KipperError>e);
-				return;
+				assert.fail(`Expected no '${(<KipperError>e).name}'`);
 			}
-			assert.fail("Expected 'IdentifierAlreadyUsedByVariableError'");
 		});
-
-		// Functions and parameters are not allowed to be nested (Local functions are not implemented yet)
-	});
-
-	describe("Nested Override from Deeper Nested Scope", () => {
-		it("Redeclaration by variable", async () => {
-			try {
-				await new KipperCompiler().compile("var x: num = 5; { { var x: num = 5; } }", defaultConfig);
-			} catch (e) {
-				assert(
-					(<KipperError>e).constructor.name === "IdentifierAlreadyUsedByVariableError",
-					"Expected different error",
-				);
-				ensureTracebackDataExists(<KipperError>e);
-				return;
-			}
-			assert.fail("Expected 'IdentifierAlreadyUsedByVariableError'");
-		});
-
-		// Functions and parameters are not allowed to be nested (Local functions are not implemented yet)
 	});
 });

--- a/test/module/core/errors/semantic-errors/unknown-reference.ts
+++ b/test/module/core/errors/semantic-errors/unknown-reference.ts
@@ -4,51 +4,64 @@ import { defaultConfig, ensureTracebackDataExists } from "../index";
 import { assert } from "chai";
 
 describe("UnknownReferenceError", () => {
-	it("Simple reference", async () => {
-		try {
-			await new KipperCompiler().compile("x;", defaultConfig);
-		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "UnknownReferenceError", "Expected different error");
-			assert.equal((<KipperError>e).name, "ReferenceError", "Expected different error");
-			ensureTracebackDataExists(<KipperError>e);
-			return;
-		}
-		assert.fail("Expected 'UnknownReferenceError'");
-	});
+	describe("Error", () => {
+		it("Simple reference", async () => {
+			try {
+				await new KipperCompiler().compile("x;", defaultConfig);
+			} catch (e) {
+				assert.equal((<KipperError>e).constructor.name, "UnknownReferenceError", "Expected different error");
+				assert.equal((<KipperError>e).name, "ReferenceError", "Expected different error");
+				ensureTracebackDataExists(<KipperError>e);
+				return;
+			}
+			assert.fail("Expected 'UnknownReferenceError'");
+		});
 
-	it("Function Call", async () => {
-		try {
-			await new KipperCompiler().compile('var x: num = call pr("pr");', defaultConfig);
-		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "UnknownReferenceError", "Expected different error");
-			assert.equal((<KipperError>e).name, "ReferenceError", "Expected different error");
-			ensureTracebackDataExists(<KipperError>e);
-			return;
-		}
-		assert.fail("Expected 'UnknownReferenceError'");
-	});
+		it("Function Call", async () => {
+			try {
+				await new KipperCompiler().compile('var x: num = call pr("pr");', defaultConfig);
+			} catch (e) {
+				assert.equal((<KipperError>e).constructor.name, "UnknownReferenceError", "Expected different error");
+				assert.equal((<KipperError>e).name, "ReferenceError", "Expected different error");
+				ensureTracebackDataExists(<KipperError>e);
+				return;
+			}
+			assert.fail("Expected 'UnknownReferenceError'");
+		});
 
-	it("Arithmetics", async () => {
-		try {
-			await new KipperCompiler().compile("var x: num = y + y;", defaultConfig);
-		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "UnknownReferenceError", "Expected different error");
-			assert.equal((<KipperError>e).name, "ReferenceError", "Expected different error");
-			ensureTracebackDataExists(<KipperError>e);
-			return;
-		}
-		assert.fail("Expected 'UnknownReferenceError'");
-	});
+		it("Arithmetics", async () => {
+			try {
+				await new KipperCompiler().compile("var x: num = y + y;", defaultConfig);
+			} catch (e) {
+				assert.equal((<KipperError>e).constructor.name, "UnknownReferenceError", "Expected different error");
+				assert.equal((<KipperError>e).name, "ReferenceError", "Expected different error");
+				ensureTracebackDataExists(<KipperError>e);
+				return;
+			}
+			assert.fail("Expected 'UnknownReferenceError'");
+		});
 
-	it("Nested reference", async () => {
-		try {
-			await new KipperCompiler().compile("{ { { { x; } } } }", defaultConfig);
-		} catch (e) {
-			assert.equal((<KipperError>e).constructor.name, "UnknownReferenceError", "Expected different error");
-			assert.equal((<KipperError>e).name, "ReferenceError", "Expected different error");
-			ensureTracebackDataExists(<KipperError>e);
-			return;
-		}
-		assert.fail("Expected 'UnknownReferenceError'");
+		it("Nested reference", async () => {
+			try {
+				await new KipperCompiler().compile("{ { { { x; } } } }", defaultConfig);
+			} catch (e) {
+				assert.equal((<KipperError>e).constructor.name, "UnknownReferenceError", "Expected different error");
+				assert.equal((<KipperError>e).name, "ReferenceError", "Expected different error");
+				ensureTracebackDataExists(<KipperError>e);
+				return;
+			}
+			assert.fail("Expected 'UnknownReferenceError'");
+		});
+
+		it("Class field access without 'this' prefix", async () => {
+			try {
+				await new KipperCompiler().compile("class A { field: num; method(): void { field; } }", defaultConfig);
+			} catch (e) {
+				assert.equal((<KipperError>e).constructor.name, "UnknownReferenceError", "Expected different error");
+				assert.equal((<KipperError>e).name, "ReferenceError", "Expected different error");
+				ensureTracebackDataExists(<KipperError>e);
+				return;
+			}
+		});
 	});
 });


### PR DESCRIPTION
<!--
Please read through the given types of changes and select the correct one using an 'x' instead of the ' ' (space) in the brackets.

Note: Comments are marked by arrows, like here. They will not be visible in the final pull request!
-->

## What type of change does this PR perform?

<!-- Please put an X in the box of the line that applies -->
<!-- If you are unsure if your code is a breaking change, read this: https://nordicapis.com/what-are-breaking-changes-and-how-do-you-avoid-them -->

- [ ] Info or documentation change (Non-breaking change that updates repo info files (e.g. README.md, CONTRIBUTING.md, etc.) or online documentation)
- [ ] Website (Change that changes the design or functionality of the websites or docs)
- [ ] Development or internal changes (These changes do not add new features or fix bugs, but update the code in other ways)
- [x] Bug fix (Non-breaking change which fixes an issue)
- [ ] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Major bug fix or feature that would cause existing functionality not to work as expected.)
- [ ] Requires a documentation update, as it changes language or compiler behaviour

## Summary

<!-- Explain the reason for this pr, changes, and solution briefly. -->

Fixed bug allowing internal references to class members without the use of `this`, causing the generated code to crash. As an addition to this fix, class members can now also use names of previous declarations, as they do not shadow them.

Closes #721 

## Detailed Changelog

_Not present for website/docs changes_

<!-- Detailed changelog that may be copied from `CHANGELOG.md` (Only add the items you've added and remove any header with no item.). -->

### Fixed

- Fixed class members being accessible without the use of 'this', causing a runtime error. ([#721](https://github.com/Kipper-Lang/Kipper/issues/721))
- Fixed class members not being allowed to use names already used in a parent scope.

## Does this PR create new warnings?

<!-- Add any new warnings or possible issues that could occur with this PR. -->

None.

## Linked issues or PRs

<!-- Include other issues and PRs related to this if any exist.  Use this format: - [ ] #ISSUE_OR_PR -->

- [x] #721